### PR TITLE
fix: install bundled wolfden-algo skill into project root

### DIFF
--- a/src-tauri/src/ai_terminal.rs
+++ b/src-tauri/src/ai_terminal.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
@@ -29,13 +29,62 @@ pub struct AiTerminalManager {
 }
 
 impl AiTerminalManager {
-    pub fn new(db_path: PathBuf) -> Self {
+    pub fn new(db_path: PathBuf, resource_dir: Option<PathBuf>) -> Self {
         let project_root = Self::find_project_root();
+
+        // Claude's `Skill` tool discovers skills under <cwd>/.claude/skills/.
+        // Bundled resources declared with "../" in tauri.conf.json land under
+        // <resource_dir>/_up_/ (Tauri v2 mangles upward traversal — same quirk
+        // documented in venv_manager.rs). Copy the bundled skill into
+        // project_root so Claude can find it from the cwd we hand it.
+        if let Err(e) = Self::install_bundled_skill(&project_root, resource_dir.as_deref()) {
+            log::warn!("Failed to install wolfden-algo skill into project root: {}", e);
+        }
+
         AiTerminalManager {
             sessions: Mutex::new(HashMap::new()),
             project_root,
             db_path,
         }
+    }
+
+    /// Copies the bundled wolfden-algo skill into <project_root>/.claude/skills/
+    /// so Claude's Skill tool can discover it from its cwd. No-op in dev mode
+    /// (resource_dir = None) because the source tree already has the skill.
+    fn install_bundled_skill(
+        project_root: &Path,
+        resource_dir: Option<&Path>,
+    ) -> std::io::Result<()> {
+        let res_dir = match resource_dir {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+
+        let rel = Path::new(".claude")
+            .join("skills")
+            .join("wolfden-algo")
+            .join("SKILL.md");
+
+        // _up_ first (the actual Tauri v2 layout), bare path as defensive fallback.
+        let candidates = [res_dir.join("_up_").join(&rel), res_dir.join(&rel)];
+        let source = match candidates.iter().find(|c| c.exists()) {
+            Some(p) => p,
+            None => {
+                log::warn!(
+                    "Bundled wolfden-algo skill not found in resource dir. Searched: {:?}",
+                    candidates
+                );
+                return Ok(());
+            }
+        };
+
+        let dest = project_root.join(&rel);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source, &dest)?;
+        log::info!("Installed wolfden-algo skill at {:?}", dest);
+        Ok(())
     }
 
     fn find_project_root() -> PathBuf {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,7 +64,11 @@ pub fn run() {
             app.manage(ProcState(process_manager::ProcessManager::new(data_dir.clone(), venv_python)));
 
             // Initialize AI terminal manager
-            app.manage(AiTermState(ai_terminal::AiTerminalManager::new(db_path.clone())));
+            let ai_resource_dir = app.path().resource_dir().ok();
+            app.manage(AiTermState(ai_terminal::AiTerminalManager::new(
+                db_path.clone(),
+                ai_resource_dir,
+            )));
 
             // Start WebSocket server for NinjaTrader connections
             let (inbound_tx, _) = broadcast::channel(256);


### PR DESCRIPTION
## Summary
Resolves "unknown skill: wolfden-algo" in the installed Windows app. PR #7 successfully bundled the skill into the installer, but Claude's `Skill` tool still couldn't find it.

## Root cause
- Tauri v2 mangles resource paths beginning with `../` into a `_up_` segment under the resource directory (the same quirk documented in `src-tauri/src/venv_manager.rs:28-31`, originally fixed by PR #3).
- So the bundled skill ships to `<resource_dir>/_up_/.claude/skills/wolfden-algo/SKILL.md`.
- Claude's `Skill` tool only discovers skills under `<cwd>/.claude/skills/`. With `cwd = C:\Users\<user>\AppData\Local\Wolf Den` (the install dir), it never sees the `_up_/` copy.
- Confirmed live: in the installed app the Claude banner shows `cwd: C:\Users\hypawolf\AppData\Local\Wolf Den` and discovery fails.

## Fix
At `AiTerminalManager` construction:
1. Accept `resource_dir: Option<PathBuf>` (passed in from `lib.rs`, mirroring what `VenvManager` already gets).
2. Copy `<resource_dir>/_up_/.claude/skills/wolfden-algo/SKILL.md` (with bare-path defensive fallback) into `<project_root>/.claude/skills/wolfden-algo/SKILL.md`.
3. No-op in dev mode (`resource_dir = None`) — the source tree already has the skill at the correct location.

## Why copy instead of pointing `find_project_root()` at `_up_/`
`project_root` is also used to write user algo files (`ai_terminal.rs:71-78`). Repointing it would mix runtime-written algos into the installer's `_up_/` directory. Copying just the skill keeps writes where they already go and only fixes the discovery problem.

## Test plan
- [ ] `cargo check` passes (verified locally — only pre-existing warnings)
- [ ] CI builds NSIS installer
- [ ] Fresh install on Windows → open AI terminal for an algo → confirm `wolfden-algo` skill loads without "unknown skill" error
- [ ] Dev mode (`cargo tauri dev`) still works — `install_bundled_skill` is a no-op when `resource_dir` is `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)