### PR TITLE
Redesign home view: modern, data-forward layout with deep-links

### DIFF
--- a/docs/superpowers/specs/2026-04-18-home-view-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-18-home-view-redesign-design.md
@@ -1,7 +1,7 @@
 # Home View Redesign — Design Spec
 
 **Date:** 2026-04-18
-**Status:** Approved
+**Status:** Implemented
 
 ## Overview
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,10 +17,11 @@ import { useAlgoLogs } from "./hooks/useAlgoLogs";
 import { useAlgoHealth } from "./hooks/useAlgoHealth";
 import type { DataSource } from "./hooks/useTradingSimulation";
 import { VenvSetupModal } from "./components/VenvSetupModal";
-import type { Algo, AlgoRun, View } from "./types";
+import type { Algo, AlgoRun, View, NavOptions, NavContext } from "./types";
 
 export const App = () => {
   const [activeView, setActiveView] = useState<View>("home");
+  const [pendingNavContext, setPendingNavContext] = useState<NavContext | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<"waiting" | "connected" | "error">("waiting");
   const [accounts, setAccounts] = useState<Record<string, { buying_power: number; cash: number; realized_pnl: number }>>({});
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
@@ -225,8 +226,8 @@ export const App = () => {
   const hasUnsavedChanges = selectedAlgo ? editorCode !== selectedAlgo.code || editorDeps !== selectedAlgo.dependencies : false;
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; confirmLabel?: string; onConfirm: () => void } | null>(null);
 
-  const handleNavigate = (view: View) => {
-    if (view === activeView) return;
+  const handleNavigate = (view: View, options?: NavOptions) => {
+    if (view === activeView && !options) return;
     if (activeView === "editor" && hasUnsavedChanges) {
       setConfirmDialog({
         message: "You have unsaved changes. Leave without saving?",
@@ -236,14 +237,25 @@ export const App = () => {
             setEditorCode(selectedAlgo.code);
             setEditorDeps(selectedAlgo.dependencies);
           }
+          setPendingNavContext(options ? { ...options, targetView: view } : null);
           setActiveView(view);
           setConfirmDialog(null);
         },
       });
       return;
     }
+    setPendingNavContext(options ? { ...options, targetView: view } : null);
     setActiveView(view);
   };
+
+  const clearPendingNavContext = useCallback(() => {
+    setPendingNavContext(null);
+  }, []);
+
+  // Referenced here so the scaffolded-but-unwired nav plumbing doesn't trip
+  // `noUnusedLocals`. Task 2 consumes both values from the view props directly;
+  // this line can be removed then.
+  void pendingNavContext; void clearPendingNavContext;
 
   const handleSelectAlgo = (id: number) => {
     if (id === selectedAlgoId) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -388,6 +388,11 @@ export const App = () => {
           activeRuns={activeRuns}
           stats={simulation.stats}
           positions={simulation.positions}
+          pnlHistory={simulation.pnlHistory}
+          runPnlHistories={simulation.runPnlHistories}
+          algoStats={simulation.algoStats}
+          onNavigate={handleNavigate}
+          onStopAlgo={handleStopAlgo}
         />
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -424,6 +424,8 @@ export const App = () => {
           onClearLogs={clearLogs}
           onOpenAiTerminal={handleOpenAiTerminal}
           aiTerminalAlgoIds={aiTerminalAlgoIds}
+          initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
+          onInstanceFocused={clearPendingNavContext}
         />
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -252,11 +252,6 @@ export const App = () => {
     setPendingNavContext(null);
   }, []);
 
-  // Referenced here so the scaffolded-but-unwired nav plumbing doesn't trip
-  // `noUnusedLocals`. Task 2 consumes both values from the view props directly;
-  // this line can be removed then.
-  void pendingNavContext; void clearPendingNavContext;
-
   const handleSelectAlgo = (id: number) => {
     if (id === selectedAlgoId) return;
     if (hasUnsavedChanges) {
@@ -433,7 +428,13 @@ export const App = () => {
       )}
 
       {activeView === "trading" && (
-        <TradingView simulation={simulation} algos={algos} activeRuns={activeRuns} />
+        <TradingView
+          simulation={simulation}
+          algos={algos}
+          activeRuns={activeRuns}
+          initialContext={pendingNavContext}
+          onContextConsumed={clearPendingNavContext}
+        />
       )}
 
       {aiTerminalAlgos.length > 0 && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,3 +19,12 @@ export type AlgoRun = {
 };
 
 export type View = "home" | "editor" | "algos" | "trading";
+
+export type NavOptions = {
+  accountFilter?: string;
+  algoFilter?: number;
+  instanceId?: string;
+  scrollTo?: "positions" | "orders" | "history" | "stats";
+};
+
+export type NavContext = NavOptions & { targetView: View };

--- a/src/views/AlgosView.tsx
+++ b/src/views/AlgosView.tsx
@@ -20,6 +20,7 @@ type AlgosViewProps = {
   onOpenAiTerminal?: (algoId: number) => void;
   aiTerminalAlgoIds?: Set<number>;
   initialInstanceId?: string | null;
+  /** Called after initialInstanceId is consumed (found or not). Not called when falling back to default auto-select. */
   onInstanceFocused?: () => void;
 };
 
@@ -378,7 +379,8 @@ export const AlgosView = ({
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
   const [hasAutoSelected, setHasAutoSelected] = useState(false);
 
-  // Auto-select first running algo on mount
+  // Auto-select on mount: prefer navigation-provided instance,
+  // otherwise fall back to first running algo
   useEffect(() => {
     if (hasAutoSelected) return;
     if (initialInstanceId) {

--- a/src/views/AlgosView.tsx
+++ b/src/views/AlgosView.tsx
@@ -19,6 +19,8 @@ type AlgosViewProps = {
   onClearLogs: (instanceId: string) => void;
   onOpenAiTerminal?: (algoId: number) => void;
   aiTerminalAlgoIds?: Set<number>;
+  initialInstanceId?: string | null;
+  onInstanceFocused?: () => void;
 };
 
 const formatDataSource = (ds: DataSource) => {
@@ -369,6 +371,8 @@ export const AlgosView = ({
   onClearLogs,
   onOpenAiTerminal,
   aiTerminalAlgoIds,
+  initialInstanceId,
+  onInstanceFocused,
 }: AlgosViewProps) => {
   const [selectedChartId, setSelectedChartId] = useState<string | null>(null);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
@@ -377,13 +381,25 @@ export const AlgosView = ({
   // Auto-select first running algo on mount
   useEffect(() => {
     if (hasAutoSelected) return;
+    if (initialInstanceId) {
+      const run = activeRuns.find((r) => r.instance_id === initialInstanceId);
+      if (run) {
+        setSelectedChartId(run.data_source_id);
+        setSelectedInstanceId(run.instance_id);
+      }
+      // mark consumed + notify App even if the instance wasn't found,
+      // so stale context doesn't leak into the next navigation
+      setHasAutoSelected(true);
+      onInstanceFocused?.();
+      return;
+    }
     const firstRunning = activeRuns.find((r) => r.status === "running");
     if (firstRunning) {
       setSelectedChartId(firstRunning.data_source_id);
       setSelectedInstanceId(firstRunning.instance_id);
       setHasAutoSelected(true);
     }
-  }, [activeRuns, hasAutoSelected]);
+  }, [activeRuns, hasAutoSelected, initialInstanceId, onInstanceFocused]);
 
   const selectedDs = dataSources.find((ds) => ds.id === selectedChartId) ?? null;
   const chartRuns = selectedChartId

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,3 +1,7 @@
+import { useMemo, useState } from "react";
+import UplotReact from "uplot-react";
+import "uplot/dist/uPlot.min.css";
+import type uPlot from "uplot";
 import type { Algo, AlgoRun, NavOptions, View } from "../types";
 import type { AlgoStats } from "../hooks/useTradingSimulation";
 
@@ -88,6 +92,18 @@ export const HomeView = (props: HomeViewProps) => {
         ? positionSymbols.join(" · ")
         : `${positionSymbols.slice(0, 3).join(" · ")} +${positionSymbols.length - 3}`;
 
+  const [timeRange, setTimeRange] = useState<TimeRange>("today");
+  const [visibleInstanceIds, setVisibleInstanceIds] = useState<Set<string>>(() => new Set(props.activeRuns.map((r) => r.instance_id)));
+
+  const toggleInstanceVisibility = (instanceId: string) => {
+    setVisibleInstanceIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(instanceId)) next.delete(instanceId);
+      else next.add(instanceId);
+      return next;
+    });
+  };
+
   return (
     <div className="flex-1 flex flex-col overflow-auto bg-[var(--bg-primary)]">
       <div className="max-w-[1400px] w-full mx-auto p-5 flex flex-col gap-4">
@@ -163,8 +179,27 @@ export const HomeView = (props: HomeViewProps) => {
           />
         </div>
 
-        {/* Section 3: Hero P&L chart — filled in Task 7 */}
-        <div id="home-section-chart" />
+        {/* Section 3: Hero P&L chart */}
+        <div id="home-section-chart" className="p-4 rounded-xl bg-[var(--bg-panel)] border border-[var(--border)]">
+          <div className="flex items-center justify-between mb-3">
+            <button
+              onClick={() => props.onNavigate("trading")}
+              className="group text-[11px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold hover:text-[var(--accent-blue)] transition-colors"
+            >
+              Session P&L
+              <span className="ml-1 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </button>
+            <TimeRangeSegmented value={timeRange} onChange={setTimeRange} />
+          </div>
+          <SessionPnlChart
+            pnlHistory={props.pnlHistory}
+            runPnlHistories={props.runPnlHistories}
+            activeRuns={props.activeRuns}
+            algos={props.algos}
+            visibleInstanceIds={visibleInstanceIds}
+            onToggleInstance={toggleInstanceVisibility}
+          />
+        </div>
 
         {/* Section 4: Bottom split (algos tape + performance) — filled in Tasks 8 & 9 */}
         <div id="home-section-bottom" className="grid grid-cols-3 gap-4">
@@ -261,4 +296,138 @@ const KpiCard = ({ label, value, valueColor, detail, sparkline, onClick }: KpiCa
       );
     })() : null}
   </button>
+);
+
+const CHART_PALETTE = ["#e5e7eb", "#22c55e", "#60a5fa", "#f59e0b", "#a78bfa", "#f472b6", "#34d399", "#fb923c"];
+
+type SessionPnlChartProps = {
+  pnlHistory: number[];
+  runPnlHistories: Record<string, number[]>;
+  activeRuns: AlgoRun[];
+  algos: Algo[];
+  visibleInstanceIds: Set<string>;
+  onToggleInstance: (instanceId: string) => void;
+};
+
+const SessionPnlChart = ({ pnlHistory, runPnlHistories, activeRuns, algos, visibleInstanceIds, onToggleInstance }: SessionPnlChartProps) => {
+  const instances = activeRuns.filter((r) => runPnlHistories[r.instance_id]?.length);
+
+  const data = useMemo<uPlot.AlignedData>(() => {
+    const length = Math.max(pnlHistory.length, ...instances.map((r) => runPnlHistories[r.instance_id]?.length ?? 0), 1);
+    const x = Array.from({ length }, (_, i) => i);
+    const totalSeries = Array.from({ length }, (_, i) => pnlHistory[i] ?? pnlHistory[pnlHistory.length - 1] ?? 0);
+    const perRun = instances.map((r) => {
+      const h = runPnlHistories[r.instance_id] ?? [];
+      return Array.from({ length }, (_, i) => h[i] ?? h[h.length - 1] ?? 0);
+    });
+    return [x, totalSeries, ...perRun] as uPlot.AlignedData;
+  }, [pnlHistory, runPnlHistories, instances]);
+
+  const options = useMemo<uPlot.Options>(() => ({
+    width: 800,
+    height: 220,
+    cursor: { drag: { x: false, y: false } },
+    legend: { show: false },
+    scales: { x: { time: false } },
+    axes: [
+      { stroke: "#6b7280", grid: { stroke: "#1a1b1f", width: 1 } },
+      { stroke: "#6b7280", grid: { stroke: "#1a1b1f", width: 1 } },
+    ],
+    series: [
+      {},
+      { label: "Total", stroke: CHART_PALETTE[0], width: 2, fill: "rgba(229,231,235,0.08)" },
+      ...instances.map((r, i) => ({
+        label: algos.find((a) => a.id === r.algo_id)?.name ?? `algo ${r.algo_id}`,
+        stroke: CHART_PALETTE[(i + 1) % CHART_PALETTE.length],
+        width: 1.5,
+        show: visibleInstanceIds.has(r.instance_id),
+      })),
+    ],
+  }), [instances, algos, visibleInstanceIds]);
+
+  if (pnlHistory.length <= 1) {
+    return (
+      <div className="h-[220px] flex items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)] rounded-lg">
+        No session activity yet
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3 mb-3">
+        <LegendItem color={CHART_PALETTE[0]} label="Total" visible={true} onClick={() => undefined} disabledToggle />
+        {instances.map((r, i) => {
+          const algoName = algos.find((a) => a.id === r.algo_id)?.name ?? `algo ${r.algo_id}`;
+          return (
+            <LegendItem
+              key={r.instance_id}
+              color={CHART_PALETTE[(i + 1) % CHART_PALETTE.length]}
+              label={algoName}
+              visible={visibleInstanceIds.has(r.instance_id)}
+              onClick={() => onToggleInstance(r.instance_id)}
+            />
+          );
+        })}
+      </div>
+      <div className="w-full overflow-hidden">
+        <UplotReact options={options} data={data} />
+      </div>
+    </>
+  );
+};
+
+type LegendItemProps = {
+  color: string;
+  label: string;
+  visible: boolean;
+  onClick: () => void;
+  disabledToggle?: boolean;
+};
+
+const LegendItem = ({ color, label, visible, onClick, disabledToggle }: LegendItemProps) => (
+  <button
+    onClick={disabledToggle ? undefined : onClick}
+    disabled={disabledToggle}
+    className={`flex items-center gap-2 text-xs px-2 py-1 rounded transition-opacity ${disabledToggle ? "cursor-default" : "hover:bg-[var(--bg-panel)]"} ${visible ? "opacity-100" : "opacity-40 line-through"}`}
+  >
+    <span className="w-3 h-0.5 rounded" style={{ backgroundColor: color }} />
+    <span className="text-[var(--text-primary)]">{label}</span>
+  </button>
+);
+
+type TimeRange = "1h" | "today" | "week" | "mtd";
+
+type SegmentedProps = {
+  value: TimeRange;
+  onChange: (v: TimeRange) => void;
+};
+
+const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; enabled: boolean }[] = [
+  { value: "1h", label: "1h", enabled: false },
+  { value: "today", label: "Today", enabled: true },
+  { value: "week", label: "Week", enabled: false },
+  { value: "mtd", label: "MTD", enabled: false },
+];
+
+const TimeRangeSegmented = ({ value, onChange }: SegmentedProps) => (
+  <div className="flex bg-[var(--bg-secondary)] border border-[var(--border)] rounded-md overflow-hidden">
+    {TIME_RANGE_OPTIONS.map((opt) => (
+      <button
+        key={opt.value}
+        disabled={!opt.enabled}
+        onClick={() => opt.enabled && onChange(opt.value)}
+        className={`px-2.5 py-1 text-[11px] transition-colors ${
+          value === opt.value
+            ? "bg-[var(--bg-panel)] text-[var(--text-primary)]"
+            : opt.enabled
+              ? "text-[var(--text-secondary)] hover:bg-[var(--bg-panel)]"
+              : "text-[var(--text-secondary)] opacity-40 cursor-not-allowed"
+        }`}
+        title={opt.enabled ? "" : "Coming soon"}
+      >
+        {opt.label}
+      </button>
+    ))}
+  </div>
 );

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -93,10 +93,10 @@ export const HomeView = (props: HomeViewProps) => {
         : `${positionSymbols.slice(0, 3).join(" · ")} +${positionSymbols.length - 3}`;
 
   const [timeRange, setTimeRange] = useState<TimeRange>("today");
-  const [visibleInstanceIds, setVisibleInstanceIds] = useState<Set<string>>(() => new Set(props.activeRuns.map((r) => r.instance_id)));
+  const [hiddenInstanceIds, setHiddenInstanceIds] = useState<Set<string>>(() => new Set());
 
   const toggleInstanceVisibility = (instanceId: string) => {
-    setVisibleInstanceIds((prev) => {
+    setHiddenInstanceIds((prev) => {
       const next = new Set(prev);
       if (next.has(instanceId)) next.delete(instanceId);
       else next.add(instanceId);
@@ -196,7 +196,7 @@ export const HomeView = (props: HomeViewProps) => {
             runPnlHistories={props.runPnlHistories}
             activeRuns={props.activeRuns}
             algos={props.algos}
-            visibleInstanceIds={visibleInstanceIds}
+            hiddenInstanceIds={hiddenInstanceIds}
             onToggleInstance={toggleInstanceVisibility}
           />
         </div>
@@ -305,12 +305,15 @@ type SessionPnlChartProps = {
   runPnlHistories: Record<string, number[]>;
   activeRuns: AlgoRun[];
   algos: Algo[];
-  visibleInstanceIds: Set<string>;
+  hiddenInstanceIds: Set<string>;
   onToggleInstance: (instanceId: string) => void;
 };
 
-const SessionPnlChart = ({ pnlHistory, runPnlHistories, activeRuns, algos, visibleInstanceIds, onToggleInstance }: SessionPnlChartProps) => {
-  const instances = activeRuns.filter((r) => runPnlHistories[r.instance_id]?.length);
+const SessionPnlChart = ({ pnlHistory, runPnlHistories, activeRuns, algos, hiddenInstanceIds, onToggleInstance }: SessionPnlChartProps) => {
+  const instances = useMemo(
+    () => activeRuns.filter((r) => runPnlHistories[r.instance_id]?.length),
+    [activeRuns, runPnlHistories]
+  );
 
   const data = useMemo<uPlot.AlignedData>(() => {
     const length = Math.max(pnlHistory.length, ...instances.map((r) => runPnlHistories[r.instance_id]?.length ?? 0), 1);
@@ -340,10 +343,10 @@ const SessionPnlChart = ({ pnlHistory, runPnlHistories, activeRuns, algos, visib
         label: algos.find((a) => a.id === r.algo_id)?.name ?? `algo ${r.algo_id}`,
         stroke: CHART_PALETTE[(i + 1) % CHART_PALETTE.length],
         width: 1.5,
-        show: visibleInstanceIds.has(r.instance_id),
+        show: !hiddenInstanceIds.has(r.instance_id),
       })),
     ],
-  }), [instances, algos, visibleInstanceIds]);
+  }), [instances, algos, hiddenInstanceIds]);
 
   if (pnlHistory.length <= 1) {
     return (
@@ -364,7 +367,7 @@ const SessionPnlChart = ({ pnlHistory, runPnlHistories, activeRuns, algos, visib
               key={r.instance_id}
               color={CHART_PALETTE[(i + 1) % CHART_PALETTE.length]}
               label={algoName}
-              visible={visibleInstanceIds.has(r.instance_id)}
+              visible={!hiddenInstanceIds.has(r.instance_id)}
               onClick={() => onToggleInstance(r.instance_id)}
             />
           );

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -77,6 +77,17 @@ export const HomeView = (props: HomeViewProps) => {
         ? "bg-[var(--accent-red)]"
         : "bg-[var(--accent-yellow)] animate-pulse";
 
+  const hasActivity = props.activeRuns.length > 0 || props.stats.totalTrades > 0;
+  const liveCount = props.activeRuns.filter((r) => r.mode === "live").length;
+  const shadowCount = props.activeRuns.filter((r) => r.mode === "shadow").length;
+  const positionSymbols = [...new Set(props.positions.map((p) => p.symbol))];
+  const positionSymbolsLabel =
+    positionSymbols.length === 0
+      ? "—"
+      : positionSymbols.length <= 3
+        ? positionSymbols.join(" · ")
+        : `${positionSymbols.slice(0, 3).join(" · ")} +${positionSymbols.length - 3}`;
+
   return (
     <div className="flex-1 flex flex-col overflow-auto bg-[var(--bg-primary)]">
       <div className="max-w-[1400px] w-full mx-auto p-5 flex flex-col gap-4">
@@ -122,8 +133,35 @@ export const HomeView = (props: HomeViewProps) => {
           )}
         </div>
 
-        {/* Section 2: KPI row — filled in Task 6 */}
-        <div id="home-section-kpis" />
+        {/* Section 2: KPI row */}
+        <div id="home-section-kpis" className="grid grid-cols-4 gap-3">
+          <KpiCard
+            label="Total P&L"
+            value={hasActivity ? formatPnl(props.stats.totalPnl) : "$0.00"}
+            valueColor={hasActivity ? pnlColorClass(props.stats.totalPnl) : undefined}
+            detail={hasActivity ? `Realized ${formatPnl(props.stats.realizedPnl)} · Unrealized ${formatPnl(props.stats.unrealizedPnl)}` : undefined}
+            sparkline={props.pnlHistory.length > 1 ? props.pnlHistory : undefined}
+            onClick={() => props.onNavigate("trading")}
+          />
+          <KpiCard
+            label="Win Rate"
+            value={props.stats.totalTrades > 0 ? `${props.stats.winRate}%` : "—"}
+            detail={props.stats.totalTrades > 0 ? `${props.stats.wins} W · ${props.stats.losses} L` : undefined}
+            onClick={() => props.onNavigate("trading", { scrollTo: "history" })}
+          />
+          <KpiCard
+            label="Active Algos"
+            value={`${props.activeRuns.length}`}
+            detail={props.activeRuns.length > 0 ? `${liveCount} live · ${shadowCount} shadow` : undefined}
+            onClick={() => props.onNavigate("algos")}
+          />
+          <KpiCard
+            label="Open Positions"
+            value={`${props.stats.openPositions}`}
+            detail={positionSymbolsLabel !== "—" ? positionSymbolsLabel : undefined}
+            onClick={() => props.onNavigate("trading", { scrollTo: "positions" })}
+          />
+        </div>
 
         {/* Section 3: Hero P&L chart — filled in Task 7 */}
         <div id="home-section-chart" />
@@ -184,5 +222,50 @@ const AccountCard = ({ name, balance, dayPnl, positionCount, isActive, onClick }
         <div className="text-sm font-medium">{positionCount}</div>
       </div>
     </div>
+  </button>
+);
+
+type KpiCardProps = {
+  label: string;
+  value: string;
+  valueColor?: string;
+  detail?: string;
+  sparkline?: number[];
+  onClick: () => void;
+};
+
+const KpiCard = ({ label, value, valueColor, detail, sparkline, onClick }: KpiCardProps) => (
+  <button
+    onClick={onClick}
+    className="group relative text-left p-4 rounded-xl bg-[var(--bg-panel)] border border-[var(--border)] hover:border-[var(--accent-blue)] hover:bg-[var(--bg-secondary)] transition-colors cursor-pointer overflow-hidden"
+  >
+    <div className="flex items-center justify-between mb-2">
+      <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold">{label}</span>
+      <span className="text-[var(--accent-blue)] text-sm opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+    </div>
+    <div className={`text-[22px] font-bold tracking-tight leading-tight ${valueColor ?? ""}`}>{value}</div>
+    {detail ? <div className="text-[11px] text-[var(--text-secondary)] mt-1">{detail}</div> : null}
+    {sparkline && sparkline.length > 1 ? (
+      <svg
+        viewBox={`0 0 ${sparkline.length} 20`}
+        preserveAspectRatio="none"
+        className="absolute right-3 bottom-3 w-16 h-5 opacity-40 pointer-events-none"
+      >
+        <polyline
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          points={sparkline
+            .map((v, i) => {
+              const min = Math.min(...sparkline);
+              const max = Math.max(...sparkline);
+              const range = max - min || 1;
+              const y = 18 - ((v - min) / range) * 16;
+              return `${i},${y}`;
+            })
+            .join(" ")}
+        />
+      </svg>
+    ) : null}
   </button>
 );

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -256,7 +256,56 @@ export const HomeView = (props: HomeViewProps) => {
               </table>
             )}
           </div>
-          <div id="home-section-performance" className="col-span-1" />
+          <div id="home-section-performance" className="col-span-1 p-4 rounded-xl bg-[var(--bg-panel)] border border-[var(--border)]">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-[11px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold">Performance</span>
+              <button
+                onClick={() => props.onNavigate("trading", { scrollTo: "stats" })}
+                className="text-[11px] text-[var(--accent-blue)] hover:underline"
+              >
+                Full stats →
+              </button>
+            </div>
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold mb-1">Quality</div>
+                <StatRow label="Profit Factor" value={props.stats.profitFactor} />
+                <StatRow label="Sharpe" value={props.stats.sharpe} />
+                <StatRow
+                  label="Max Drawdown"
+                  value={props.stats.totalTrades > 0 ? formatPnl(props.stats.maxDrawdown) : "—"}
+                  valueColor={props.stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+                />
+              </div>
+              <div className="border-t border-[var(--border)] pt-3">
+                <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold mb-1">Trades</div>
+                <StatRow
+                  label="Avg Win"
+                  value={props.stats.totalTrades > 0 ? formatPnl(props.stats.avgWin) : "—"}
+                  valueColor={props.stats.totalTrades > 0 ? "text-[var(--accent-green)]" : undefined}
+                />
+                <StatRow
+                  label="Avg Loss"
+                  value={props.stats.totalTrades > 0 ? formatPnl(props.stats.avgLoss) : "—"}
+                  valueColor={props.stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+                />
+                <StatRow label="Avg Duration" value={props.stats.avgTradeDuration || "—"} />
+              </div>
+              <div className="border-t border-[var(--border)] pt-3">
+                <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold mb-1">Streaks</div>
+                <StatRow
+                  label="Consecutive W"
+                  value={props.stats.totalTrades > 0 ? `${props.stats.consecutiveWins}` : "—"}
+                  valueColor={props.stats.totalTrades > 0 ? "text-[var(--accent-green)]" : undefined}
+                />
+                <StatRow
+                  label="Consecutive L"
+                  value={props.stats.totalTrades > 0 ? `${props.stats.consecutiveLosses}` : "—"}
+                  valueColor={props.stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+                />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -562,3 +611,16 @@ const AlgoTapeRow = ({ instanceId: _id, algoName, mode, account, pnl, trades, wi
     </tr>
   );
 };
+
+type StatRowProps = {
+  label: string;
+  value: string;
+  valueColor?: string;
+};
+
+const StatRow = ({ label, value, valueColor }: StatRowProps) => (
+  <div className="flex items-center justify-between py-1 text-sm">
+    <span className="text-[var(--text-secondary)]">{label}</span>
+    <span className={`font-medium tabular-nums ${valueColor ?? ""}`}>{value}</span>
+  </div>
+);

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,4 +1,5 @@
-import type { Algo, AlgoRun } from "../types";
+import type { Algo, AlgoRun, NavOptions, View } from "../types";
+import type { AlgoStats } from "../hooks/useTradingSimulation";
 
 type Position = {
   symbol: string;
@@ -46,245 +47,56 @@ type HomeViewProps = {
   activeRuns: AlgoRun[];
   stats: SessionStats;
   positions: Position[];
+  pnlHistory: number[];
+  runPnlHistories: Record<string, number[]>;
+  algoStats: Record<string, AlgoStats>;
+  onNavigate: (view: View, options?: NavOptions) => void;
+  onStopAlgo: (instanceId: string) => void;
 };
 
-const formatPnl = (value: number) => {
-  const sign = value >= 0 ? "+" : "";
-  return `${sign}$${Math.abs(value).toFixed(2)}`;
-};
-
-const pnlColor = (value: number) =>
-  value >= 0 ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
-
-export const HomeView = ({ connectionStatus, accounts, algos, activeRuns, stats, positions }: HomeViewProps) => {
-  const accountNames = Object.keys(accounts);
-  const hasActivity = activeRuns.length > 0;
-  const t = stats.totalTrades;
-
-  const accountPositionCount = (accountName: string) =>
-    positions.filter((p) => p.account === accountName).length;
-
-  const accountPnl = (accountName: string) =>
-    positions.filter((p) => p.account === accountName).reduce((sum, p) => sum + p.targetPnl, 0);
-
-  const accountRunCount = (accountName: string) =>
-    activeRuns.filter((r) => r.account === accountName).length;
-
-  const isAccountActive = (accountName: string) => accountRunCount(accountName) > 0;
+export const HomeView = (props: HomeViewProps) => {
+  const accountCount = Object.keys(props.accounts).length;
+  const runningCount = props.activeRuns.length;
+  const connectionLabel =
+    props.connectionStatus === "connected"
+      ? `Connected to NinjaTrader · ${accountCount} account${accountCount === 1 ? "" : "s"} · ${runningCount} algo${runningCount === 1 ? "" : "s"} running`
+      : props.connectionStatus === "error"
+        ? "Connection error"
+        : "Waiting for NinjaTrader…";
+  const statusColor =
+    props.connectionStatus === "connected"
+      ? "bg-[var(--accent-green)]"
+      : props.connectionStatus === "error"
+        ? "bg-[var(--accent-red)]"
+        : "bg-[var(--accent-yellow)] animate-pulse";
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      {/* Hero Header */}
-      <div className="px-5 pt-5 pb-4 bg-[var(--bg-secondary)] border-b border-[var(--border)]">
-        <h1 className="text-xl font-semibold mb-1">Wolf Den</h1>
-        <p className="text-sm text-[var(--text-secondary)] mb-3">
-          Algorithmic trading command center
-        </p>
-        <div className="flex items-center gap-3">
-          <div
-            className={`w-2.5 h-2.5 rounded-full ${
-              connectionStatus === "connected"
-                ? "bg-[var(--accent-green)]"
-                : connectionStatus === "error"
-                  ? "bg-[var(--accent-red)]"
-                  : "bg-[var(--accent-yellow)] animate-pulse"
-            }`}
-          />
-          <span
-            className={`text-sm ${
-              connectionStatus === "connected"
-                ? "text-[var(--accent-green)]"
-                : connectionStatus === "error"
-                  ? "text-[var(--accent-red)]"
-                  : "text-[var(--accent-yellow)]"
-            }`}
-          >
-            {connectionStatus === "connected" && "Connected to NinjaTrader"}
-            {connectionStatus === "waiting" && "Waiting for NinjaTrader..."}
-            {connectionStatus === "error" && "Connection error"}
-          </span>
-        </div>
-      </div>
-
-      {/* Three-Column Layout */}
-      <div className="flex-1 flex min-h-0">
-        {/* Left Column: Accounts */}
-        <div className="flex-1 p-5 overflow-auto border-r border-[var(--border)]">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
-            Accounts
-          </h2>
-
-          <div className="space-y-3">
-            {accountNames.length === 0 ? (
-              <p className="text-sm text-[var(--text-secondary)]">
-                No accounts connected
-              </p>
-            ) : accountNames.map((name) => {
-              const data = accounts[name];
-              const balance = data.cash || data.buying_power;
-              const dayPnl = data.realized_pnl + accountPnl(name);
-              return (
-                <div
-                  key={name}
-                  className="p-4 rounded-lg bg-[var(--bg-panel)] border border-[var(--border)]"
-                >
-                  <div className="flex items-center justify-between mb-3">
-                    <div className="flex items-center gap-2">
-                      <div
-                        className={`w-2 h-2 rounded-full ${
-                          isAccountActive(name)
-                            ? "bg-[var(--accent-green)]"
-                            : "bg-[var(--border)]"
-                        }`}
-                      />
-                      <span className="text-sm font-medium">{name}</span>
-                    </div>
-                    <span className="text-[10px] uppercase text-[var(--text-secondary)]">
-                      NinjaTrader
-                    </span>
-                  </div>
-
-                  <div className="grid grid-cols-3 gap-3">
-                    <div>
-                      <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">Balance</div>
-                      <div className="text-sm font-medium">${balance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</div>
-                    </div>
-                    <div>
-                      <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">Day P&L</div>
-                      <div className={`text-sm font-medium ${dayPnl !== 0 ? pnlColor(dayPnl) : ""}`}>
-                        {dayPnl !== 0 ? formatPnl(dayPnl) : "$0.00"}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">Positions</div>
-                      <div className="text-sm font-medium">{accountPositionCount(name)}</div>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+    <div className="flex-1 flex flex-col overflow-auto bg-[var(--bg-primary)]">
+      <div className="max-w-[1400px] w-full mx-auto p-5 flex flex-col gap-4">
+        {/* Section 0: Compact header */}
+        <div id="home-section-header" className="flex items-baseline gap-3">
+          <h1 className="text-[22px] font-semibold tracking-tight">Wolf Den</h1>
+          <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+            <span className={`w-2 h-2 rounded-full ${statusColor}`} />
+            <span>{connectionLabel}</span>
           </div>
         </div>
 
-        {/* Middle Column: Session Stats */}
-        <div className="flex-1 p-5 overflow-auto border-r border-[var(--border)]">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
-            Today's Session
-          </h2>
+        {/* Section 1: Account strip — filled in Task 5 */}
+        <div id="home-section-accounts" />
 
-          <div className="space-y-3">
-            <StatRow
-              label="Total P&L"
-              value={hasActivity ? formatPnl(stats.totalPnl) : "$0.00"}
-              color={hasActivity ? pnlColor(stats.totalPnl) : undefined}
-            />
-            <StatRow
-              label="Realized"
-              value={hasActivity ? formatPnl(stats.realizedPnl) : "$0.00"}
-              color={hasActivity ? pnlColor(stats.realizedPnl) : undefined}
-            />
-            <StatRow
-              label="Unrealized"
-              value={hasActivity ? formatPnl(stats.unrealizedPnl) : "$0.00"}
-              color={hasActivity ? pnlColor(stats.unrealizedPnl) : undefined}
-            />
+        {/* Section 2: KPI row — filled in Task 6 */}
+        <div id="home-section-kpis" />
 
-            <div className="border-t border-[var(--border)]" />
-            <SectionLabel label="Performance" />
-            <StatRow label="Win Rate" value={t > 0 ? `${stats.winRate}%` : "--"} />
-            <StatRow label="Profit Factor" value={stats.profitFactor} />
-            <StatRow label="Sharpe Ratio" value={stats.sharpe} />
-            <StatRow label="Max Drawdown" value={t > 0 ? formatPnl(stats.maxDrawdown) : "--"} color={t > 0 ? "text-[var(--accent-red)]" : undefined} />
+        {/* Section 3: Hero P&L chart — filled in Task 7 */}
+        <div id="home-section-chart" />
 
-            <div className="border-t border-[var(--border)]" />
-            <SectionLabel label="Trades" />
-            <StatRow label="Total Trades" value={`${stats.totalTrades}`} />
-            <StatRow label="Wins / Losses" value={t > 0 ? `${stats.wins} / ${stats.losses}` : "0 / 0"} />
-            <StatRow label="Avg Win" value={t > 0 ? formatPnl(stats.avgWin) : "--"} color={t > 0 ? "text-[var(--accent-green)]" : undefined} />
-            <StatRow label="Avg Loss" value={t > 0 ? formatPnl(stats.avgLoss) : "--"} color={t > 0 ? "text-[var(--accent-red)]" : undefined} />
-            <StatRow label="Largest Win" value={t > 0 ? formatPnl(stats.largestWin) : "--"} color={t > 0 ? "text-[var(--accent-green)]" : undefined} />
-            <StatRow label="Largest Loss" value={t > 0 ? formatPnl(stats.largestLoss) : "--"} color={t > 0 ? "text-[var(--accent-red)]" : undefined} />
-            <StatRow label="Avg Duration" value={stats.avgTradeDuration} />
-
-            <div className="border-t border-[var(--border)]" />
-            <SectionLabel label="Streaks" />
-            <StatRow label="Consecutive Wins" value={t > 0 ? `${stats.consecutiveWins}` : "--"} color={t > 0 ? "text-[var(--accent-green)]" : undefined} />
-            <StatRow label="Consecutive Losses" value={t > 0 ? `${stats.consecutiveLosses}` : "--"} color={t > 0 ? "text-[var(--accent-red)]" : undefined} />
-
-            <div className="border-t border-[var(--border)]" />
-            <SectionLabel label="Exposure" />
-            <StatRow label="Open Positions" value={`${stats.openPositions}`} />
-            <StatRow label="Active Algos" value={`${activeRuns.length}`} />
-          </div>
-        </div>
-
-        {/* Right Column: Active Algos */}
-        <div className="flex-1 flex flex-col p-5 overflow-auto">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
-            Active Algos
-          </h2>
-
-          <div className="flex-1 min-h-0">
-            {activeRuns.length === 0 ? (
-              <p className="text-sm text-[var(--text-secondary)]">
-                No algos running — start one from the Algos view
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {activeRuns.map((run) => {
-                  const algo = algos.find((a) => a.id === run.algo_id);
-                  if (!algo) return null;
-                  return (
-                    <div
-                      key={run.instance_id}
-                      className="flex items-center justify-between p-3 rounded-lg bg-[var(--bg-panel)] border border-[var(--border)]"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`w-2 h-2 rounded-full ${
-                            run.mode === "live"
-                              ? "bg-[var(--accent-green)]"
-                              : "bg-[var(--accent-yellow)]"
-                          }`}
-                        />
-                        <div>
-                          <span className="text-sm">{algo.name}</span>
-                          <span className="text-xs text-[var(--text-secondary)] ml-2">
-                            {run.data_source_id.split(":")[0].split(" ")[0]} {run.data_source_id.split(":")[1]}
-                          </span>
-                          <span className="text-xs text-[var(--text-secondary)] ml-1">{run.account}</span>
-                        </div>
-                      </div>
-                      <span
-                        className={`text-[10px] uppercase px-2.5 py-1 rounded-md font-medium ${
-                          run.mode === "live"
-                            ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
-                            : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]"
-                        }`}
-                      >
-                        {run.mode}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+        {/* Section 4: Bottom split (algos tape + performance) — filled in Tasks 8 & 9 */}
+        <div id="home-section-bottom" className="grid grid-cols-3 gap-4">
+          <div id="home-section-algos" className="col-span-2" />
+          <div id="home-section-performance" className="col-span-1" />
         </div>
       </div>
     </div>
   );
 };
-
-const SectionLabel = ({ label }: { label: string }) => (
-  <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold pt-1">
-    {label}
-  </div>
-);
-
-const StatRow = ({ label, value, color }: { label: string; value: string; color?: string }) => (
-  <div className="flex items-center justify-between">
-    <span className="text-sm text-[var(--text-secondary)]">{label}</span>
-    <span className={`text-sm font-semibold ${color ?? ""}`}>{value}</span>
-  </div>
-);

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -245,27 +245,20 @@ const KpiCard = ({ label, value, valueColor, detail, sparkline, onClick }: KpiCa
     </div>
     <div className={`text-[22px] font-bold tracking-tight leading-tight ${valueColor ?? ""}`}>{value}</div>
     {detail ? <div className="text-[11px] text-[var(--text-secondary)] mt-1">{detail}</div> : null}
-    {sparkline && sparkline.length > 1 ? (
-      <svg
-        viewBox={`0 0 ${sparkline.length} 20`}
-        preserveAspectRatio="none"
-        className="absolute right-3 bottom-3 w-16 h-5 opacity-40 pointer-events-none"
-      >
-        <polyline
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          points={sparkline
-            .map((v, i) => {
-              const min = Math.min(...sparkline);
-              const max = Math.max(...sparkline);
-              const range = max - min || 1;
-              const y = 18 - ((v - min) / range) * 16;
-              return `${i},${y}`;
-            })
-            .join(" ")}
-        />
-      </svg>
-    ) : null}
+    {sparkline && sparkline.length > 1 ? (() => {
+      const min = Math.min(...sparkline);
+      const max = Math.max(...sparkline);
+      const range = max - min || 1;
+      const points = sparkline.map((v, i) => `${i},${18 - ((v - min) / range) * 16}`).join(" ");
+      return (
+        <svg
+          viewBox={`0 0 ${sparkline.length} 20`}
+          preserveAspectRatio="none"
+          className={`absolute right-3 bottom-3 w-16 h-5 opacity-40 pointer-events-none ${valueColor ?? ""}`}
+        >
+          <polyline fill="none" stroke="currentColor" strokeWidth="1.5" points={points} />
+        </svg>
+      );
+    })() : null}
   </button>
 );

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -57,6 +57,13 @@ type HomeViewProps = {
 export const HomeView = (props: HomeViewProps) => {
   const accountCount = Object.keys(props.accounts).length;
   const runningCount = props.activeRuns.length;
+  const accountNames = Object.keys(props.accounts);
+  const accountPositionCount = (accountName: string) =>
+    props.positions.filter((p) => p.account === accountName).length;
+  const accountLivePnl = (accountName: string) =>
+    props.positions.filter((p) => p.account === accountName).reduce((sum, p) => sum + p.targetPnl, 0);
+  const accountIsActive = (accountName: string) =>
+    props.activeRuns.some((r) => r.account === accountName);
   const connectionLabel =
     props.connectionStatus === "connected"
       ? `Connected to NinjaTrader · ${accountCount} account${accountCount === 1 ? "" : "s"} · ${runningCount} algo${runningCount === 1 ? "" : "s"} running`
@@ -82,8 +89,38 @@ export const HomeView = (props: HomeViewProps) => {
           </div>
         </div>
 
-        {/* Section 1: Account strip — filled in Task 5 */}
-        <div id="home-section-accounts" />
+        {/* Section 1: Account strip */}
+        <div id="home-section-accounts">
+          {accountNames.length === 0 ? (
+            <div className="p-4 rounded-xl bg-[var(--bg-panel)] border border-[var(--border)] text-sm text-[var(--text-secondary)]">
+              No accounts connected
+            </div>
+          ) : (
+            <div className={`grid gap-3 ${
+              accountNames.length === 1 ? "grid-cols-1" :
+              accountNames.length === 2 ? "grid-cols-2" :
+              accountNames.length === 3 ? "grid-cols-3" :
+              "grid-cols-4 overflow-x-auto"
+            }`}>
+              {accountNames.map((name) => {
+                const data = props.accounts[name];
+                const balance = data.cash || data.buying_power;
+                const dayPnl = data.realized_pnl + accountLivePnl(name);
+                return (
+                  <AccountCard
+                    key={name}
+                    name={name}
+                    balance={balance}
+                    dayPnl={dayPnl}
+                    positionCount={accountPositionCount(name)}
+                    isActive={accountIsActive(name)}
+                    onClick={() => props.onNavigate("trading", { accountFilter: name })}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         {/* Section 2: KPI row — filled in Task 6 */}
         <div id="home-section-kpis" />
@@ -100,3 +137,52 @@ export const HomeView = (props: HomeViewProps) => {
     </div>
   );
 };
+
+const formatPnl = (value: number): string => {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}$${Math.abs(value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+};
+
+const pnlColorClass = (value: number): string =>
+  value > 0 ? "text-[var(--accent-green)]" : value < 0 ? "text-[var(--accent-red)]" : "text-[var(--text-primary)]";
+
+type AccountCardProps = {
+  name: string;
+  balance: number;
+  dayPnl: number;
+  positionCount: number;
+  isActive: boolean;
+  onClick: () => void;
+};
+
+const AccountCard = ({ name, balance, dayPnl, positionCount, isActive, onClick }: AccountCardProps) => (
+  <button
+    onClick={onClick}
+    className="group text-left p-4 rounded-xl bg-[var(--bg-panel)] border border-[var(--border)] hover:border-[var(--accent-blue)] hover:bg-[var(--bg-secondary)] transition-colors cursor-pointer"
+  >
+    <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center gap-2">
+        <span className={`w-1.5 h-1.5 rounded-full ${isActive ? "bg-[var(--accent-green)]" : "bg-[var(--border)]"}`} />
+        <span className="text-sm font-medium">{name}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] uppercase text-[var(--text-secondary)] tracking-wider">NinjaTrader</span>
+        <span className="text-[var(--accent-blue)] text-sm opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+      </div>
+    </div>
+    <div className="grid grid-cols-3 gap-3">
+      <div>
+        <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">Balance</div>
+        <div className="text-sm font-medium">${balance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</div>
+      </div>
+      <div>
+        <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">Day P&L</div>
+        <div className={`text-sm font-medium ${pnlColorClass(dayPnl)}`}>{dayPnl !== 0 ? formatPnl(dayPnl) : "$0.00"}</div>
+      </div>
+      <div>
+        <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">Positions</div>
+        <div className="text-sm font-medium">{positionCount}</div>
+      </div>
+    </div>
+  </button>
+);

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type MouseEvent } from "react";
 import UplotReact from "uplot-react";
 import "uplot/dist/uPlot.min.css";
 import type uPlot from "uplot";
@@ -203,7 +203,59 @@ export const HomeView = (props: HomeViewProps) => {
 
         {/* Section 4: Bottom split (algos tape + performance) — filled in Tasks 8 & 9 */}
         <div id="home-section-bottom" className="grid grid-cols-3 gap-4">
-          <div id="home-section-algos" className="col-span-2" />
+          <div id="home-section-algos" className="col-span-2 p-4 rounded-xl bg-[var(--bg-panel)] border border-[var(--border)]">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-[11px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold">Active Algos</span>
+              <button
+                onClick={() => props.onNavigate("algos")}
+                className="text-[11px] text-[var(--accent-blue)] hover:underline"
+              >
+                View all →
+              </button>
+            </div>
+            {props.activeRuns.length === 0 ? (
+              <div className="text-sm text-[var(--text-secondary)] py-6 text-center">
+                No algos running — start one from the Algos view
+              </div>
+            ) : (
+              <table className="w-full">
+                <thead>
+                  <tr>
+                    <th className="text-left px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">Algo</th>
+                    <th className="text-left px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">Mode</th>
+                    <th className="text-left px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">Account</th>
+                    <th className="text-right px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">P&L</th>
+                    <th className="text-right px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">Trades</th>
+                    <th className="text-right px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">Win %</th>
+                    <th className="text-left px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">Trend</th>
+                    <th className="px-3 py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {props.activeRuns.map((run) => {
+                    const algo = props.algos.find((a) => a.id === run.algo_id);
+                    const stats = props.algoStats[run.instance_id];
+                    const history = props.runPnlHistories[run.instance_id] ?? [];
+                    return (
+                      <AlgoTapeRow
+                        key={run.instance_id}
+                        instanceId={run.instance_id}
+                        algoName={algo?.name ?? `algo ${run.algo_id}`}
+                        mode={run.mode}
+                        account={run.account}
+                        pnl={stats?.pnl ?? 0}
+                        trades={stats?.totalTrades ?? 0}
+                        winRate={stats?.winRate ?? 0}
+                        history={history}
+                        onClickRow={() => props.onNavigate("algos", { instanceId: run.instance_id })}
+                        onStop={() => props.onStopAlgo(run.instance_id)}
+                      />
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
           <div id="home-section-performance" className="col-span-1" />
         </div>
       </div>
@@ -434,3 +486,79 @@ const TimeRangeSegmented = ({ value, onChange }: SegmentedProps) => (
     ))}
   </div>
 );
+
+type AlgoTapeRowProps = {
+  instanceId: string;
+  algoName: string;
+  mode: string;
+  account: string;
+  pnl: number;
+  trades: number;
+  winRate: number;
+  history: number[];
+  onClickRow: () => void;
+  onStop: () => void;
+};
+
+const AlgoTapeRow = ({ instanceId: _id, algoName, mode, account, pnl, trades, winRate, history, onClickRow, onStop }: AlgoTapeRowProps) => {
+  const modePill =
+    mode === "live"
+      ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
+      : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+
+  const handleStop = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onStop();
+  };
+
+  const sparkline = (() => {
+    if (history.length <= 1) return null;
+    const min = Math.min(...history);
+    const max = Math.max(...history);
+    const range = max - min || 1;
+    const points = history.map((v, i) => `${i},${16 - ((v - min) / range) * 14}`).join(" ");
+    return (
+      <svg viewBox={`0 0 ${history.length} 18`} preserveAspectRatio="none" className="w-16 h-4">
+        <polyline
+          fill="none"
+          stroke={pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)"}
+          strokeWidth="1.2"
+          points={points}
+        />
+      </svg>
+    );
+  })();
+
+  return (
+    <tr
+      onClick={onClickRow}
+      className="group border-t border-[var(--border)] hover:bg-[var(--bg-secondary)] transition-colors cursor-pointer"
+    >
+      <td className="px-3 py-2 text-sm">
+        <div className="flex items-center gap-2">
+          <span className={`w-1.5 h-1.5 rounded-full ${mode === "live" ? "bg-[var(--accent-green)]" : "bg-[var(--accent-yellow)]"}`} />
+          <span className="font-medium">{algoName}</span>
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <span className={`text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded ${modePill}`}>{mode}</span>
+      </td>
+      <td className="px-3 py-2 text-sm text-[var(--text-secondary)]">{account}</td>
+      <td className={`px-3 py-2 text-sm text-right font-medium tabular-nums ${pnlColorClass(pnl)}`}>{formatPnl(pnl)}</td>
+      <td className="px-3 py-2 text-sm text-right tabular-nums">{trades}</td>
+      <td className="px-3 py-2 text-sm text-right tabular-nums">{trades > 0 ? `${winRate}%` : "—"}</td>
+      <td className="px-3 py-2">
+        {sparkline ?? <span className="text-[var(--text-secondary)] text-xs">—</span>}
+      </td>
+      <td className="px-3 py-2 text-right">
+        <button
+          onClick={handleStop}
+          className="opacity-0 group-hover:opacity-100 text-[10px] uppercase tracking-wider px-2 py-1 rounded border border-[var(--border)] hover:border-[var(--accent-red)] hover:text-[var(--accent-red)] transition-all"
+          title="Stop this algo"
+        >
+          Stop
+        </button>
+      </td>
+    </tr>
+  );
+};

--- a/src/views/TradingView.tsx
+++ b/src/views/TradingView.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { type TradingSimulation, type Position, formatPrice } from "../hooks/useTradingSimulation";
-import type { Algo, AlgoRun } from "../types";
+import type { Algo, AlgoRun, NavContext } from "../types";
 
 type TradingViewProps = {
   simulation: TradingSimulation;
   algos: Algo[];
   activeRuns: AlgoRun[];
+  initialContext?: NavContext | null;
+  onContextConsumed?: () => void;
 };
 
 const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
@@ -95,7 +97,7 @@ const useAnimatedNumber = (target: number, speed = 0.08) => {
 
 type TradingMode = "live" | "shadow";
 
-export const TradingView = ({ simulation, algos, activeRuns }: TradingViewProps) => {
+export const TradingView = ({ simulation, algos, activeRuns, initialContext, onContextConsumed }: TradingViewProps) => {
   const { positions, orders, pnlHistory, shadowPnlHistory, runPnlHistories, stats, shadowStats } = simulation;
   const [selectedAlgoId, setSelectedAlgoId] = useState<number | null>(null);
   const [selectedAccount, setSelectedAccount] = useState<string | null>(null);
@@ -108,6 +110,20 @@ export const TradingView = ({ simulation, algos, activeRuns }: TradingViewProps)
       setSelectedAlgoId(null);
     }
   }, [activeRuns, selectedAlgoId]);
+
+  useEffect(() => {
+    if (!initialContext || initialContext.targetView !== "trading") return;
+    if (initialContext.accountFilter !== undefined) setSelectedAccount(initialContext.accountFilter);
+    if (initialContext.algoFilter !== undefined) setSelectedAlgoId(initialContext.algoFilter);
+    if (initialContext.scrollTo) {
+      requestAnimationFrame(() => {
+        const scrollTarget = initialContext.scrollTo === "history" ? "orders" : initialContext.scrollTo;
+        const el = document.getElementById(`trading-anchor-${scrollTarget}`);
+        if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    }
+    onContextConsumed?.();
+  }, [initialContext, onContextConsumed]);
 
   const runningAlgos = algos.filter((a) => activeRuns.some((r) => r.algo_id === a.id));
 
@@ -327,6 +343,7 @@ export const TradingView = ({ simulation, algos, activeRuns }: TradingViewProps)
 
       {/* Top Row: P&L + Stats */}
       <div className="flex gap-3">
+        <div id="trading-anchor-stats" />
         <div className="flex-1 grid grid-cols-3 gap-4 p-4 bg-[var(--bg-panel)] rounded-lg">
           <PnlCard label="Realized P&L" value={animatedRealized} />
           <PnlCard label="Unrealized P&L" value={animatedUnrealized} />
@@ -359,6 +376,7 @@ export const TradingView = ({ simulation, algos, activeRuns }: TradingViewProps)
       {/* Bottom Row: Positions + Orders */}
       <div className="flex gap-3 flex-1 min-h-0">
         <div className="flex-1 bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+          <div id="trading-anchor-positions" />
           <div className="px-4 py-2.5 border-b border-[var(--border)]">
             <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
               Open Positions
@@ -407,6 +425,7 @@ export const TradingView = ({ simulation, algos, activeRuns }: TradingViewProps)
         </div>
 
         <div className="flex-1 bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+          <div id="trading-anchor-orders" />
           <div className="px-4 py-2.5 border-b border-[var(--border)]">
             <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
               Recent Orders

--- a/src/views/TradingView.tsx
+++ b/src/views/TradingView.tsx
@@ -113,16 +113,24 @@ export const TradingView = ({ simulation, algos, activeRuns, initialContext, onC
 
   useEffect(() => {
     if (!initialContext || initialContext.targetView !== "trading") return;
+
     if (initialContext.accountFilter !== undefined) setSelectedAccount(initialContext.accountFilter);
     if (initialContext.algoFilter !== undefined) setSelectedAlgoId(initialContext.algoFilter);
+
+    let rafHandle: number | undefined;
     if (initialContext.scrollTo) {
-      requestAnimationFrame(() => {
+      rafHandle = requestAnimationFrame(() => {
         const scrollTarget = initialContext.scrollTo === "history" ? "orders" : initialContext.scrollTo;
         const el = document.getElementById(`trading-anchor-${scrollTarget}`);
         if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
       });
     }
+
     onContextConsumed?.();
+
+    return () => {
+      if (rafHandle !== undefined) cancelAnimationFrame(rafHandle);
+    };
   }, [initialContext, onContextConsumed]);
 
   const runningAlgos = algos.filter((a) => activeRuns.some((r) => r.algo_id === a.id));


### PR DESCRIPTION
## Summary

Replaces the old three-column home view (Accounts | long flat stat list | Active Algos) with a modern top-down layout and makes every card/row a click-through into the relevant deep-dive view.

**Top-down hierarchy:** account strip → KPI row → hero P&L chart → active algos tape + grouped performance stats.

**Deep-links:** clicking any card or row navigates to Trading or Algos with the correct filter or instance pre-applied. Implemented via new \`NavOptions\` / \`NavContext\` types, a \`pendingNavContext\` state in \`App\`, and \`initialContext\` / \`initialInstanceId\` props on the target views.

### Sections

- **Section 0 — Compact header.** Title + pluralized connection status in one row.
- **Section 1 — Account strip.** Horizontal grid of account cards (balance, day P&L, position count). Clicking a card opens Trading filtered by that account.
- **Section 2 — KPI row.** Four scannable cards: Total P&L (with sparkline tinted to P&L sign), Win Rate, Active Algos, Open Positions. Each routes to the relevant deep-dive.
- **Section 3 — Hero P&L chart.** Multi-line uPlot chart with a \"Total\" area line plus one line per running algo. Legend toggles visibility; time-range segmented control (1h / Today / Week / MTD) — only \"Today\" wired in v1, the rest are intentionally disabled.
- **Section 4 — Bottom split.** 2/3 Active Algos tape (mode pill, per-row sparkline, inline Stop button on hover, row click opens Algos with the instance focused) + 1/3 Performance panel (Quality / Trades / Streaks grouped stats with \"Full stats →\" link).

### Click map

| Click | Goes to |
|---|---|
| Account card | Trading (account filter) |
| KPI Total P&L | Trading |
| KPI Win Rate | Trading (scroll to history) |
| KPI Active Algos | Algos |
| KPI Open Positions | Trading (scroll to positions) |
| Chart title | Trading |
| Chart legend | stays — toggles line |
| Time range | stays — rescopes chart |
| Algo tape row | Algos (instance focused) |
| Algo tape Stop | \`onStopAlgo\` — no navigation |
| \"View all →\" | Algos |
| \"Full stats →\" | Trading (scroll to stats) |

### Component changes

- \`src/types.ts\` — new \`NavOptions\` + \`NavContext\` types.
- \`src/App.tsx\` — \`pendingNavContext\` state, \`handleNavigate(view, options?)\`, wiring through to HomeView / TradingView / AlgosView.
- \`src/views/HomeView.tsx\` — full rewrite.
- \`src/views/TradingView.tsx\` — accepts \`initialContext\`, adds scroll anchors (\`trading-anchor-{positions,orders,stats}\`), \`history\` aliased to \`orders\`.
- \`src/views/AlgosView.tsx\` — accepts \`initialInstanceId\`, prefers it over the default first-running auto-select; consume callback fires whether or not the instance was found so stale context doesn't leak.

### Spec & plan

- Spec: \`docs/superpowers/specs/2026-04-18-home-view-redesign-design.md\` (Status: Implemented)
- Plan: \`docs/superpowers/plans/2026-04-18-home-view-redesign.md\` (10 tasks)

## Out of scope / follow-ups

- Historical P&L ranges (Week / MTD / 1h) — need persistence beyond the in-memory simulation. Segments render but are disabled.
- Chart width is fixed at 800px; responsive sizing is a polish pass.
- Keyboard affordance on the clickable \`<tr>\` rows — a11y follow-up.

## Test plan

- [ ] \`npm run tauri dev\` with NinjaTrader connected
- [ ] Home view loads with a compact header + all four sections
- [ ] Start one live + one shadow algo; verify:
  - KPIs update (Total P&L colored, Win Rate %, Active Algos 2 with live/shadow split, Open Positions with symbols)
  - Hero chart renders \"Total\" line + one per algo; legend toggles individual lines
  - Active Algos tape shows both rows with correct mode pills, sparklines, and Win %
- [ ] Click each region and verify correct destination + filter:
  - Account card → Trading filtered by that account
  - Each KPI (Total P&L / Win Rate / Active Algos / Open Positions) → correct view + scroll target
  - Chart title \"Session P&L →\" → Trading
  - Algo tape row → Algos focused on that instance
  - Algo tape Stop button → removes row, stays on home (no navigation)
  - \"View all →\" → Algos
  - \"Full stats →\" → Trading (stats section)
- [ ] Empty states render cleanly (no accounts, no runs, no trades)
- [ ] After navigating away via the Sidebar and back, no stale filter leaks into the target view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned home dashboard with KPI cards (Total P&L, Win Rate, Active Algos, Open Positions) and session performance visualization.
  * Added session P&L chart with per-algo visibility toggle.
  * Improved smart navigation: views now remember filters, selections, and scroll positions when navigating between sections.

* **Chores**
  * Updated design specification status to reflect implementation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->