### PR TITLE
fix: strip Windows extended-length prefix from project root

### DIFF
--- a/src-tauri/src/ai_terminal.rs
+++ b/src-tauri/src/ai_terminal.rs
@@ -99,10 +99,12 @@ impl AiTerminalManager {
         ];
         for c in &candidates {
             if c.join("algo_runtime").exists() {
-                return c.canonicalize().unwrap_or_else(|_| c.clone());
+                let canon = c.canonicalize().unwrap_or_else(|_| c.clone());
+                return strip_unc_prefix(canon);
             }
         }
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        strip_unc_prefix(cwd)
     }
 
     /// Derives a filesystem slug from an algo name.
@@ -444,6 +446,28 @@ fn which_claude() -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Strips the Windows extended-length path prefix (`\\?\` or `\\?\UNC\`) from
+/// a path. Rust's `current_dir()` and `canonicalize()` can return prefixed
+/// paths, but downstream consumers (notably Bun, which Claude Code runs on)
+/// segfault when handed extended-length paths on Windows. No-op on non-Windows
+/// or for paths without the prefix.
+fn strip_unc_prefix(path: PathBuf) -> PathBuf {
+    if !cfg!(windows) {
+        return path;
+    }
+    let s = match path.to_str() {
+        Some(s) => s,
+        None => return path,
+    };
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{}", rest));
+    }
+    if let Some(rest) = s.strip_prefix(r"\\?\") {
+        return PathBuf::from(rest);
+    }
+    path
 }
 
 /// Returns true if `path` is a Windows batch file that must be launched via


### PR DESCRIPTION
## Summary
Resolves a deterministic Bun segfault in the installed Windows app when Claude Code tries to Read or Write the algo file.

## Symptom
On every algo edit attempt in the installed Windows app, Claude Code prints `Do you want to overwrite <algo>.py?`, then Bun crashes with:
```
panic(main thread): Segmentation fault at address 0x18
```
Claude never actually performs the file operation.

## Root cause
`ai_terminal.rs::find_project_root()` falls back to `std::env::current_dir()` in the installed app, because `algo_runtime/` is bundled under Tauri's `_up_/` segment (mangled from the `../` resource path) and isn't where the candidate probes look. On Windows, `current_dir()` can return a path with the extended-length prefix `\\?\`, e.g.:

```
\\?\C:\Users\hypawolf\AppData\Local\Wolf Den
```

That prefix then propagates into:
- the cwd we pass via `cmd.cwd()` to the Claude PTY, and
- the algo file path interpolated into `--system-prompt`

Bun (which Claude Code runs on) has fragile Windows path handling and segfaults internally when asked to Read/Write a `\\?\`-prefixed path. The Bun panic banner clearly shows the offending arg:
```
The algo file is at \\?\C:\Users\hypawolf\AppData\Local\...
```

Confirmed reproducible every time on the installed app; never reaches a successful Read/Write.

## Fix
Add a `strip_unc_prefix` helper that strips `\\?\` (and the UNC variant `\\?\UNC\`) from a `PathBuf` on Windows. Apply it to both return paths in `find_project_root()` so `project_root` — and everything derived from it — stays free of the prefix. Rust's std and the `notify` crate handle either form fine; only Bun is picky. No-op on non-Windows.

## Test plan
- [ ] `cargo check` passes (verified locally — only pre-existing warnings)
- [ ] CI builds NSIS installer
- [ ] Fresh install on Windows → open AI terminal for an algo → ask Claude to edit it → confirm Read and Write succeed without Bun crashing
- [ ] Dev mode (`cargo tauri dev` on macOS/Linux) unaffected — `cfg!(windows)` short-circuits the helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling for more reliable project root discovery on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->