### PR TITLE
fix: bundle wolfden-algo skill with installer

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,7 @@
     ],
     "resources": [
       "../algo_runtime/**/*",
+      "../.claude/skills/wolfden-algo/**/*",
       "python/**/*"
     ],
     "windows": {


### PR DESCRIPTION
## Summary
- Adds `../.claude/skills/wolfden-algo/**/*` to the Tauri bundle resources so the installed app ships with the skill Claude Code needs to operate.
- Without this, the per-algo Claude Code session (spawned in `src-tauri/src/ai_terminal.rs`) is locked down to load the `wolfden-algo` skill from cwd, but the installed app has no such skill on disk — leaving the AI terminal non-functional.

## Why
`find_project_root()` in `ai_terminal.rs` looks for `algo_runtime/` next to the exe and uses that as the Claude `cwd`. Tauri extracts bundled resources to that same root, preserving the path (minus the `../` prefix), so this resource pattern lands at `<install>/.claude/skills/wolfden-algo/SKILL.md` — exactly where the `Skill` tool discovers it.

## Test plan
- [ ] `npm run tauri build` produces an NSIS installer
- [ ] After install, `<install_dir>/.claude/skills/wolfden-algo/SKILL.md` exists
- [ ] Launching the AI terminal for an algo loads the wolfden-algo skill without "Unknown skill" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated bundling configuration to include additional resources in the application package, ensuring all necessary files are available with the deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->