### PR TITLE
feat: editor view redesign — multi-tab workspace

### DIFF
--- a/docs/superpowers/plans/2026-04-19-editor-view-redesign.md
+++ b/docs/superpowers/plans/2026-04-19-editor-view-redesign.md
@@ -1,0 +1,1976 @@
+# Editor View Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the algo editor into a multi-tab workspace (Variant B "Workspace" direction), aligned with `docs/superpowers/specs/2026-04-19-editor-view-redesign-design.md`.
+
+**Architecture:** A new `useEditorTabs` hook centralizes tab state (open tabs, per-tab dirty buffers, active tab). `EditorView` becomes a layout-only orchestrator that composes `AlgoManager` + new `EditorTabs` + slimmed `AlgoEditor` + new `EditorStatusBar`. `Sidebar.tsx` is restyled to a 52px icon-only rail. A custom Monaco theme (`wolf-den-dark`) replaces `vs-dark`. No backend / Tauri-command / schema changes.
+
+**Tech Stack:** React 19, TypeScript 6, `@monaco-editor/react` 4.7, `monaco-editor` 0.55, `lucide-react` (already installed) for icons, Tailwind 4 + CSS vars in `src/styles.css`.
+
+---
+
+## Project has no test framework — adapted task template
+
+The standard `superpowers:writing-plans` template uses a TDD flow. This project has no vitest / jest setup (see `package.json`), and the spec's verification plan is `npm run build` + manual smoke matrix. Every task here replaces the "write failing test → run → implement → pass" cycle with:
+
+1. **Implement** — write the code.
+2. **Type-check** — run `npm run build` from the repo root; expect zero TypeScript errors. (The project's `build` script is `tsc && vite build` — passing `tsc` means the types are clean.)
+3. **Smoke** — a targeted manual walk-through described per task.
+4. **Commit** — Conventional Commits.
+
+Do not introduce a test framework in this plan. It's out of scope.
+
+---
+
+## Task dependency map
+
+Tasks 1–6 are independent pure additions / backward-compatible edits. They can be done in any order, or in parallel by a subagent runner.
+
+Task 7 is the **coordinated rewire**: `AlgoEditor.tsx`, `EditorView.tsx`, and `App.tsx` change together (their prop shapes are mutually dependent) and ship in a single commit.
+
+Task 8 is the final smoke + polish.
+
+```
+1 (hook)        ──┐
+2 (theme)       ──┤
+3 (StatusBar)   ──┼──▶ 7 (rewire) ──▶ 8 (smoke + polish)
+4 (EditorTabs)  ──┤
+5 (Sidebar)     ──┤
+6 (AlgoManager) ──┘
+```
+
+---
+
+### Task 1: Create `useEditorTabs` hook
+
+**Files:**
+- Create: `src/hooks/useEditorTabs.ts`
+
+- [ ] **Step 1: Write the hook**
+
+Create `src/hooks/useEditorTabs.ts` with this exact content:
+
+```ts
+import { useCallback, useMemo, useState } from "react";
+import type { Algo } from "../types";
+
+export type TabBuffer = {
+  code: string;
+  deps: string;
+  savedCode: string;
+  savedDeps: string;
+};
+
+type State = {
+  openTabIds: number[];
+  activeTabId: number | null;
+  buffers: Record<number, TabBuffer>;
+};
+
+const EMPTY: State = {
+  openTabIds: [],
+  activeTabId: null,
+  buffers: {},
+};
+
+export type UseEditorTabs = ReturnType<typeof useEditorTabs>;
+
+export const useEditorTabs = () => {
+  const [state, setState] = useState<State>(EMPTY);
+
+  const isDirty = useCallback(
+    (id: number): boolean => {
+      const b = state.buffers[id];
+      if (!b) return false;
+      return b.code !== b.savedCode || b.deps !== b.savedDeps;
+    },
+    [state.buffers],
+  );
+
+  const hasAnyDirty = useMemo(
+    () => state.openTabIds.some((id) => {
+      const b = state.buffers[id];
+      return !!b && (b.code !== b.savedCode || b.deps !== b.savedDeps);
+    }),
+    [state.openTabIds, state.buffers],
+  );
+
+  const openTab = useCallback((algo: Algo) => {
+    setState((s) => {
+      const alreadyOpen = s.openTabIds.includes(algo.id);
+      if (alreadyOpen) {
+        return { ...s, activeTabId: algo.id };
+      }
+      return {
+        openTabIds: [...s.openTabIds, algo.id],
+        activeTabId: algo.id,
+        buffers: {
+          ...s.buffers,
+          [algo.id]: {
+            code: algo.code,
+            deps: algo.dependencies,
+            savedCode: algo.code,
+            savedDeps: algo.dependencies,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const switchTab = useCallback((id: number) => {
+    setState((s) => (s.openTabIds.includes(id) ? { ...s, activeTabId: id } : s));
+  }, []);
+
+  const pickNextActive = (openTabIds: number[], closingId: number): number | null => {
+    const idx = openTabIds.indexOf(closingId);
+    if (idx === -1) return null;
+    // right neighbor
+    if (idx + 1 < openTabIds.length) return openTabIds[idx + 1];
+    // left neighbor
+    if (idx - 1 >= 0) return openTabIds[idx - 1];
+    return null;
+  };
+
+  const forceCloseTab = useCallback((id: number) => {
+    setState((s) => {
+      if (!s.openTabIds.includes(id)) return s;
+      const nextOpen = s.openTabIds.filter((x) => x !== id);
+      const nextActive =
+        s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
+      const { [id]: _removed, ...nextBuffers } = s.buffers;
+      return {
+        openTabIds: nextOpen,
+        activeTabId: nextActive,
+        buffers: nextBuffers,
+      };
+    });
+  }, []);
+
+  const closeTab = useCallback(
+    (id: number): { dirty: boolean } => {
+      const dirty = isDirty(id);
+      if (!dirty) {
+        forceCloseTab(id);
+      }
+      return { dirty };
+    },
+    [isDirty, forceCloseTab],
+  );
+
+  const updateCode = useCallback((code: string) => {
+    setState((s) => {
+      if (s.activeTabId === null) return s;
+      const b = s.buffers[s.activeTabId];
+      if (!b) return s;
+      return {
+        ...s,
+        buffers: { ...s.buffers, [s.activeTabId]: { ...b, code } },
+      };
+    });
+  }, []);
+
+  const updateDeps = useCallback((deps: string) => {
+    setState((s) => {
+      if (s.activeTabId === null) return s;
+      const b = s.buffers[s.activeTabId];
+      if (!b) return s;
+      return {
+        ...s,
+        buffers: { ...s.buffers, [s.activeTabId]: { ...b, deps } },
+      };
+    });
+  }, []);
+
+  const markActiveSaved = useCallback(() => {
+    setState((s) => {
+      if (s.activeTabId === null) return s;
+      const b = s.buffers[s.activeTabId];
+      if (!b) return s;
+      return {
+        ...s,
+        buffers: {
+          ...s.buffers,
+          [s.activeTabId]: { ...b, savedCode: b.code, savedDeps: b.deps },
+        },
+      };
+    });
+  }, []);
+
+  const onAlgoDeleted = useCallback((id: number) => {
+    setState((s) => {
+      if (!s.openTabIds.includes(id)) return s;
+      const nextOpen = s.openTabIds.filter((x) => x !== id);
+      const nextActive =
+        s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
+      const { [id]: _removed, ...nextBuffers } = s.buffers;
+      return {
+        openTabIds: nextOpen,
+        activeTabId: nextActive,
+        buffers: nextBuffers,
+      };
+    });
+  }, []);
+
+  type ExternalUpdateResult = { synced: boolean; conflicted: boolean };
+
+  const onAlgoExternallyUpdated = useCallback(
+    (id: number, code: string, deps: string): ExternalUpdateResult => {
+      let result: ExternalUpdateResult = { synced: false, conflicted: false };
+      setState((s) => {
+        const b = s.buffers[id];
+        if (!b) {
+          result = { synced: false, conflicted: false };
+          return s;
+        }
+        const dirty = b.code !== b.savedCode || b.deps !== b.savedDeps;
+        if (dirty) {
+          result = { synced: false, conflicted: true };
+          return s;
+        }
+        result = { synced: true, conflicted: false };
+        return {
+          ...s,
+          buffers: {
+            ...s.buffers,
+            [id]: { code, deps, savedCode: code, savedDeps: deps },
+          },
+        };
+      });
+      return result;
+    },
+    [],
+  );
+
+  const activeBuffer = state.activeTabId !== null ? state.buffers[state.activeTabId] : null;
+
+  return {
+    openTabIds: state.openTabIds,
+    activeTabId: state.activeTabId,
+    activeCode: activeBuffer?.code ?? "",
+    activeDeps: activeBuffer?.deps ?? "",
+    isDirty,
+    hasAnyDirty,
+    openTab,
+    switchTab,
+    closeTab,
+    forceCloseTab,
+    updateCode,
+    updateDeps,
+    markActiveSaved,
+    onAlgoDeleted,
+    onAlgoExternallyUpdated,
+  };
+};
+```
+
+Notes:
+- `onAlgoExternallyUpdated` returns a result object so the caller (`App.tsx`) can toast on conflict. The spec requires that toast; putting the decision in the caller keeps the hook UI-free.
+- The `pickNextActive` helper operates on the *pre-close* `openTabIds` array — that's the list where the neighbor indices make sense.
+- `buffers` is a plain object (`Record<number, TabBuffer>`), not a `Map` — objects play nicely with React's reference-equality change detection when we spread.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: no TypeScript errors. `tsc` completes cleanly, Vite build succeeds. The hook is imported by nothing yet, so it lives as dead code for this commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useEditorTabs.ts
+git commit -m "feat(editor): add useEditorTabs hook for multi-tab state"
+```
+
+---
+
+### Task 2: Create Monaco theme module
+
+**Files:**
+- Create: `src/lib/monacoTheme.ts`
+
+- [ ] **Step 1: Write the theme module**
+
+Create `src/lib/monacoTheme.ts` with this exact content:
+
+```ts
+import type { Monaco } from "@monaco-editor/react";
+
+export const WOLF_DEN_THEME = "wolf-den-dark";
+
+export const defineWolfDenTheme = (monaco: Monaco): void => {
+  monaco.editor.defineTheme(WOLF_DEN_THEME, {
+    base: "vs-dark",
+    inherit: true,
+    rules: [
+      { token: "keyword", foreground: "c792ea" },
+      { token: "keyword.flow", foreground: "c792ea" },
+      { token: "operator", foreground: "89ddff" },
+      { token: "delimiter", foreground: "89ddff" },
+      { token: "string", foreground: "c3e88d" },
+      { token: "string.escape", foreground: "c3e88d" },
+      { token: "number", foreground: "f78c6c" },
+      { token: "comment", foreground: "546e7a", fontStyle: "italic" },
+      { token: "type", foreground: "ffcb6b" },
+      { token: "type.identifier", foreground: "ffcb6b" },
+      { token: "identifier", foreground: "e0e0e8" },
+      // Python-specific (Monaco's python tokenizer emits these)
+      { token: "keyword.python", foreground: "c792ea" },
+      { token: "function", foreground: "82aaff" },
+      { token: "function.call", foreground: "82aaff" },
+      { token: "identifier.function", foreground: "82aaff" },
+    ],
+    colors: {
+      "editor.background": "#1a1a28",
+      "editor.foreground": "#e0e0e8",
+      "editorLineNumber.foreground": "#55556a",
+      "editorLineNumber.activeForeground": "#e0e0e8",
+      "editor.selectionBackground": "#4d9fff33",
+      "editor.lineHighlightBackground": "#4d9fff0d",
+      "editor.lineHighlightBorder": "#00000000",
+      "editorCursor.foreground": "#4d9fff",
+      "editorWidget.background": "#20202e",
+      "editorWidget.border": "#2a2a3a",
+      "editorIndentGuide.background": "#2a2a3a",
+      "editorIndentGuide.activeBackground": "#3a3a4e",
+      "editorBracketMatch.background": "#4d9fff26",
+      "editorBracketMatch.border": "#4d9fff",
+    },
+  });
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: no TypeScript errors. The theme module is imported by nothing yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/monacoTheme.ts
+git commit -m "feat(editor): add wolf-den-dark Monaco theme"
+```
+
+---
+
+### Task 3: Create `EditorStatusBar` component
+
+**Files:**
+- Create: `src/components/EditorStatusBar.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/EditorStatusBar.tsx` with this exact content:
+
+```tsx
+type EditorStatusBarProps = {
+  isDirty: boolean;
+  depsCount: number;
+  cursorLine: number;
+  cursorCol: number;
+  onSave: () => void;
+  onToggleDeps: () => void;
+};
+
+export const EditorStatusBar = ({
+  isDirty,
+  depsCount,
+  cursorLine,
+  cursorCol,
+  onSave,
+  onToggleDeps,
+}: EditorStatusBarProps) => {
+  return (
+    <div className="flex items-center justify-between h-[26px] px-4 border-t border-[var(--border)] bg-[var(--bg-panel)] text-[11px] text-[var(--text-secondary)] select-none">
+      {/* Left group */}
+      <div className="flex items-center gap-4">
+        {isDirty ? (
+          <button
+            onClick={onSave}
+            className="flex items-center gap-2 px-1 -mx-1 rounded hover:bg-[var(--bg-secondary)] transition-colors text-[var(--accent-yellow)]"
+            title="Save changes"
+          >
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-yellow)]" />
+            <span>Unsaved · ⌘S</span>
+          </button>
+        ) : (
+          <span className="flex items-center gap-2">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-green)]" />
+            <span>Saved</span>
+          </span>
+        )}
+        <span className="text-[var(--text-muted)]">Python 3.11</span>
+        <button
+          onClick={onToggleDeps}
+          className="px-1 -mx-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-secondary)] transition-colors"
+          title="Toggle dependencies"
+        >
+          deps: {depsCount}
+        </button>
+      </div>
+
+      {/* Right group */}
+      <div className="flex items-center gap-4 text-[var(--text-muted)]">
+        <span>
+          Ln {cursorLine}, Col {cursorCol}
+        </span>
+        <span>Spaces: 4</span>
+        <span>UTF-8</span>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/EditorStatusBar.tsx
+git commit -m "feat(editor): add EditorStatusBar component"
+```
+
+---
+
+### Task 4: Create `EditorTabs` component
+
+**Files:**
+- Create: `src/components/EditorTabs.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/EditorTabs.tsx` with this exact content:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { MoreHorizontal, Plus, Sparkles, X } from "lucide-react";
+
+export type EditorTab = {
+  id: number;
+  name: string;
+  isDirty: boolean;
+  hasAiTerminal: boolean;
+};
+
+type EditorTabsProps = {
+  tabs: EditorTab[];
+  activeTabId: number | null;
+  onSelect: (id: number) => void;
+  onClose: (id: number) => void;
+  onCreateAlgo: () => void;
+  onCreateAlgoWithAi: () => void;
+  onRenameActive: () => void;
+  onDeleteActive: () => void;
+  onCloseOthers: (id: number) => void;
+  onCloseAll: () => void;
+};
+
+export const EditorTabs = ({
+  tabs,
+  activeTabId,
+  onSelect,
+  onClose,
+  onCreateAlgo,
+  onCreateAlgoWithAi,
+  onRenameActive,
+  onDeleteActive,
+  onCloseOthers,
+  onCloseAll,
+}: EditorTabsProps) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  const menuAction = (fn: () => void) => () => {
+    setMenuOpen(false);
+    fn();
+  };
+
+  return (
+    <div className="flex items-stretch h-[38px] bg-[var(--bg-secondary)] border-b border-[var(--border)]">
+      <div className="flex items-stretch overflow-x-auto flex-1 min-w-0">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              onClick={() => onSelect(tab.id)}
+              className={`group/tab relative flex items-center gap-2 px-3 text-xs cursor-pointer flex-shrink-0 border-r border-[var(--border)] transition-colors ${
+                isActive
+                  ? "bg-[var(--bg-panel)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)]/30"
+              }`}
+            >
+              {isActive && (
+                <span className="absolute top-0 left-0 right-0 h-[2px] bg-[var(--accent-blue)]" />
+              )}
+              <span className="inline-flex items-center justify-center w-[14px] h-[14px] rounded-[3px] bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)] text-[9px] font-bold flex-shrink-0">
+                Py
+              </span>
+              <span className="max-w-[180px] truncate">{tab.name}</span>
+              {tab.hasAiTerminal && (
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse flex-shrink-0"
+                  title="AI terminal active"
+                />
+              )}
+              {tab.isDirty && !tab.hasAiTerminal && (
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-yellow)] flex-shrink-0 group-hover/tab:hidden"
+                  title="Unsaved"
+                />
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(tab.id);
+                }}
+                className="inline-flex items-center justify-center w-4 h-4 rounded opacity-0 group-hover/tab:opacity-100 hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] transition-opacity flex-shrink-0"
+                title="Close tab"
+              >
+                <X size={10} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-1 px-2 flex-shrink-0 border-l border-[var(--border)]">
+        <button
+          onClick={onCreateAlgo}
+          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors"
+          title="New algo"
+        >
+          <Plus size={14} />
+        </button>
+        <button
+          onClick={onCreateAlgoWithAi}
+          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--accent-blue)] hover:bg-[var(--bg-panel)] transition-colors"
+          title="New algo with AI"
+        >
+          <Sparkles size={13} />
+        </button>
+        <div ref={menuRef} className="relative">
+          <button
+            onClick={() => setMenuOpen((v) => !v)}
+            disabled={activeTabId === null}
+            className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            title="More actions"
+          >
+            <MoreHorizontal size={14} />
+          </button>
+          {menuOpen && activeTabId !== null && (
+            <div className="absolute right-0 top-full mt-1 z-30 w-44 bg-[var(--bg-elevated)] border border-[var(--border)] rounded-md shadow-xl py-1 text-xs">
+              <MenuItem label="Rename" onClick={menuAction(onRenameActive)} />
+              <MenuItem
+                label="Close others"
+                onClick={menuAction(() => onCloseOthers(activeTabId))}
+                disabled={tabs.length < 2}
+              />
+              <MenuItem
+                label="Close all"
+                onClick={menuAction(onCloseAll)}
+              />
+              <div className="h-px bg-[var(--border)] my-1" />
+              <MenuItem
+                label="Delete algo"
+                onClick={menuAction(onDeleteActive)}
+                danger
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type MenuItemProps = {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+};
+
+const MenuItem = ({ label, onClick, disabled, danger }: MenuItemProps) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`w-full text-left px-3 py-1.5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+      danger
+        ? "text-[var(--accent-red)] hover:bg-[var(--accent-red)]/10"
+        : "text-[var(--text-primary)] hover:bg-[var(--bg-panel)]"
+    }`}
+  >
+    {label}
+  </button>
+);
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/EditorTabs.tsx
+git commit -m "feat(editor): add EditorTabs component"
+```
+
+---
+
+### Task 5: Restyle `Sidebar.tsx` to 52px icon-only rail
+
+**Files:**
+- Modify: `src/components/Sidebar.tsx`
+
+- [ ] **Step 1: Replace the file**
+
+Overwrite `src/components/Sidebar.tsx` with this exact content:
+
+```tsx
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import type { View } from "../types";
+
+type SidebarProps = {
+  activeView: View;
+  onNavigate: (view: View) => void;
+  connectionStatus: "waiting" | "connected" | "error";
+};
+
+const NAV_ITEMS: { view: View; label: string; icon: string }[] = [
+  { view: "home", label: "Home", icon: "⌂" },
+  { view: "editor", label: "Editor", icon: "λ" },
+  { view: "algos", label: "Algos", icon: "▶" },
+  { view: "trading", label: "Trading", icon: "⇅" },
+];
+
+const openGuideWindow = async () => {
+  const existing = await WebviewWindow.getByLabel("guide");
+  if (existing) {
+    await existing.setFocus();
+    return;
+  }
+  new WebviewWindow("guide", {
+    title: "Wolf Den — Guide",
+    url: "guide.html",
+    width: 1200,
+    height: 900,
+    resizable: true,
+    titleBarStyle: "overlay",
+    hiddenTitle: true,
+  });
+};
+
+export const Sidebar = ({ activeView, onNavigate, connectionStatus }: SidebarProps) => {
+  const statusTitle =
+    connectionStatus === "connected"
+      ? "NinjaTrader Connected"
+      : connectionStatus === "error"
+        ? "Connection Error"
+        : "Waiting for NinjaTrader...";
+
+  return (
+    <div className="relative flex flex-col w-[52px] bg-[var(--bg-secondary)] border-r border-[var(--border)] select-none">
+      {/* Logo */}
+      <div className="flex items-center justify-center h-12 border-b border-[var(--border)] p-1.5">
+        <img src="/wolf-den-logo.svg" alt="Wolf Den" className="w-8 h-8 object-contain" />
+      </div>
+
+      {/* Nav Items */}
+      <nav className="flex-1 flex flex-col items-center pt-3 gap-1">
+        {NAV_ITEMS.map(({ view, label, icon }) => (
+          <button
+            key={view}
+            onClick={() => onNavigate(view)}
+            title={label}
+            className={`flex items-center justify-center w-9 h-9 rounded-lg transition-colors ${
+              activeView === view
+                ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
+                : "text-[var(--text-secondary)] hover:bg-[var(--bg-panel)] hover:text-[var(--text-primary)]"
+            }`}
+          >
+            <span className="text-base leading-none">{icon}</span>
+          </button>
+        ))}
+      </nav>
+
+      {/* Guide (bottom) */}
+      <div className="flex flex-col items-center pb-2 gap-1">
+        <button
+          onClick={openGuideWindow}
+          title="Guide"
+          className="flex items-center justify-center w-9 h-9 rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--bg-panel)] hover:text-[var(--text-primary)]"
+        >
+          <span className="text-base leading-none">?</span>
+        </button>
+      </div>
+
+      {/* Connection Status — bottom-right corner */}
+      <div
+        title={statusTitle}
+        className={`absolute bottom-2 right-2 w-2 h-2 rounded-full ${
+          connectionStatus === "connected"
+            ? "bg-[var(--accent-green)]"
+            : connectionStatus === "error"
+              ? "bg-[var(--accent-red)]"
+              : "bg-[var(--accent-yellow)] animate-pulse"
+        }`}
+      />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Smoke**
+
+```bash
+npm run tauri dev
+```
+
+Verify each view still renders:
+- Home view loads; left rail is 52px wide, icons-only, no text labels.
+- Click Editor → opens Editor (still today's layout at this point — Task 7 rewires it).
+- Click Algos → loads. Click Trading → loads.
+- Connection dot is visible in bottom-right of rail; color reflects NinjaTrader state.
+- Hover an icon → tooltip shows the view label.
+
+Close the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Sidebar.tsx
+git commit -m "feat(ui): restyle Sidebar to 52px icon-only rail"
+```
+
+---
+
+### Task 6: Refresh `AlgoManager.tsx` — filter, dirty dot, overflow menu
+
+**Files:**
+- Modify: `src/components/AlgoManager.tsx`
+
+- [ ] **Step 1: Replace the file**
+
+Overwrite `src/components/AlgoManager.tsx` with this exact content:
+
+```tsx
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MoreHorizontal, Pencil, Plus, Search, Sparkles, Terminal, Trash2 } from "lucide-react";
+import type { Algo } from "../types";
+
+type AlgoManagerProps = {
+  algos: Algo[];
+  selectedAlgoId: number | null;
+  dirtyAlgoIds?: Set<number>;
+  onSelectAlgo: (id: number) => void;
+  onCreateAlgo: () => void;
+  onCreateAlgoWithAi?: () => void;
+  onOpenAiTerminal?: (algoId: number) => void;
+  aiTerminalAlgoIds?: Set<number>;
+  onDeleteAlgo: (id: number) => void;
+  onRenameAlgo: (id: number, newName: string) => void;
+};
+
+export const AlgoManager = ({
+  algos,
+  selectedAlgoId,
+  dirtyAlgoIds,
+  onSelectAlgo,
+  onCreateAlgo,
+  onCreateAlgoWithAi,
+  onOpenAiTerminal,
+  aiTerminalAlgoIds,
+  onDeleteAlgo,
+  onRenameAlgo,
+}: AlgoManagerProps) => {
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [filter, setFilter] = useState("");
+  const [menuOpenId, setMenuOpenId] = useState<number | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (editingId !== null && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editingId]);
+
+  useEffect(() => {
+    if (menuOpenId === null) return;
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        setMenuOpenId(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpenId]);
+
+  const startRename = (algo: Algo) => {
+    setMenuOpenId(null);
+    setEditingId(algo.id);
+    setEditingName(algo.name);
+  };
+
+  const commitRename = () => {
+    if (editingId === null) return;
+    const trimmed = editingName.trim();
+    if (trimmed && trimmed !== algos.find((a) => a.id === editingId)?.name) {
+      onRenameAlgo(editingId, trimmed);
+    }
+    setEditingId(null);
+  };
+
+  const cancelRename = () => setEditingId(null);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return algos;
+    return algos.filter((a) => a.name.toLowerCase().includes(q));
+  }, [algos, filter]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3 border-b border-[var(--border)]">
+        <div className="flex items-center justify-between mb-2.5">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Algos · {algos.length}
+          </span>
+          <div className="flex items-center gap-1">
+            {onCreateAlgoWithAi && (
+              <button
+                onClick={onCreateAlgoWithAi}
+                title="New algo with AI"
+                className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
+              >
+                <Sparkles size={13} />
+              </button>
+            )}
+            <button
+              onClick={onCreateAlgo}
+              title="New algo"
+              className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
+            >
+              <Plus size={14} />
+            </button>
+          </div>
+        </div>
+        <div className="relative">
+          <Search
+            size={12}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
+          />
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter algos…"
+            className="w-full bg-[var(--bg-secondary)] border border-transparent rounded-md pl-8 pr-2.5 py-1.5 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--border)]"
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-1.5">
+        {algos.length === 0 ? (
+          <div className="p-4 text-sm text-[var(--text-secondary)]">
+            No algos yet. Click <span className="inline-block align-middle"><Plus size={12} /></span> to create one.
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="p-4 text-sm text-[var(--text-secondary)]">
+            No algos match "{filter}".
+          </div>
+        ) : (
+          filtered.map((algo) => {
+            const isSelected = algo.id === selectedAlgoId;
+            const isEditing = editingId === algo.id;
+            const isDirty = dirtyAlgoIds?.has(algo.id) ?? false;
+            const hasActiveTerminal = aiTerminalAlgoIds?.has(algo.id) ?? false;
+            const menuOpen = menuOpenId === algo.id;
+
+            return (
+              <div
+                key={algo.id}
+                onClick={() => !isEditing && onSelectAlgo(algo.id)}
+                className={`group/algo relative flex items-center justify-between px-2.5 py-2 rounded-md cursor-pointer transition-colors ${
+                  isSelected
+                    ? "bg-[var(--accent-blue)]/10 text-[var(--text-primary)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  {isDirty && !isEditing && (
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-yellow)] flex-shrink-0"
+                      title="Unsaved"
+                    />
+                  )}
+                  {isEditing ? (
+                    <input
+                      ref={inputRef}
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename();
+                        if (e.key === "Escape") cancelRename();
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      className="text-sm bg-[var(--bg-primary)] text-[var(--text-primary)] border border-[var(--accent-blue)] rounded px-2 py-0.5 outline-none w-full min-w-0"
+                    />
+                  ) : (
+                    <span className="text-sm truncate">{algo.name}</span>
+                  )}
+                  {hasActiveTerminal && !isEditing && (
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse flex-shrink-0"
+                      title="AI terminal active"
+                    />
+                  )}
+                </div>
+                {!isEditing && (
+                  <div className="relative flex-shrink-0">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMenuOpenId(menuOpen ? null : algo.id);
+                      }}
+                      className="w-6 h-6 inline-flex items-center justify-center rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors"
+                      title="More actions"
+                    >
+                      <MoreHorizontal size={13} />
+                    </button>
+                    {menuOpen && (
+                      <div
+                        ref={menuRef}
+                        className="absolute right-0 top-full mt-1 z-30 w-44 bg-[var(--bg-elevated)] border border-[var(--border)] rounded-md shadow-xl py-1 text-xs"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <MenuRow
+                          icon={<Pencil size={11} />}
+                          label="Rename"
+                          onClick={() => startRename(algo)}
+                        />
+                        {onOpenAiTerminal && (
+                          <MenuRow
+                            icon={<Terminal size={11} />}
+                            label="AI terminal"
+                            disabled={hasActiveTerminal}
+                            onClick={() => {
+                              setMenuOpenId(null);
+                              onSelectAlgo(algo.id);
+                              onOpenAiTerminal(algo.id);
+                            }}
+                          />
+                        )}
+                        <div className="h-px bg-[var(--border)] my-1" />
+                        <MenuRow
+                          icon={<Trash2 size={11} />}
+                          label="Delete"
+                          danger
+                          onClick={() => {
+                            setMenuOpenId(null);
+                            onSelectAlgo(algo.id);
+                            onDeleteAlgo(algo.id);
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+type MenuRowProps = {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+};
+
+const MenuRow = ({ icon, label, onClick, disabled, danger }: MenuRowProps) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`w-full flex items-center gap-2 px-3 py-1.5 text-left transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+      danger
+        ? "text-[var(--accent-red)] hover:bg-[var(--accent-red)]/10"
+        : "text-[var(--text-primary)] hover:bg-[var(--bg-panel)]"
+    }`}
+  >
+    <span className="text-[var(--text-muted)]">{icon}</span>
+    <span>{label}</span>
+  </button>
+);
+```
+
+Notes:
+- `dirtyAlgoIds?: Set<number>` is optional so this change is backward-compatible while Task 7 is pending. After Task 7 the caller will always pass it.
+- The old hover-only row of buttons is gone. The overflow menu carries rename / AI terminal / delete. The outer `onClick` still selects the algo — that preserves today's row-click semantic.
+- **Spec deviation (intentional):** the spec mentions an "Open" menu item (conditional on not-in-`openTabIds`). In practice the row-click already does the same thing (`handleSelectAlgo` → `tabs.openTab`), so a redundant menu item hurts UX more than it helps. Omitted. If you prefer the spec literal, add an `openTabIds?: Set<number>` prop and an `Open` menu item above `Rename` guarded by `!openTabIds.has(algo.id)`.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Smoke**
+
+```bash
+npm run tauri dev
+```
+
+Verify on the Editor view (still today's layout until Task 7):
+- Algo list renders with the new filter input at the top.
+- Typing in the filter narrows the list.
+- Clicking `⋯` on an algo opens the overflow menu; it closes when you click elsewhere.
+- Rename from the menu still works.
+- Delete from the menu still triggers the existing confirm dialog and deletes the algo.
+- `+` creates a new algo; `Sparkles` creates with AI.
+- AI-terminal pulse dot still appears on algos with an active terminal.
+
+Close the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/AlgoManager.tsx
+git commit -m "feat(editor): refresh AlgoManager with filter and overflow menu"
+```
+
+---
+
+### Task 7: Coordinated rewire — `AlgoEditor` + `EditorView` + `App`
+
+This is the keystone task. Three files change together because their prop shapes are mutually dependent. Implement in the order below, run `npm run build` once at the end, then walk the full smoke matrix, then commit once.
+
+**Files:**
+- Modify: `src/components/AlgoEditor.tsx`
+- Modify: `src/views/EditorView.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Slim `src/components/AlgoEditor.tsx`**
+
+Overwrite `src/components/AlgoEditor.tsx` with this exact content:
+
+```tsx
+import { useCallback } from "react";
+import Editor from "@monaco-editor/react";
+import type { Monaco } from "@monaco-editor/react";
+import { defineWolfDenTheme, WOLF_DEN_THEME } from "../lib/monacoTheme";
+
+type AlgoEditorProps = {
+  code: string;
+  deps: string;
+  showDeps: boolean;
+  onChange: (value: string) => void;
+  onDepsChange: (value: string) => void;
+  onSave: () => void;
+  onCursorChange: (line: number, col: number) => void;
+};
+
+export const DEFAULT_ALGO = `from wolf_types import AlgoResult, market_buy, market_sell
+
+
+def create_algo():
+    """Return a dict of handler functions."""
+
+    def init():
+        return {'prices': ()}
+
+    def on_tick(state, tick, ctx):
+        prices = (*state['prices'], tick.price)[-20:]
+        new_state = {**state, 'prices': prices}
+        return AlgoResult(new_state, ())
+
+    return {'init': init, 'on_tick': on_tick}
+`;
+
+export const AlgoEditor = ({
+  code,
+  deps,
+  showDeps,
+  onChange,
+  onDepsChange,
+  onSave,
+  onCursorChange,
+}: AlgoEditorProps) => {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        onSave();
+      }
+    },
+    [onSave],
+  );
+
+  const beforeMount = useCallback((monaco: Monaco) => {
+    defineWolfDenTheme(monaco);
+  }, []);
+
+  const onMount = useCallback(
+    (editor: Parameters<NonNullable<React.ComponentProps<typeof Editor>["onMount"]>>[0]) => {
+      editor.onDidChangeCursorPosition((e) => {
+        onCursorChange(e.position.lineNumber, e.position.column);
+      });
+      const pos = editor.getPosition();
+      if (pos) onCursorChange(pos.lineNumber, pos.column);
+    },
+    [onCursorChange],
+  );
+
+  return (
+    <div
+      className="flex flex-col h-full"
+      onKeyDown={handleKeyDown as unknown as React.KeyboardEventHandler}
+    >
+      {showDeps && (
+        <div className="px-4 py-3 border-b border-[var(--border)] bg-[var(--bg-secondary)]">
+          <label className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold block mb-1.5">
+            Pip Dependencies
+          </label>
+          <input
+            type="text"
+            value={deps}
+            onChange={(e) => onDepsChange(e.target.value)}
+            placeholder="e.g. tensorflow pandas scikit-learn"
+            className="w-full px-3 py-2 text-xs bg-[var(--bg-primary)] border border-[var(--border)] rounded-md text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]/50 focus:outline-none focus:border-[var(--accent-blue)]/50"
+          />
+          <p className="text-[10px] text-[var(--text-secondary)] mt-1.5">
+            Space-separated pip packages. Installed automatically when the algo starts.
+          </p>
+        </div>
+      )}
+      <div className="flex-1 p-0.5">
+        <Editor
+          height="100%"
+          defaultLanguage="python"
+          theme={WOLF_DEN_THEME}
+          beforeMount={beforeMount}
+          onMount={onMount}
+          value={code}
+          onChange={(value) => onChange(value ?? "")}
+          options={{
+            fontSize: 13,
+            fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            tabSize: 4,
+            insertSpaces: true,
+            wordWrap: "off",
+            lineNumbers: "on",
+            renderLineHighlight: "line",
+            cursorBlinking: "smooth",
+            smoothScrolling: true,
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+```
+
+Key changes:
+- No header. The deps toggle button / save button / label are gone.
+- `showDeps` is a prop (controlled by parent via the status bar).
+- `beforeMount` registers the wolf-den-dark theme; `theme` prop applies it.
+- `onMount` wires cursor position reporting.
+- `DEFAULT_ALGO` export stays — `App.tsx` imports it.
+
+- [ ] **Step 2: Rewrite `src/views/EditorView.tsx`**
+
+Overwrite `src/views/EditorView.tsx` with this exact content:
+
+```tsx
+import { useState } from "react";
+import { AlgoEditor } from "../components/AlgoEditor";
+import { AlgoManager } from "../components/AlgoManager";
+import { EditorTabs, type EditorTab } from "../components/EditorTabs";
+import { EditorStatusBar } from "../components/EditorStatusBar";
+import type { UseEditorTabs } from "../hooks/useEditorTabs";
+import type { Algo } from "../types";
+
+type EditorViewProps = {
+  algos: Algo[];
+  tabs: UseEditorTabs;
+  aiTerminalAlgoIds: Set<number>;
+  onSelectAlgo: (id: number) => void;
+  onCreateAlgo: () => void;
+  onCreateAlgoWithAi: () => void;
+  onOpenAiTerminal: (algoId: number) => void;
+  onRequestCloseTab: (id: number) => void;
+  onDeleteAlgo: (id: number) => void;
+  onRenameAlgo: (id: number, newName: string) => void;
+  onSaveAlgo: () => void;
+  onRenameActiveAlgo: () => void;
+};
+
+export const EditorView = ({
+  algos,
+  tabs,
+  aiTerminalAlgoIds,
+  onSelectAlgo,
+  onCreateAlgo,
+  onCreateAlgoWithAi,
+  onOpenAiTerminal,
+  onRequestCloseTab,
+  onDeleteAlgo,
+  onRenameAlgo,
+  onSaveAlgo,
+  onRenameActiveAlgo,
+}: EditorViewProps) => {
+  const [showDeps, setShowDeps] = useState(false);
+  const [cursor, setCursor] = useState({ line: 1, col: 1 });
+
+  const activeTabId = tabs.activeTabId;
+  const dirtyAlgoIds = new Set(tabs.openTabIds.filter((id) => tabs.isDirty(id)));
+
+  const tabItems: EditorTab[] = tabs.openTabIds.map((id) => {
+    const algo = algos.find((a) => a.id === id);
+    return {
+      id,
+      name: algo?.name ?? `algo_${id}`,
+      isDirty: tabs.isDirty(id),
+      hasAiTerminal: aiTerminalAlgoIds.has(id),
+    };
+  });
+
+  const depsCount = tabs.activeDeps.split(/\s+/).filter(Boolean).length;
+  const isActiveDirty = activeTabId !== null ? tabs.isDirty(activeTabId) : false;
+
+  const handleCloseOthers = (keepId: number) => {
+    for (const id of [...tabs.openTabIds]) {
+      if (id !== keepId) onRequestCloseTab(id);
+    }
+  };
+
+  const handleCloseAll = () => {
+    for (const id of [...tabs.openTabIds]) {
+      onRequestCloseTab(id);
+    }
+  };
+
+  const handleDeleteActive = () => {
+    if (activeTabId !== null) onDeleteAlgo(activeTabId);
+  };
+
+  return (
+    <div className="flex-1 flex gap-3 p-4 overflow-hidden">
+      {/* Left: Algo List */}
+      <div className="w-72 flex-shrink-0 bg-[var(--bg-panel)] rounded-lg overflow-hidden">
+        <AlgoManager
+          algos={algos}
+          selectedAlgoId={activeTabId}
+          dirtyAlgoIds={dirtyAlgoIds}
+          onSelectAlgo={onSelectAlgo}
+          onCreateAlgo={onCreateAlgo}
+          onCreateAlgoWithAi={onCreateAlgoWithAi}
+          onOpenAiTerminal={onOpenAiTerminal}
+          aiTerminalAlgoIds={aiTerminalAlgoIds}
+          onDeleteAlgo={onDeleteAlgo}
+          onRenameAlgo={onRenameAlgo}
+        />
+      </div>
+
+      {/* Right: Editor column */}
+      <div className="flex-1 bg-[var(--bg-panel)] rounded-lg overflow-hidden flex flex-col">
+        <EditorTabs
+          tabs={tabItems}
+          activeTabId={activeTabId}
+          onSelect={(id) => tabs.switchTab(id)}
+          onClose={onRequestCloseTab}
+          onCreateAlgo={onCreateAlgo}
+          onCreateAlgoWithAi={onCreateAlgoWithAi}
+          onRenameActive={onRenameActiveAlgo}
+          onDeleteActive={handleDeleteActive}
+          onCloseOthers={handleCloseOthers}
+          onCloseAll={handleCloseAll}
+        />
+
+        {activeTabId !== null ? (
+          <>
+            <div className="flex-1 min-h-0">
+              <AlgoEditor
+                code={tabs.activeCode}
+                deps={tabs.activeDeps}
+                showDeps={showDeps}
+                onChange={tabs.updateCode}
+                onDepsChange={tabs.updateDeps}
+                onSave={onSaveAlgo}
+                onCursorChange={(line, col) => setCursor({ line, col })}
+              />
+            </div>
+            <EditorStatusBar
+              isDirty={isActiveDirty}
+              depsCount={depsCount}
+              cursorLine={cursor.line}
+              cursorCol={cursor.col}
+              onSave={onSaveAlgo}
+              onToggleDeps={() => setShowDeps((v) => !v)}
+            />
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)]">
+            {algos.length === 0
+              ? "Create an algo to get started"
+              : "Select an algo to edit"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Rewrite `src/App.tsx`**
+
+Overwrite `src/App.tsx` with this exact content:
+
+```tsx
+import { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { DEFAULT_ALGO } from "./components/AlgoEditor";
+import { Sidebar } from "./components/Sidebar";
+import { HomeView } from "./views/HomeView";
+import { EditorView } from "./views/EditorView";
+import { AlgosView } from "./views/AlgosView";
+import { TradingView } from "./views/TradingView";
+import { TitleBar } from "./components/TitleBar";
+import { ConfirmDialog } from "./components/ConfirmDialog";
+import { AiTerminalPanel } from "./components/AiTerminalPanel";
+import { ToastContainer, toast } from "./components/Toast";
+import { useTradingSimulation } from "./hooks/useTradingSimulation";
+import { useAlgoErrors } from "./hooks/useAlgoErrors";
+import { useAlgoLogs } from "./hooks/useAlgoLogs";
+import { useAlgoHealth } from "./hooks/useAlgoHealth";
+import { useEditorTabs } from "./hooks/useEditorTabs";
+import type { DataSource } from "./hooks/useTradingSimulation";
+import { VenvSetupModal } from "./components/VenvSetupModal";
+import type { Algo, AlgoRun, View, NavOptions, NavContext } from "./types";
+
+export const App = () => {
+  const [activeView, setActiveView] = useState<View>("home");
+  const [pendingNavContext, setPendingNavContext] = useState<NavContext | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<"waiting" | "connected" | "error">("waiting");
+  const [accounts, setAccounts] = useState<Record<string, { buying_power: number; cash: number; realized_pnl: number }>>({});
+  const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const [algos, setAlgos] = useState<Algo[]>([]);
+  const [activeRuns, setActiveRuns] = useState<AlgoRun[]>([]);
+
+  const tabs = useEditorTabs();
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  const algosRef = useRef(algos);
+  useEffect(() => {
+    algosRef.current = algos;
+  }, [algos]);
+
+  const activeRunsRef = useRef(activeRuns);
+  useEffect(() => {
+    activeRunsRef.current = activeRuns;
+  }, [activeRuns]);
+
+  const [aiTerminalAlgoIds, setAiTerminalAlgoIds] = useState<Set<number>>(new Set());
+  const [venvReady, setVenvReady] = useState<boolean | null>(null);
+
+  const simulation = useTradingSimulation(algos, activeRuns, dataSources);
+
+  const handleAutoStop = useCallback(async (instanceId: string) => {
+    toast.error(`Algo instance ${instanceId.slice(0, 8)}... halted due to repeated errors`);
+    try {
+      await invoke("stop_algo_instance", { instanceId });
+    } catch (e) {
+      console.error("Failed to auto-stop algo:", e);
+    }
+    setActiveRuns((prev) => prev.filter((r) => r.instance_id !== instanceId));
+  }, []);
+
+  const { errorsByInstance, clearErrors } = useAlgoErrors(handleAutoStop);
+  const { logsByInstance, clearLogs } = useAlgoLogs();
+  const { healthByInstance } = useAlgoHealth();
+
+  const aiTerminalAlgos = algos.filter((a) => aiTerminalAlgoIds.has(a.id));
+
+  const loadAlgos = useCallback(async () => {
+    try {
+      const result = await invoke<Algo[]>("get_algos");
+      setAlgos(result);
+    } catch (e) {
+      console.error("Failed to load algos:", e);
+    }
+  }, []);
+
+  const loadRunningInstances = useCallback(async () => {
+    try {
+      type Instance = { id: string; algo_id: number; data_source_id: string; account: string; mode: string; status: string };
+      const instances = await invoke<Instance[]>("get_algo_instances", { dataSourceId: null });
+      const running = instances
+        .filter((i) => i.status === "running")
+        .map((i) => ({
+          algo_id: i.algo_id,
+          status: i.status,
+          mode: i.mode,
+          account: i.account,
+          data_source_id: i.data_source_id,
+          instance_id: i.id,
+        }));
+      setActiveRuns(running);
+    } catch (e) {
+      console.error("Failed to load running instances:", e);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAlgos();
+    loadRunningInstances();
+  }, [loadAlgos, loadRunningInstances]);
+
+  useEffect(() => {
+    const checkVenv = async () => {
+      try {
+        const status = await invoke<{ healthy: boolean }>("check_venv_status");
+        if (status.healthy) {
+          setVenvReady(true);
+        } else {
+          setVenvReady(false);
+        }
+      } catch {
+        setVenvReady(false);
+      }
+    };
+    checkVenv();
+  }, []);
+
+  useEffect(() => {
+    const u1 = listen<number>("nt-connection-count", (event) => {
+      setConnectionStatus(event.payload > 0 ? "connected" : "waiting");
+    });
+    const u2 = listen<{ name: string; buying_power: number; cash: number; realized_pnl: number }>("nt-account", (event) => {
+      const { name, ...data } = event.payload;
+      setAccounts((prev) => ({ ...prev, [name]: data }));
+    });
+    const u3 = listen<string>("nt-account-removed", (event) => {
+      setAccounts((prev) => {
+        const next = { ...prev };
+        delete next[event.payload];
+        return next;
+      });
+    });
+    const u4 = listen<DataSource>("nt-chart", (event) => {
+      setDataSources((prev) => {
+        const exists = prev.some((ds) => ds.id === event.payload.id);
+        if (exists) return prev.map((ds) => ds.id === event.payload.id ? event.payload : ds);
+        return [...prev, event.payload];
+      });
+    });
+    const u5 = listen<string>("nt-chart-removed", (event) => {
+      const removedId = event.payload;
+      setDataSources((prev) => prev.filter((ds) => ds.id !== removedId));
+      const toStop = activeRunsRef.current.filter((r) => r.data_source_id === removedId);
+      for (const run of toStop) {
+        invoke("stop_algo_instance", { instanceId: run.instance_id }).catch((e) =>
+          console.error("Failed to stop algo on chart disconnect:", e)
+        );
+      }
+      setActiveRuns((prev) => prev.filter((r) => r.data_source_id !== removedId));
+    });
+    const u6 = listen<{ algo_id: number; code: string }>("algo-code-updated", (event) => {
+      const { algo_id, code } = event.payload;
+      const algo = algosRef.current.find((a) => a.id === algo_id);
+      const deps = algo?.dependencies ?? "";
+      setAlgos((prev) =>
+        prev.map((a) => (a.id === algo_id ? { ...a, code, updated_at: new Date().toISOString() } : a))
+      );
+      const result = tabsRef.current.onAlgoExternallyUpdated(algo_id, code, deps);
+      if (result.conflicted) {
+        const name = algosRef.current.find((a) => a.id === algo_id)?.name ?? `algo ${algo_id}`;
+        toast.error(`External update to ${name}. Your unsaved edits will overwrite it on save.`);
+      }
+    });
+    return () => {
+      u1.then((f) => f());
+      u2.then((f) => f());
+      u3.then((f) => f());
+      u4.then((f) => f());
+      u5.then((f) => f());
+      u6.then((f) => f());
+    };
+  }, []);
+
+  const [confirmDialog, setConfirmDialog] = useState<{ message: string; confirmLabel?: string; onConfirm: () => void } | null>(null);
+
+  const handleNavigate = (view: View, options?: NavOptions) => {
+    if (view === activeView && !options) return;
+    setPendingNavContext(options ? { ...options, targetView: view } : null);
+    setActiveView(view);
+  };
+
+  const clearPendingNavContext = useCallback(() => {
+    setPendingNavContext(null);
+  }, []);
+
+  const handleSelectAlgo = (id: number) => {
+    const algo = algos.find((a) => a.id === id);
+    if (!algo) return;
+    tabs.openTab(algo);
+  };
+
+  const handleRequestCloseTab = (id: number) => {
+    const { dirty } = tabs.closeTab(id);
+    if (!dirty) return;
+    const name = algos.find((a) => a.id === id)?.name ?? `algo ${id}`;
+    setConfirmDialog({
+      message: `Close ${name}? Unsaved changes will be lost.`,
+      confirmLabel: "Close",
+      onConfirm: () => {
+        tabs.forceCloseTab(id);
+        setConfirmDialog(null);
+      },
+    });
+  };
+
+  const handleCreateAlgo = async () => {
+    try {
+      const name = `algo_${Date.now()}`;
+      const algo = await invoke<Algo>("create_algo", {
+        name,
+        code: DEFAULT_ALGO,
+        dependencies: "",
+      });
+      setAlgos((prev) => [algo, ...prev]);
+      tabs.openTab(algo);
+    } catch (e) {
+      console.error("Failed to create algo:", e);
+      toast.error("Failed to create algo: " + e);
+    }
+  };
+
+  const handleSaveAlgo = async () => {
+    const activeId = tabs.activeTabId;
+    if (activeId === null) return;
+    const algo = algos.find((a) => a.id === activeId);
+    if (!algo) return;
+    try {
+      await invoke("update_algo", {
+        id: algo.id,
+        name: algo.name,
+        code: tabs.activeCode,
+        dependencies: tabs.activeDeps,
+      });
+      tabs.markActiveSaved();
+      await loadAlgos();
+    } catch (e) {
+      console.error("Failed to save algo:", e);
+      toast.error("Failed to save: " + e);
+    }
+  };
+
+  const handleRenameAlgo = async (id: number, newName: string) => {
+    const algo = algos.find((a) => a.id === id);
+    if (!algo) return;
+    try {
+      await invoke("update_algo", {
+        id,
+        name: newName,
+        code: algo.code,
+        dependencies: algo.dependencies,
+      });
+      await loadAlgos();
+    } catch (e) {
+      console.error("Failed to rename algo:", e);
+    }
+  };
+
+  const handleRenameActiveAlgo = () => {
+    // Rename is inline in AlgoManager; from the tab-strip menu we jump the user to
+    // the sidebar item and let them trigger inline rename there. Simplest in v1:
+    // toast the user with a hint. (A focused rename modal is a follow-up.)
+    const activeId = tabs.activeTabId;
+    if (activeId === null) return;
+    const algo = algos.find((a) => a.id === activeId);
+    if (!algo) return;
+    const newName = window.prompt("Rename algo", algo.name);
+    if (newName && newName.trim() && newName.trim() !== algo.name) {
+      handleRenameAlgo(activeId, newName.trim());
+    }
+  };
+
+  const handleDeleteAlgo = (id: number) => {
+    setConfirmDialog({
+      message: "Are you sure you want to delete this algo?",
+      confirmLabel: "Delete",
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        try {
+          await invoke("delete_algo", { id });
+          tabs.onAlgoDeleted(id);
+          await loadAlgos();
+        } catch (e) {
+          console.error("Failed to delete algo:", e);
+        }
+      },
+    });
+  };
+
+  const handleCreateAlgoWithAi = useCallback(async () => {
+    try {
+      const name = `algo_${Date.now()}`;
+      const algo = await invoke<Algo>("create_algo", {
+        name,
+        code: DEFAULT_ALGO,
+        dependencies: "",
+      });
+      setAlgos((prev) => [algo, ...prev]);
+      tabs.openTab(algo);
+      setAiTerminalAlgoIds((prev) => new Set(prev).add(algo.id));
+    } catch (e) {
+      console.error("Failed to create algo:", e);
+      toast.error("Failed to create algo: " + e);
+    }
+  }, [tabs]);
+
+  const handleOpenAiTerminal = useCallback((algoId: number) => {
+    if (aiTerminalAlgoIds.has(algoId)) return;
+    setAiTerminalAlgoIds((prev) => new Set(prev).add(algoId));
+  }, [aiTerminalAlgoIds]);
+
+  const handleCloseAiTerminal = useCallback((algoId: number) => {
+    setAiTerminalAlgoIds((prev) => {
+      const next = new Set(prev);
+      next.delete(algoId);
+      return next;
+    });
+  }, []);
+
+  const handleStartAlgo = async (id: number, mode: "live" | "shadow", account: string, dataSourceId: string) => {
+    let instanceId: string | null = null;
+    try {
+      const instance = await invoke<{ id: string }>("create_algo_instance", {
+        algoId: id,
+        dataSourceId: dataSourceId,
+        account,
+        mode,
+      });
+      instanceId = instance.id;
+      setActiveRuns((prev) => [...prev, {
+        algo_id: id, status: "installing", mode, account,
+        data_source_id: dataSourceId, instance_id: instanceId!,
+      }]);
+      await invoke("start_algo_instance", { instanceId });
+      setActiveRuns((prev) => prev.map((r) =>
+        r.instance_id === instanceId ? { ...r, status: "running" } : r
+      ));
+    } catch (e) {
+      console.error("Failed to start algo:", e);
+      if (instanceId) {
+        setActiveRuns((prev) => prev.filter((r) => r.instance_id !== instanceId));
+      }
+      toast.error("Failed to start algo: " + e);
+    }
+  };
+
+  const handleStopAlgo = async (instanceId: string) => {
+    try {
+      await invoke("stop_algo_instance", { instanceId });
+    } catch (e) {
+      console.error("Failed to stop algo:", e);
+    }
+    setActiveRuns((prev) => prev.filter((r) => r.instance_id !== instanceId));
+    clearErrors(instanceId);
+    clearLogs(instanceId);
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-[var(--bg-primary)]">
+      <TitleBar title="Wolf Den" />
+      <div className="flex flex-1 min-h-0">
+        <Sidebar
+          activeView={activeView}
+          onNavigate={handleNavigate}
+          connectionStatus={connectionStatus}
+        />
+
+        {activeView === "home" && (
+          <HomeView
+            connectionStatus={connectionStatus}
+            accounts={accounts}
+            algos={algos}
+            activeRuns={activeRuns}
+            stats={simulation.stats}
+            positions={simulation.positions}
+            pnlHistory={simulation.pnlHistory}
+            runPnlHistories={simulation.runPnlHistories}
+            algoStats={simulation.algoStats}
+            onNavigate={handleNavigate}
+            onStopAlgo={handleStopAlgo}
+          />
+        )}
+
+        {activeView === "editor" && (
+          <EditorView
+            algos={algos}
+            tabs={tabs}
+            aiTerminalAlgoIds={aiTerminalAlgoIds}
+            onSelectAlgo={handleSelectAlgo}
+            onCreateAlgo={handleCreateAlgo}
+            onCreateAlgoWithAi={handleCreateAlgoWithAi}
+            onOpenAiTerminal={handleOpenAiTerminal}
+            onRequestCloseTab={handleRequestCloseTab}
+            onDeleteAlgo={handleDeleteAlgo}
+            onRenameAlgo={handleRenameAlgo}
+            onSaveAlgo={handleSaveAlgo}
+            onRenameActiveAlgo={handleRenameActiveAlgo}
+          />
+        )}
+
+        {activeView === "algos" && (
+          <AlgosView
+            algos={algos}
+            dataSources={dataSources}
+            activeRuns={activeRuns}
+            algoStats={simulation.algoStats}
+            errorsByInstance={errorsByInstance}
+            logsByInstance={logsByInstance}
+            healthByInstance={healthByInstance}
+            onStartAlgo={handleStartAlgo}
+            onStopAlgo={handleStopAlgo}
+            onClearLogs={clearLogs}
+            onOpenAiTerminal={handleOpenAiTerminal}
+            aiTerminalAlgoIds={aiTerminalAlgoIds}
+            initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
+            onInstanceFocused={clearPendingNavContext}
+          />
+        )}
+
+        {activeView === "trading" && (
+          <TradingView
+            simulation={simulation}
+            algos={algos}
+            activeRuns={activeRuns}
+            initialContext={pendingNavContext}
+            onContextConsumed={clearPendingNavContext}
+          />
+        )}
+
+        {aiTerminalAlgos.length > 0 && (
+          <AiTerminalPanel
+            tabs={aiTerminalAlgos.map((a) => ({ algoId: a.id, algoName: a.name }))}
+            selectedAlgoId={tabs.activeTabId}
+            onSelectAlgo={(id) => {
+              const algo = algos.find((a) => a.id === id);
+              if (algo) tabs.openTab(algo);
+            }}
+            onClose={handleCloseAiTerminal}
+            onSpawnError={(algoId, error) => {
+              handleCloseAiTerminal(algoId);
+              if (error.includes("not found")) {
+                toast.error("Claude Code CLI not found. Install it with: npm install -g @anthropic-ai/claude-code");
+              } else {
+                toast.error("Failed to start AI terminal: " + error);
+              }
+            }}
+          />
+        )}
+      </div>
+
+      {venvReady === false && (
+        <VenvSetupModal onComplete={() => setVenvReady(true)} />
+      )}
+
+      {confirmDialog !== null && (
+        <ConfirmDialog
+          message={confirmDialog.message}
+          confirmLabel={confirmDialog.confirmLabel}
+          onConfirm={confirmDialog.onConfirm}
+          onCancel={() => setConfirmDialog(null)}
+        />
+      )}
+
+      <ToastContainer />
+    </div>
+  );
+};
+```
+
+Notable deltas vs. today's `App.tsx`:
+- Removed: `selectedAlgoId`, `selectedAlgoIdRef`, `editorCode`, `editorDeps`, `hasUnsavedChanges`, the `selectedAlgo`-→-editor-state `useEffect`, the unsaved-guard branches in `handleNavigate` and `handleSelectAlgo`.
+- Added: `const tabs = useEditorTabs()`, `tabsRef`, `algosRef` (used by the `algo-code-updated` listener to read latest state without re-subscribing).
+- `algo-code-updated` listener now routes to `tabs.onAlgoExternallyUpdated` and toasts on conflict instead of stomping the editor buffer.
+- `handleRequestCloseTab` is the new route for tab-close clicks — it uses the existing `ConfirmDialog` pattern.
+- `handleRenameActiveAlgo` uses `window.prompt` as a minimal inline path. Hand-rolled rename modal is a follow-up.
+- `AiTerminalPanel.selectedAlgoId` now reflects `tabs.activeTabId`; clicking an AI-terminal tab calls `tabs.openTab(algo)`.
+
+- [ ] **Step 4: Type-check**
+
+```bash
+npm run build
+```
+
+Expected: zero TypeScript errors. If any errors surface, they are almost certainly prop-shape mismatches between the three files edited in this task — re-read the three overwrites in this task and confirm the types line up.
+
+- [ ] **Step 5: Smoke — full matrix**
+
+```bash
+npm run tauri dev
+```
+
+Walk the full matrix from the spec:
+
+1. **Home view** renders. Left rail is 52px icon-only. Connection dot visible bottom-right.
+2. **Navigate to Editor** — empty state ("Create an algo to get started" or "Select an algo to edit") because no tab is open.
+3. Open **3 algos** in sequence from the sidebar — each opens a new tab and becomes active.
+4. **Switch between tabs** — editor shows each algo's buffer; active tab highlighted; no confirm dialog.
+5. **Edit tab A**, switch to B, switch back to A — A's edits are preserved, A still shows the yellow dirty dot in tab strip, in the sidebar list, and in the status bar.
+6. **Press ⌘S** on the dirty tab — status bar transitions to "Saved" (green dot); dirty dots clear in tab strip + sidebar + status bar.
+7. **Click the status bar "Unsaved · ⌘S" chip** on a dirty tab — saves identically to ⌘S.
+8. **Click the deps chip** in the status bar — deps strip reveals above the editor; click again — collapses.
+9. **Close a clean tab** via the tab's `×` — tab closes silently; right neighbor activates.
+10. **Close a dirty tab** via the tab's `×` — confirm dialog fires ("Close ALGO? Unsaved changes will be lost."). Cancel → tab stays dirty. Confirm → tab closes.
+11. **Close the active tab** — right neighbor activates; if no right neighbor, left neighbor; if neither, empty state.
+12. **Delete an algo** with its tab open (sidebar `⋯` → Delete) — one delete confirm only; on confirm the algo is deleted and the tab closes.
+13. **Rename an algo** inline from the sidebar `⋯` → Rename — tab label updates live.
+14. **Rename from the tab-strip `⋯`** — `window.prompt` opens; confirm → updates name.
+15. **Navigate Editor → Home → Editor** — tab list and dirty state survive; no prompt fires.
+16. **Create-with-AI** from the sidebar sparkles button — new algo opens as a tab AND an AI terminal spawns in the right panel.
+17. **Click an AI-terminal tab** in the right panel — that algo's editor tab becomes active (opens one if not open).
+18. **Monaco theme** — editor background matches `--bg-panel`, selection is translucent blue, keywords purple, strings green, comments italic grey. No `vs-dark` charcoal showing through.
+19. **Regression**: Algos view loads; Trading view loads; Guide button still opens the guide window.
+
+If any step fails, fix inline in one of the three edited files (do **not** re-touch the hook or the Task 1–6 files). Re-run `npm run build` and re-walk the affected area of the matrix.
+
+- [ ] **Step 6: Commit**
+
+Stage all three files and commit as one:
+
+```bash
+git add src/components/AlgoEditor.tsx src/views/EditorView.tsx src/App.tsx
+git commit -m "feat(editor): multi-tab workspace with useEditorTabs hook
+
+Rewire AlgoEditor to receive controlled code/deps props, EditorView to
+orchestrate tabs + editor + status bar, and App to adopt useEditorTabs
+in place of singleton editor state. Removes the view-nav unsaved-changes
+dialog (buffers now persist in the hook), fixes the algo-code-updated
+handler to avoid stomping unsaved edits, and wires the wolf-den-dark
+Monaco theme."
+```
+
+---
+
+### Task 8: Final smoke walk-through and polish
+
+- [ ] **Step 1: Fresh smoke**
+
+Close any dev server. Pull a fresh build from a clean state:
+
+```bash
+npm run build && npm run tauri dev
+```
+
+Re-walk items 1–19 from Task 7 Step 5 end-to-end, this time without making changes. This catches anything broken only in the production-build path (Tailwind purging, etc.).
+
+- [ ] **Step 2: Visual check against the prototype**
+
+Open the Variant B prototype side-by-side with the running app and spot-compare:
+
+```bash
+open /Users/hypawolf/code/wolf-den/prototypes/editor-view/variant-b-workspace.html
+```
+
+Look at: tab strip height/colors, active-tab top border, lang tag rendering, dirty/AI indicator placement, status bar density, Monaco syntax colors. Minor pixel nudges are fine; structural differences should have been caught earlier.
+
+- [ ] **Step 3: Commit any polish fixes**
+
+If you made adjustments:
+
+```bash
+git add -p
+git commit -m "fix(editor): polish after full smoke walk-through"
+```
+
+If no changes — skip the commit.
+
+- [ ] **Step 4: Announce completion**
+
+The project is done. The branch is ready for PR review.
+
+---
+
+## Spec-to-task coverage check
+
+| Spec section | Task(s) |
+|---|---|
+| `useEditorTabs` hook (state + API) | 1 |
+| `src/lib/monacoTheme.ts` | 2 |
+| `EditorStatusBar.tsx` | 3 |
+| `EditorTabs.tsx` | 4 |
+| `Sidebar.tsx` restyle | 5 |
+| `AlgoManager.tsx` refresh (filter, dirty dot, overflow) | 6 |
+| `AlgoEditor.tsx` slim-down | 7 |
+| `EditorView.tsx` orchestrator | 7 |
+| `App.tsx` state migration | 7 |
+| Behavior change: no nav unsaved-guard | 7 (`handleNavigate` simplified) |
+| Behavior change: no tab-switch prompt | 1 (`switchTab` never prompts) |
+| External-update rule (clean-sync / dirty-keep + toast) | 1 (hook) + 7 (caller toast) |
+| Close-active-tab neighbor rule | 1 (`pickNextActive`) |
+| Save-failure toast + no-mark-saved-on-throw | 7 (`handleSaveAlgo` catch block) |
+| Open-tab for stale id no-op | 1 (`openTab` initializes from algo arg, no DB fetch — stale caller protected) + 7 (`handleSelectAlgo` looks up in `algos` before calling) |
+| `onAlgoDeleted` / `forceCloseTab` / non-open no-op | 1 |
+| External update for non-open algo | 1 (buffer lookup short-circuits) |
+| Verification plan (build + smoke) | 7 Step 5 + 8 |
+| Monaco theme palette | 2 |
+| Mouse-clickable save affordance in status bar | 3 |
+| Confirm dispatch via `App`'s existing `ConfirmDialog` | 7 (`handleRequestCloseTab`) |

--- a/docs/superpowers/specs/2026-04-19-editor-view-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-editor-view-redesign-design.md
@@ -1,0 +1,342 @@
+# Editor View Redesign — Design
+
+**Date:** 2026-04-19
+**Direction:** Variant B — "Workspace" (VS Code / Cursor inspired)
+**Prototypes:** `prototypes/editor-view/` (Variants A, B, C)
+
+## Summary
+
+Modernize the algo editor from a single-algo-at-a-time pane into a multi-tab workspace. Users can have several algos open simultaneously, each with its own unsaved buffer. Tab buffers persist across view navigation. The existing left rail (`Sidebar.tsx`) is visually tightened to match the new chrome. A Monaco theme aligned with the app's design tokens replaces the generic `vs-dark`. An integrated status bar replaces the ad-hoc header.
+
+## Goals
+
+- Multi-tab editing — several algos open at once, independent dirty buffers, zero-friction tab switching.
+- Cleaner chrome — filename-led tab strip and an always-visible status bar carry the state that a decorative header used to carry.
+- Design-token-aware editor — Monaco's colors match the app's panel / accent palette instead of clashing with it.
+- Surgical refactor — no backend / Tauri-command / schema changes; PRable as one unit.
+
+## Non-Goals
+
+- Command palette (⌘K) — deferred to a later project that spans the whole app.
+- Autosave — explicit save remains the semantic; algos can be running live and side-effectful writes belong to user intent, not debounce.
+- Tab persistence across app restart — in-memory only. (Can be layered on later.)
+- Integrated terminal in the bottom panel — AI terminal keeps its current right-side panel behavior.
+- Backtest / split-editor buttons — the prototype showed them; the features don't exist, dropped for YAGNI.
+
+## Scope
+
+### In scope
+- New `useEditorTabs` hook (centralized tab state).
+- New components: `EditorTabs.tsx`, `EditorStatusBar.tsx`.
+- Edits: `AlgoEditor.tsx` (slimmed to Monaco + deps strip), `AlgoManager.tsx` (search + dirty dot + always-on overflow), `Sidebar.tsx` (restyle to 52px icon-only), `EditorView.tsx` (layout-only orchestrator), `App.tsx` (adopt hook, drop singleton editor buffers).
+- New: `src/lib/monacoTheme.ts` — custom Monaco theme.
+- Removal of the confirm-on-view-navigation dialog (tab buffers persist, so it becomes redundant).
+
+### Out of scope
+- Other views (Home, Algos, Trading) — untouched except for the restyled shared left rail.
+- `AiTerminalPanel` — no change; keeps its independent right-side tab list.
+- Backend commands and the Tauri event surface.
+
+## Architecture
+
+### File layout
+
+```
+src/
+  hooks/
+    useEditorTabs.ts          [new]
+  lib/
+    monacoTheme.ts            [new]
+  components/
+    Sidebar.tsx               [edit]  — restyle 80→52px, icon-only
+    AlgoManager.tsx           [edit]  — filter input, dirty dot, overflow menu
+    AlgoEditor.tsx            [edit]  — drop header; Monaco + deps strip only
+    EditorTabs.tsx            [new]   — tab strip
+    EditorStatusBar.tsx       [new]   — dirty state, deps count, cursor position
+  views/
+    EditorView.tsx            [edit]  — layout-only orchestrator
+  App.tsx                     [edit]  — adopt useEditorTabs; remove nav unsaved-guard
+```
+
+### Component tree (Editor view)
+
+```
+<EditorView>
+  <AlgoManager>                    ← left pane, algo list + filter + overflow
+  <div.editor-column>
+    <EditorTabs>                   ← tab strip (filenames, dirty dot, AI pulse, close)
+    <AlgoEditor>                   ← Monaco + deps strip
+    <EditorStatusBar>              ← dirty · language · deps · ln/col · encoding
+  </div>
+</EditorView>
+```
+
+The left rail (`Sidebar.tsx`) sits outside `EditorView` inside `App.tsx`, same as today. `AiTerminalPanel` also sits outside `EditorView`, same as today — independent of editor tabs.
+
+## The `useEditorTabs` hook
+
+Centralizes all multi-tab state and mutations. Matches the codebase's existing `useAlgo*` hook pattern.
+
+### State
+
+```ts
+type TabBuffer = {
+  code: string;
+  deps: string;
+  savedCode: string;   // snapshot at last save / load / open
+  savedDeps: string;
+};
+
+type State = {
+  openTabIds: number[];               // ordered, left-to-right
+  activeTabId: number | null;
+  buffers: Record<number, TabBuffer>; // keyed by algo id
+};
+```
+
+### API
+
+| Returned | Purpose |
+|---|---|
+| `openTabIds: number[]` | Render tab strip in order |
+| `activeTabId: number \| null` | Which tab is in the editor |
+| `activeCode: string`, `activeDeps: string` | Derived; drive Monaco + deps input |
+| `isDirty(id: number): boolean` | Per-tab dirty flag |
+| `hasAnyDirty: boolean` | Derived convenience |
+| `openTab(algo: Algo): void` | Idempotent; initializes buffer from `algo.code` / `algo.dependencies` if new; activates either way |
+| `switchTab(id: number): void` | No prompt — buffers persist |
+| `closeTab(id: number): { dirty: boolean }` | Caller inspects `dirty` and shows confirm if needed |
+| `forceCloseTab(id: number): void` | Post-confirm close path |
+| `updateCode(code: string)`, `updateDeps(deps: string)` | Update active tab's buffer |
+| `markActiveSaved(): void` | Snapshot `code`→`savedCode`, `deps`→`savedDeps` on successful save |
+| `onAlgoDeleted(id: number): void` | External hook — closes tab silently |
+| `onAlgoExternallyUpdated(id: number, code: string, deps: string): void` | Sync rule below |
+
+### Close-active-tab rule
+
+When closing the active tab: activate right neighbor; else left neighbor; else set `activeTabId` to `null` (empty state).
+
+### External-update rule (`algo-code-updated` event)
+
+- **Buffer clean** → replace both `code` and `savedCode` (full sync).
+- **Buffer dirty** → leave everything alone. Toast: *"External update to `<name>`. Your unsaved edits will overwrite it on save."*
+
+Fixes an existing latent issue where the event unconditionally overwrites unsaved edits on the selected algo.
+
+### Behavior changes from today
+
+1. **No more unsaved-changes dialog on view navigation.** Tab buffers persist in the hook across view switches, so no data is lost.
+2. **Tab/algo-select never prompts.** Buffers are preserved — the whole point of multi-tab.
+
+Close-dirty-tab still prompts. Delete algo still prompts (the delete confirm covers the unsaved-data case too — no second prompt).
+
+**Confirm dispatch.** The dirty-close confirm reuses the existing `ConfirmDialog` pattern in `App.tsx`. `EditorView` receives an `onRequestCloseTab(id: number)` prop from `App`; `App` inspects `tabs.isDirty(id)` and either calls `tabs.forceCloseTab(id)` directly (clean) or opens the existing `ConfirmDialog` (dirty) and calls `tabs.forceCloseTab(id)` on confirm. No new dialog component.
+
+## Component specs
+
+### `Sidebar.tsx` (edit — restyle only)
+
+- Width 80px → 52px.
+- Drop the uppercase text labels beneath each icon; rely on `title` tooltips.
+- Logo shrinks to `32px`.
+- Connection dot relocates to bottom-right corner of the rail.
+- No prop / behavior changes. Guide button stays.
+
+### `EditorView.tsx` (edit — layout-only)
+
+New prop shape:
+
+```ts
+type EditorViewProps = {
+  algos: Algo[];
+  tabs: ReturnType<typeof useEditorTabs>;
+  aiTerminalAlgoIds: Set<number>;
+  onSelectAlgo: (id: number) => void;           // wraps tabs.openTab
+  onCreateAlgo: () => void;
+  onCreateAlgoWithAi: () => void;
+  onOpenAiTerminal: (algoId: number) => void;
+  onRequestCloseTab: (id: number) => void;      // routes to App for dirty-confirm dispatch
+  onDeleteAlgo: (id: number) => void;
+  onRenameAlgo: (id: number, newName: string) => void;
+  onSaveAlgo: () => void;
+};
+```
+
+Layout:
+
+```
+<AlgoManager ...>  <div.editor-column>
+                     <EditorTabs ...>
+                     {activeTabId !== null
+                       ? <AlgoEditor ...>  <EditorStatusBar ...>
+                       : <empty-state>}
+                   </div>
+```
+
+Owns local `showDeps` + `cursor { line, col }` state; passes them down.
+
+### `EditorTabs.tsx` (new)
+
+Props:
+
+```ts
+type EditorTabsProps = {
+  tabs: Array<{ id: number; name: string; isDirty: boolean; hasAiTerminal: boolean }>;
+  activeTabId: number | null;
+  onSelect: (id: number) => void;
+  onClose: (id: number) => void;         // EditorView forwards to App via onRequestCloseTab
+  onCreateAlgo: () => void;
+  onCreateAlgoWithAi: () => void;
+  onRenameActive: () => void;
+  onDeleteActive: () => void;
+  onCloseOthers: (id: number) => void;
+  onCloseAll: () => void;
+};
+```
+
+Renders horizontal strip. Each tab: `Py` lang tag, filename (truncates with ellipsis), dirty dot (yellow) or AI pulse (blue), close `×` on hover. Active tab has a 2px `var(--accent-blue)` top border. Tabstrip-right has `+` and `+ AI` buttons and a `⋯` menu (Rename, Close Others, Close All, Delete). Horizontal scroll on overflow.
+
+### `AlgoEditor.tsx` (edit — slim down)
+
+New props:
+
+```ts
+type AlgoEditorProps = {
+  code: string;
+  deps: string;
+  showDeps: boolean;
+  onChange: (code: string) => void;
+  onDepsChange: (deps: string) => void;
+  onSave: () => void;
+  onCursorChange: (line: number, col: number) => void;
+};
+```
+
+Renders only:
+- Deps reveal strip (same visual as today; toggled via `showDeps` from parent).
+- Monaco editor with `beforeMount={defineWolfDenTheme}` and `theme="wolf-den-dark"`.
+- Monaco's `onDidChangeCursorPosition` hook calls `onCursorChange`.
+
+No header. No save button (the mouse-clickable save affordance moves into `EditorStatusBar`'s dirty chip). Keyboard `⌘S` / `Ctrl+S` stays bound here (Monaco has focus).
+
+### `EditorStatusBar.tsx` (new)
+
+Props:
+
+```ts
+type EditorStatusBarProps = {
+  isDirty: boolean;
+  depsCount: number;
+  cursorLine: number;
+  cursorCol: number;
+  onSave: () => void;          // invoked when the dirty chip is clicked
+  onToggleDeps: () => void;    // invoked when the deps chip is clicked
+};
+```
+
+Two groups:
+
+- **Left:**
+  - **Save chip** (primary mouse-clickable save affordance since `AlgoEditor` no longer has a Save button):
+    - When `isDirty`: yellow dot + `"Unsaved · ⌘S"`. Clickable — calls `onSave`. Cursor pointer; hover state highlights the background.
+    - When clean: green dot + `"Saved"`. Non-interactive.
+  - `"Python 3.11"` — static.
+  - `deps: N` chip — clickable, calls `onToggleDeps`.
+- **Right:** `"Ln 12, Col 28"`; `"Spaces: 4"`; `"UTF-8"` — all static.
+
+Height 26px; border-top `var(--border)`; font 11px; background `var(--bg-panel)`.
+
+### `AlgoManager.tsx` (edit — refresh)
+
+Existing selection / create behavior preserved. Added:
+
+- Filter input at top of list (local-state filter by name substring).
+- Per-item dirty dot — accepts `dirtyAlgoIds: Set<number>` prop.
+- Hover-only action buttons replaced with always-present `⋯` overflow. Menu items: Open (if not currently in `openTabIds`), Rename, AI Terminal, Delete.
+
+## `src/lib/monacoTheme.ts`
+
+Exports `defineWolfDenTheme(monaco)`. Called from `AlgoEditor`'s `beforeMount`.
+
+- Base: `vs-dark`, `inherit: true`.
+- Applied via `theme="wolf-den-dark"` prop on the `<Editor>` component.
+
+Color overrides:
+
+| Monaco key | Hex | Token |
+|---|---|---|
+| `editor.background` | `#1a1a28` | `--bg-panel` |
+| `editor.foreground` | `#e0e0e8` | `--text-primary` |
+| `editorLineNumber.foreground` | `#55556a` | `--text-muted` |
+| `editorLineNumber.activeForeground` | `#e0e0e8` | `--text-primary` |
+| `editor.selectionBackground` | `#4d9fff33` | `--accent-blue` @ 20% |
+| `editor.lineHighlightBackground` | `#4d9fff0d` | `--accent-blue` @ 5% |
+| `editor.lineHighlightBorder` | `#00000000` | transparent |
+| `editorCursor.foreground` | `#4d9fff` | `--accent-blue` |
+| `editorWidget.background` | `#20202e` | `--bg-elevated` |
+| `editorWidget.border` | `#2a2a3a` | `--border` |
+| `editorIndentGuide.background` | `#2a2a3a` | `--border` |
+
+Token rules (`rules: [...]`): keyword `#c792ea`, function `#82aaff`, string `#c3e88d`, number `#f78c6c`, comment `#546e7a` italic, operator `#89ddff`, class `#ffcb6b`. Matches the prototype palette.
+
+Hardcoded hex rather than reading CSS vars at runtime — Monaco's `defineTheme` wants strings up front; the CSS vars themselves are already constants in `styles.css`. If tokens ever become dynamic (light mode), revisit.
+
+## State migration in `App.tsx`
+
+Removed:
+- `selectedAlgoId`, `selectedAlgoIdRef`
+- `editorCode`, `editorDeps`
+- `hasUnsavedChanges`
+- Confirm-on-navigate logic inside `handleNavigate`
+- Confirm-on-select logic inside `handleSelectAlgo`
+- The `useEffect` that syncs `selectedAlgo` → `editorCode` / `editorDeps`
+
+Added:
+- `const tabs = useEditorTabs()` — single replacement for the above.
+- All AI-terminal and nav-context code that previously referenced `selectedAlgoId` now uses `tabs.activeTabId` (same semantic — "the algo currently in focus in the editor").
+
+Handler rewiring:
+
+| Today | New |
+|---|---|
+| `handleSelectAlgo(id)` — sets `selectedAlgoId`, confirms if dirty | `tabs.openTab(algo)` — idempotent, no confirm |
+| `handleSaveAlgo()` — reads `editorCode` / `editorDeps`, calls backend, reloads | Reads `tabs.activeCode` / `tabs.activeDeps`, calls backend, calls `tabs.markActiveSaved()` on success, toasts on failure |
+| `handleCreateAlgo` / `handleCreateAlgoWithAi` | After backend create, calls `tabs.openTab(newAlgo)` |
+| `handleDeleteAlgo(id)` → on confirm | Backend delete → `tabs.onAlgoDeleted(id)` → `loadAlgos()` |
+| `algo-code-updated` event handler | Calls `tabs.onAlgoExternallyUpdated(algo_id, code, deps)` |
+
+## Error handling
+
+- **Save failure** — existing handler adds `toast.error("Failed to save: <msg>")` and does **not** call `markActiveSaved()` on throw. Buffer stays dirty; user retries.
+- **Open-tab for stale / missing id** — `openTab` defensively no-ops if the algo isn't in the current list.
+- **`onAlgoDeleted` for non-open id** — no-op.
+- **`forceCloseTab` on non-open id** — no-op.
+- **External-update event for non-open algo** — ignored; next `openTab` picks up the current code.
+
+## Verification plan
+
+The project has no test framework. Verification is manual + TypeScript type-check.
+
+1. `npm run build` passes (type-check is clean on all touched files).
+2. Smoke matrix:
+   - Open 3 tabs; switch between them — each retains independent buffer and dirty state.
+   - Edit tab A, switch to B, switch back to A — edits preserved; A still dirty.
+   - Close dirty tab → confirm dialog. Cancel keeps tab; Confirm drops edits.
+   - Close active tab — right neighbor activates; left neighbor activates if no right.
+   - Close last tab — empty state shows.
+   - Delete algo with tab open (via sidebar `⋯` or tab `⋯`) — single delete confirm only; tab closes on confirm.
+   - Rename algo from sidebar — tab label updates live.
+   - Save active tab — dirty dots clear in tab strip, sidebar, and status bar.
+   - Editor → Home → Editor — tabs and dirty state survive view nav; no prompt fires.
+   - External `algo-code-updated` event on clean buffer — syncs transparently.
+   - External `algo-code-updated` event on dirty buffer — toast fires; buffer untouched; save overwrites.
+   - Monaco theme: background / selection / line highlight / syntax colors match the prototype.
+3. Regression walk: Home, Algos, Trading views render correctly with the restyled 52px left rail; connection dot still visible; Guide button still works.
+
+## Ship strategy
+
+Single PR. No feature flag. No backend / schema / Tauri-command changes. No persisted-state migration. The risky diff is `App.tsx` and the hook; the smoke matrix catches regressions.
+
+## Open questions
+
+None at spec time.

--- a/prototypes/editor-view/_shared.css
+++ b/prototypes/editor-view/_shared.css
@@ -1,0 +1,113 @@
+/* Shared tokens + primitives for editor-view prototypes */
+:root {
+  --bg-primary: #0a0a0f;
+  --bg-secondary: #12121a;
+  --bg-panel: #1a1a28;
+  --bg-elevated: #20202e;
+  --border: #2a2a3a;
+  --border-strong: #3a3a4e;
+  --text-primary: #e0e0e8;
+  --text-secondary: #8888a0;
+  --text-muted: #55556a;
+  --accent-green: #00d68f;
+  --accent-red: #ff4d6a;
+  --accent-yellow: #ffc107;
+  --accent-blue: #4d9fff;
+  --accent-purple: #b388ff;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+
+button { cursor: pointer; font-family: inherit; color: inherit; border: none; background: none; padding: 0; }
+
+/* Fake Monaco editor area */
+.editor-surface {
+  font-family: "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: var(--bg-panel);
+  height: 100%;
+  overflow: auto;
+  position: relative;
+}
+.editor-gutter {
+  display: inline-block;
+  width: 48px;
+  text-align: right;
+  padding-right: 12px;
+  color: var(--text-muted);
+  user-select: none;
+  -webkit-user-select: none;
+}
+.editor-line {
+  white-space: pre;
+  padding: 0 12px 0 0;
+}
+.editor-line.active {
+  background: rgba(77, 159, 255, 0.05);
+  border-left: 2px solid rgba(77, 159, 255, 0.4);
+  margin-left: -2px;
+}
+.tok-kw { color: #c792ea; }
+.tok-fn { color: #82aaff; }
+.tok-str { color: #c3e88d; }
+.tok-num { color: #f78c6c; }
+.tok-com { color: #546e7a; font-style: italic; }
+.tok-id { color: #e0e0e8; }
+.tok-op { color: #89ddff; }
+.tok-cls { color: #ffcb6b; }
+
+/* Nav banner on prototype pages */
+.proto-banner {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 100;
+  display: flex;
+  gap: 6px;
+  padding: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+}
+.proto-banner a {
+  padding: 6px 10px;
+  font-size: 11px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+.proto-banner a:hover { color: var(--text-primary); background: var(--bg-panel); }
+.proto-banner a.active {
+  background: var(--accent-blue);
+  color: #fff;
+}
+.proto-banner .label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 6px 6px 6px 10px;
+  align-self: center;
+}
+
+/* Scrollbar polish */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 10px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+::-webkit-scrollbar-track { background: transparent; }

--- a/prototypes/editor-view/_shared.js
+++ b/prototypes/editor-view/_shared.js
@@ -1,0 +1,56 @@
+// Shared prototype helpers: proto-banner injection + fake-editor rendering.
+
+(function injectBanner() {
+  const here = (location.pathname.split("/").pop() || "index.html").toLowerCase();
+  const banner = document.createElement("div");
+  banner.className = "proto-banner";
+  banner.innerHTML = `
+    <span class="label">Editor Prototypes</span>
+    <a href="index.html" data-f="index.html">Overview</a>
+    <a href="variant-a-minimal.html" data-f="variant-a-minimal.html">A · Minimal</a>
+    <a href="variant-b-workspace.html" data-f="variant-b-workspace.html">B · Workspace</a>
+    <a href="variant-c-focus.html" data-f="variant-c-focus.html">C · Focus</a>
+  `;
+  document.body.appendChild(banner);
+  banner.querySelectorAll("a").forEach((a) => {
+    if (a.dataset.f === here) a.classList.add("active");
+  });
+})();
+
+// Render a Python code sample with manual syntax coloring.
+window.renderEditor = function renderEditor(rootEl, opts = {}) {
+  const activeLine = opts.activeLine ?? 12;
+  const lines = [
+    ['<span class="tok-kw">from</span> <span class="tok-id">wolf_types</span> <span class="tok-kw">import</span> <span class="tok-id">AlgoResult</span>, <span class="tok-id">market_buy</span>, <span class="tok-id">market_sell</span>'],
+    [''],
+    [''],
+    ['<span class="tok-kw">def</span> <span class="tok-fn">create_algo</span>():'],
+    ['    <span class="tok-str">"""Momentum breakout with trailing stop."""</span>'],
+    [''],
+    ['    <span class="tok-kw">def</span> <span class="tok-fn">init</span>():'],
+    ['        <span class="tok-kw">return</span> {<span class="tok-str">\'prices\'</span>: (), <span class="tok-str">\'position\'</span>: <span class="tok-num">0</span>}'],
+    [''],
+    ['    <span class="tok-kw">def</span> <span class="tok-fn">on_tick</span>(<span class="tok-id">state</span>, <span class="tok-id">tick</span>, <span class="tok-id">ctx</span>):'],
+    ['        <span class="tok-com"># keep last 20 prices for SMA</span>'],
+    ['        <span class="tok-id">prices</span> <span class="tok-op">=</span> (<span class="tok-op">*</span><span class="tok-id">state</span>[<span class="tok-str">\'prices\'</span>], <span class="tok-id">tick</span>.<span class="tok-id">price</span>)[<span class="tok-op">-</span><span class="tok-num">20</span>:]'],
+    ['        <span class="tok-kw">if</span> <span class="tok-fn">len</span>(<span class="tok-id">prices</span>) <span class="tok-op">&lt;</span> <span class="tok-num">20</span>:'],
+    ['            <span class="tok-kw">return</span> <span class="tok-cls">AlgoResult</span>({<span class="tok-op">**</span><span class="tok-id">state</span>, <span class="tok-str">\'prices\'</span>: <span class="tok-id">prices</span>}, ())'],
+    [''],
+    ['        <span class="tok-id">sma</span> <span class="tok-op">=</span> <span class="tok-fn">sum</span>(<span class="tok-id">prices</span>) <span class="tok-op">/</span> <span class="tok-fn">len</span>(<span class="tok-id">prices</span>)'],
+    ['        <span class="tok-id">orders</span> <span class="tok-op">=</span> ()'],
+    [''],
+    ['        <span class="tok-kw">if</span> <span class="tok-id">tick</span>.<span class="tok-id">price</span> <span class="tok-op">&gt;</span> <span class="tok-id">sma</span> <span class="tok-op">*</span> <span class="tok-num">1.02</span> <span class="tok-kw">and</span> <span class="tok-id">state</span>[<span class="tok-str">\'position\'</span>] <span class="tok-op">==</span> <span class="tok-num">0</span>:'],
+    ['            <span class="tok-id">orders</span> <span class="tok-op">=</span> (<span class="tok-fn">market_buy</span>(<span class="tok-num">1</span>),)'],
+    [''],
+    ['        <span class="tok-kw">return</span> <span class="tok-cls">AlgoResult</span>({<span class="tok-op">**</span><span class="tok-id">state</span>, <span class="tok-str">\'prices\'</span>: <span class="tok-id">prices</span>}, <span class="tok-id">orders</span>)'],
+    [''],
+    ['    <span class="tok-kw">return</span> {<span class="tok-str">\'init\'</span>: <span class="tok-id">init</span>, <span class="tok-str">\'on_tick\'</span>: <span class="tok-id">on_tick</span>}'],
+  ];
+  rootEl.innerHTML = lines
+    .map((l, i) => {
+      const isActive = i + 1 === activeLine;
+      const num = String(i + 1).padStart(2, " ");
+      return `<div class="editor-line${isActive ? " active" : ""}"><span class="editor-gutter">${num}</span>${l[0]}</div>`;
+    })
+    .join("");
+};

--- a/prototypes/editor-view/index.html
+++ b/prototypes/editor-view/index.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Editor View Prototypes · Wolf Den</title>
+    <link rel="stylesheet" href="_shared.css" />
+    <style>
+      body { overflow: auto; }
+      .container { max-width: 1000px; margin: 0 auto; padding: 72px 32px 96px; }
+      h1 {
+        font-size: 28px;
+        font-weight: 700;
+        margin: 0 0 6px;
+        letter-spacing: -0.02em;
+      }
+      .sub { color: var(--text-secondary); font-size: 14px; margin-bottom: 40px; }
+      .grid { display: grid; grid-template-columns: 1fr; gap: 20px; }
+      @media (min-width: 820px) { .grid { grid-template-columns: repeat(3, 1fr); } }
+      .card {
+        background: var(--bg-panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        transition: border-color 0.15s, transform 0.15s;
+      }
+      .card:hover { border-color: var(--border-strong); transform: translateY(-2px); }
+      .card h3 { margin: 0; font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
+      .card p { margin: 0; color: var(--text-secondary); font-size: 13px; line-height: 1.55; }
+      .card .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--accent-blue);
+        font-weight: 600;
+      }
+      .card ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .card li {
+        font-size: 12px;
+        color: var(--text-secondary);
+        padding-left: 14px;
+        position: relative;
+      }
+      .card li::before {
+        content: "";
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: var(--border-strong);
+        position: absolute;
+        left: 2px;
+        top: 7px;
+      }
+      .card a.cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--accent-blue);
+        text-decoration: none;
+        margin-top: 4px;
+      }
+      .card a.cta:hover { text-decoration: underline; }
+      .section-h {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        margin: 48px 0 16px;
+        font-weight: 600;
+      }
+      .notes {
+        background: var(--bg-panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 20px 24px;
+        color: var(--text-secondary);
+        font-size: 13px;
+        line-height: 1.65;
+      }
+      .notes strong { color: var(--text-primary); }
+      .notes code {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 12px;
+        background: var(--bg-secondary);
+        padding: 1px 5px;
+        border-radius: 4px;
+        color: var(--accent-blue);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Editor View · Design Prototypes</h1>
+      <p class="sub">
+        Three directions for modernizing the algo editor. Open each variant, compare the chrome,
+        hierarchy, and feel — then tell me which direction (or which parts of which) to build.
+      </p>
+
+      <div class="grid">
+        <div class="card">
+          <span class="tag">Variant A</span>
+          <h3>Minimal · Linear-inspired</h3>
+          <p>
+            Restrained chrome. Contextual breadcrumb header replaces the static "Algo Editor" label.
+            Footer status bar carries saved-state, cursor position, and deps count.
+          </p>
+          <ul>
+            <li>Unsaved dot in sidebar + header</li>
+            <li>Autosave with visible state</li>
+            <li>Overflow <code>⋯</code> menu, not button row</li>
+            <li>Subtle sidebar search</li>
+          </ul>
+          <a class="cta" href="variant-a-minimal.html">Open prototype →</a>
+        </div>
+
+        <div class="card">
+          <span class="tag">Variant B</span>
+          <h3>Workspace · VS Code-inspired</h3>
+          <p>
+            Editor tabs. Activity bar on the far left. Multiple algos open at once. Richer status
+            bar. Familiar to anyone who's used VS Code or Cursor.
+          </p>
+          <ul>
+            <li>Tabs with dirty dot + close</li>
+            <li>Activity bar for future panels</li>
+            <li>Breadcrumb under tabs</li>
+            <li>⌘K command palette affordance</li>
+          </ul>
+          <a class="cta" href="variant-b-workspace.html">Open prototype →</a>
+        </div>
+
+        <div class="card">
+          <span class="tag">Variant C</span>
+          <h3>Focus · Writer-inspired</h3>
+          <p>
+            Max editor real estate. Sidebar collapses to a thin rail; peeks open on hover. Floating
+            ⌘K palette is the primary nav. For people who know their algos by name.
+          </p>
+          <ul>
+            <li>Collapsed rail with just algo count</li>
+            <li>Hover-peek sidebar</li>
+            <li>Floating command palette</li>
+            <li>Minimalist top bar</li>
+          </ul>
+          <a class="cta" href="variant-c-focus.html">Open prototype →</a>
+        </div>
+      </div>
+
+      <div class="section-h">Notes</div>
+      <div class="notes">
+        <strong>These are visual prototypes only.</strong> The editor surface is a hand-rolled
+        lookalike — the real implementation would swap in Monaco with a custom theme that reads
+        your <code>--bg-panel</code>, <code>--border</code>, and accent tokens (none of the
+        variants use <code>vs-dark</code>).<br /><br />
+        Every button, tab, and search box is static — clicking around the app isn't wired up.
+        Focus on the <strong>layout, hierarchy, density, and chrome</strong>, not the
+        interactions. Flip between variants with the banner in the top right of each page.
+      </div>
+    </div>
+    <script src="_shared.js"></script>
+  </body>
+</html>

--- a/prototypes/editor-view/variant-a-minimal.html
+++ b/prototypes/editor-view/variant-a-minimal.html
@@ -1,0 +1,434 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Variant A · Minimal · Editor Prototype</title>
+    <link rel="stylesheet" href="_shared.css" />
+    <style>
+      .app { display: flex; flex-direction: column; height: 100vh; }
+      .workspace { display: flex; flex: 1; gap: 12px; padding: 12px 12px 0; min-height: 0; }
+
+      /* ======== Sidebar ======== */
+      .sidebar {
+        width: 280px;
+        flex-shrink: 0;
+        background: var(--bg-panel);
+        border-radius: 12px;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .side-head {
+        padding: 14px 14px 10px;
+        border-bottom: 1px solid var(--border);
+      }
+      .side-head-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 10px;
+      }
+      .side-title {
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-secondary);
+      }
+      .side-actions { display: flex; gap: 4px; }
+      .icon-btn {
+        width: 26px;
+        height: 26px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 6px;
+        color: var(--text-secondary);
+        transition: background 0.12s, color 0.12s;
+      }
+      .icon-btn:hover { background: var(--bg-secondary); color: var(--text-primary); }
+      .icon-btn.primary { color: var(--accent-blue); }
+      .icon-btn.primary:hover { background: rgba(77,159,255,0.1); }
+      .search-wrap {
+        position: relative;
+      }
+      .search-wrap svg {
+        position: absolute;
+        left: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-muted);
+      }
+      .search {
+        width: 100%;
+        background: var(--bg-secondary);
+        border: 1px solid transparent;
+        border-radius: 8px;
+        padding: 7px 10px 7px 32px;
+        font-size: 12px;
+        color: var(--text-primary);
+        outline: none;
+        transition: border-color 0.12s;
+      }
+      .search:focus { border-color: var(--border-strong); }
+      .search::placeholder { color: var(--text-muted); }
+
+      .algo-list { flex: 1; overflow: auto; padding: 6px; }
+      .algo-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 10px;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 13px;
+        transition: background 0.1s;
+        gap: 8px;
+      }
+      .algo-item:hover { background: var(--bg-secondary); }
+      .algo-item.selected {
+        background: rgba(77, 159, 255, 0.1);
+        color: var(--text-primary);
+      }
+      .algo-item.selected .algo-name { color: var(--text-primary); }
+      .algo-name { color: var(--text-secondary); display: flex; align-items: center; gap: 6px; min-width: 0; }
+      .algo-name .dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-yellow);
+        flex-shrink: 0;
+      }
+      .algo-name span.file { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .algo-meta {
+        display: flex; align-items: center; gap: 8px;
+        color: var(--text-muted);
+        font-size: 11px;
+        flex-shrink: 0;
+      }
+      .algo-item .overflow {
+        opacity: 0;
+        transition: opacity 0.12s;
+      }
+      .algo-item:hover .overflow,
+      .algo-item.selected .overflow { opacity: 1; }
+      .ai-pulse {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-blue);
+        animation: pulse 1.8s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.4; }
+      }
+
+      .side-foot {
+        padding: 10px 14px;
+        border-top: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 11px;
+        color: var(--text-muted);
+      }
+
+      /* ======== Main editor column ======== */
+      .main {
+        flex: 1;
+        min-width: 0;
+        background: var(--bg-panel);
+        border-radius: 12px;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border);
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        min-width: 0;
+      }
+      .breadcrumb .crumb-muted { color: var(--text-muted); }
+      .breadcrumb .sep { color: var(--border-strong); }
+      .breadcrumb .filename {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+      .breadcrumb .filename .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent-yellow);
+      }
+      .top-actions { display: flex; align-items: center; gap: 4px; }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 9px;
+        font-size: 11px;
+        font-weight: 500;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border-radius: 999px;
+        transition: all 0.12s;
+      }
+      .chip:hover { background: var(--bg-elevated); color: var(--text-primary); }
+      .chip.active { background: rgba(77,159,255,0.15); color: var(--accent-blue); }
+      .chip .num {
+        background: var(--bg-elevated);
+        padding: 0 6px;
+        border-radius: 999px;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .deps-strip {
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg-secondary);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .deps-strip label {
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        white-space: nowrap;
+      }
+      .deps-strip input {
+        flex: 1;
+        background: var(--bg-primary);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 6px 10px;
+        font-family: "JetBrains Mono", monospace;
+        font-size: 12px;
+        color: var(--text-primary);
+        outline: none;
+      }
+      .deps-strip input:focus { border-color: var(--accent-blue); }
+
+      .editor-pane { flex: 1; min-height: 0; position: relative; }
+
+      /* ======== Status bar ======== */
+      .statusbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 16px;
+        height: 26px;
+        border-top: 1px solid var(--border);
+        background: var(--bg-panel);
+        font-size: 11px;
+        color: var(--text-secondary);
+        flex-shrink: 0;
+      }
+      .status-group { display: flex; align-items: center; gap: 14px; }
+      .status-item { display: inline-flex; align-items: center; gap: 6px; }
+      .status-dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-green);
+      }
+      .status-item.muted { color: var(--text-muted); }
+      .status-item kbd {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 3px;
+        padding: 0 4px;
+        font-family: inherit;
+        font-size: 10px;
+      }
+
+      /* Shell/workspace bar */
+      .shell-bar {
+        height: 40px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        padding: 0 16px;
+        gap: 14px;
+        background: var(--bg-primary);
+        flex-shrink: 0;
+      }
+      .shell-title {
+        font-weight: 700;
+        font-size: 13px;
+        letter-spacing: -0.01em;
+      }
+      .shell-tabs { display: flex; align-items: center; gap: 4px; }
+      .shell-tab {
+        padding: 6px 12px;
+        font-size: 12px;
+        color: var(--text-secondary);
+        border-radius: 6px;
+      }
+      .shell-tab.active {
+        background: var(--bg-panel);
+        color: var(--text-primary);
+      }
+      .shell-right { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+
+      .workspace-foot { height: 10px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <!-- App shell (static for context) -->
+      <div class="shell-bar">
+        <div class="shell-title">Wolf Den</div>
+        <div class="shell-tabs">
+          <div class="shell-tab">Home</div>
+          <div class="shell-tab active">Editor</div>
+          <div class="shell-tab">Runs</div>
+          <div class="shell-tab">Market</div>
+        </div>
+        <div class="shell-right">
+          <button class="chip">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+            Search
+            <kbd style="background:var(--bg-primary);border:1px solid var(--border);border-radius:3px;padding:0 4px;font-family:inherit;font-size:10px;">⌘K</kbd>
+          </button>
+        </div>
+      </div>
+
+      <div class="workspace">
+        <!-- Sidebar -->
+        <aside class="sidebar">
+          <div class="side-head">
+            <div class="side-head-row">
+              <span class="side-title">Algos · 4</span>
+              <div class="side-actions">
+                <button class="icon-btn" title="Create with AI">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z" /></svg>
+                </button>
+                <button class="icon-btn primary" title="New algo">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M12 5v14M5 12h14" /></svg>
+                </button>
+              </div>
+            </div>
+            <div class="search-wrap">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+              <input class="search" placeholder="Filter algos…" />
+            </div>
+          </div>
+
+          <div class="algo-list">
+            <div class="algo-item selected">
+              <div class="algo-name">
+                <span class="dot" title="Unsaved"></span>
+                <span class="file">momentum.py</span>
+              </div>
+              <div class="algo-meta">
+                <span class="ai-pulse" title="AI terminal active"></span>
+                <button class="icon-btn overflow" style="width:20px;height:20px;">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="algo-item">
+              <div class="algo-name">
+                <span class="file">mean-reversion.py</span>
+              </div>
+              <div class="algo-meta">
+                <button class="icon-btn overflow" style="width:20px;height:20px;">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="algo-item">
+              <div class="algo-name">
+                <span class="file">pairs-trade.py</span>
+              </div>
+              <div class="algo-meta">
+                <button class="icon-btn overflow" style="width:20px;height:20px;">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="algo-item">
+              <div class="algo-name">
+                <span class="file">volatility-breakout.py</span>
+              </div>
+              <div class="algo-meta">
+                <button class="icon-btn overflow" style="width:20px;height:20px;">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="side-foot">
+            <span>4 algos</span>
+            <span>1 unsaved</span>
+          </div>
+        </aside>
+
+        <!-- Main editor column -->
+        <main class="main">
+          <div class="topbar">
+            <div class="breadcrumb">
+              <span class="crumb-muted">Algos</span>
+              <span class="sep">/</span>
+              <span class="filename">
+                momentum.py
+                <span class="dot" title="Unsaved"></span>
+              </span>
+            </div>
+            <div class="top-actions">
+              <button class="chip active">
+                deps
+                <span class="num">3</span>
+              </button>
+              <button class="icon-btn" title="Rename"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /><path d="m15 5 4 4" /></svg></button>
+              <button class="icon-btn" title="Run / Backtest"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg></button>
+              <button class="icon-btn" title="More"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg></button>
+            </div>
+          </div>
+
+          <div class="deps-strip">
+            <label>pip deps</label>
+            <input value="numpy pandas scikit-learn" />
+          </div>
+
+          <div class="editor-pane">
+            <div class="editor-surface" id="editor-surface" style="padding: 12px 0;"></div>
+          </div>
+
+          <div class="statusbar">
+            <div class="status-group">
+              <span class="status-item"><span class="status-dot" style="background: var(--accent-yellow);"></span> Unsaved · autosave in 1s</span>
+              <span class="status-item muted">Python 3.11</span>
+              <span class="status-item muted">UTF-8 · LF</span>
+            </div>
+            <div class="status-group">
+              <span class="status-item muted">deps: 3</span>
+              <span class="status-item muted">Ln 12, Col 28</span>
+              <span class="status-item muted">Spaces: 4</span>
+              <span class="status-item"><kbd>⌘S</kbd> save now</span>
+            </div>
+          </div>
+        </main>
+      </div>
+
+      <div class="workspace-foot"></div>
+    </div>
+
+    <script src="_shared.js"></script>
+    <script>
+      renderEditor(document.getElementById("editor-surface"), { activeLine: 12 });
+    </script>
+  </body>
+</html>

--- a/prototypes/editor-view/variant-b-workspace.html
+++ b/prototypes/editor-view/variant-b-workspace.html
@@ -1,0 +1,536 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Variant B · Workspace · Editor Prototype</title>
+    <link rel="stylesheet" href="_shared.css" />
+    <style>
+      .app { display: flex; flex-direction: column; height: 100vh; }
+
+      /* Top shell */
+      .topshell {
+        height: 38px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        padding: 0 12px 0 14px;
+        gap: 12px;
+        background: var(--bg-primary);
+      }
+      .topshell .brand {
+        font-weight: 700;
+        font-size: 13px;
+        letter-spacing: -0.01em;
+      }
+      .topshell .crumb {
+        font-size: 12px;
+        color: var(--text-secondary);
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+      .topshell .crumb span.sep { color: var(--border-strong); }
+      .topshell .palette {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 10px 4px 8px;
+        font-size: 12px;
+        color: var(--text-secondary);
+        background: var(--bg-panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        min-width: 260px;
+      }
+      .topshell .palette kbd {
+        margin-left: auto;
+        padding: 1px 5px;
+        background: var(--bg-secondary);
+        border-radius: 3px;
+        font-family: inherit;
+        font-size: 10px;
+        color: var(--text-muted);
+      }
+
+      /* Main frame */
+      .frame { display: flex; flex: 1; min-height: 0; }
+
+      /* Activity bar */
+      .activity {
+        width: 52px;
+        flex-shrink: 0;
+        background: var(--bg-primary);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 10px 0;
+        gap: 4px;
+      }
+      .act-btn {
+        width: 40px;
+        height: 40px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        color: var(--text-muted);
+        position: relative;
+        transition: background 0.12s, color 0.12s;
+      }
+      .act-btn:hover { background: var(--bg-panel); color: var(--text-primary); }
+      .act-btn.active {
+        background: var(--bg-panel);
+        color: var(--accent-blue);
+      }
+      .act-btn.active::before {
+        content: "";
+        position: absolute;
+        left: -6px;
+        top: 8px;
+        bottom: 8px;
+        width: 3px;
+        border-radius: 2px;
+        background: var(--accent-blue);
+      }
+      .act-spacer { flex: 1; }
+
+      /* Sidebar */
+      .sidebar {
+        width: 260px;
+        flex-shrink: 0;
+        background: var(--bg-panel);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+      .side-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 12px 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      .side-title {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-secondary);
+        font-weight: 600;
+      }
+      .side-head .actions { display: flex; gap: 2px; }
+      .side-head .actions button {
+        width: 24px; height: 24px;
+        border-radius: 6px;
+        color: var(--text-secondary);
+        display: inline-flex; align-items: center; justify-content: center;
+      }
+      .side-head .actions button:hover { background: var(--bg-secondary); color: var(--text-primary); }
+
+      .algo-tree { flex: 1; overflow: auto; padding: 8px 4px; font-size: 13px; }
+      .tree-group {
+        padding: 4px 10px 4px 6px;
+        color: var(--text-secondary);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        cursor: pointer;
+      }
+      .tree-group svg { transition: transform 0.15s; }
+      .tree-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 4px 8px 4px 24px;
+        border-radius: 6px;
+        cursor: pointer;
+        gap: 6px;
+      }
+      .tree-item:hover { background: var(--bg-secondary); }
+      .tree-item.active {
+        background: rgba(77,159,255,0.1);
+      }
+      .tree-item .left {
+        display: flex; align-items: center; gap: 8px;
+        color: var(--text-secondary);
+        min-width: 0;
+      }
+      .tree-item.active .left { color: var(--text-primary); }
+      .tree-item .file { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .tree-item .lang-tag {
+        width: 14px; height: 14px;
+        display: inline-flex; align-items: center; justify-content: center;
+        border-radius: 3px;
+        background: rgba(255,195,0,0.15);
+        color: var(--accent-yellow);
+        font-size: 9px;
+        font-weight: 700;
+        flex-shrink: 0;
+      }
+      .tree-item .meta {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 10px;
+        color: var(--text-muted);
+      }
+      .dirty-dot {
+        width: 7px; height: 7px; border-radius: 50%;
+        background: var(--accent-yellow);
+      }
+      .pulse {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-blue);
+        animation: pulse 1.8s ease-in-out infinite;
+      }
+      @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+      /* Editor column */
+      .editor-col { flex: 1; display: flex; flex-direction: column; min-width: 0; background: var(--bg-panel); }
+
+      /* Tab strip */
+      .tabstrip {
+        display: flex;
+        align-items: stretch;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border);
+        height: 38px;
+        overflow-x: auto;
+      }
+      .tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 0 12px;
+        font-size: 12px;
+        color: var(--text-secondary);
+        border-right: 1px solid var(--border);
+        position: relative;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .tab:hover { background: rgba(255,255,255,0.02); color: var(--text-primary); }
+      .tab.active {
+        background: var(--bg-panel);
+        color: var(--text-primary);
+      }
+      .tab.active::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0; right: 0;
+        height: 2px;
+        background: var(--accent-blue);
+      }
+      .tab .close {
+        width: 16px; height: 16px;
+        border-radius: 4px;
+        display: inline-flex; align-items: center; justify-content: center;
+        color: var(--text-muted);
+        opacity: 0.6;
+      }
+      .tab .close:hover { background: var(--bg-elevated); color: var(--text-primary); opacity: 1; }
+      .tab .lang-tag {
+        width: 14px; height: 14px;
+        display: inline-flex; align-items: center; justify-content: center;
+        border-radius: 3px;
+        background: rgba(255,195,0,0.15);
+        color: var(--accent-yellow);
+        font-size: 9px;
+        font-weight: 700;
+      }
+      .tabstrip-right {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 6px;
+        flex-shrink: 0;
+      }
+      .tab-icon-btn {
+        width: 26px; height: 26px;
+        border-radius: 6px;
+        color: var(--text-secondary);
+        display: inline-flex; align-items: center; justify-content: center;
+      }
+      .tab-icon-btn:hover { background: var(--bg-panel); color: var(--text-primary); }
+
+      /* Sub-toolbar (breadcrumb) */
+      .subtool {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--border);
+        font-size: 12px;
+        background: var(--bg-panel);
+      }
+      .subtool .breadcrumb {
+        display: flex; align-items: center; gap: 6px; color: var(--text-muted);
+      }
+      .subtool .breadcrumb strong { color: var(--text-primary); font-weight: 600; }
+      .subtool .actions { display: flex; gap: 4px; align-items: center; }
+      .subtool button.run {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        background: var(--accent-green);
+        color: #000;
+        border-radius: 6px;
+      }
+      .subtool button.run:hover { opacity: 0.9; }
+      .subtool button.save {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border-radius: 6px;
+      }
+      .subtool button.save:hover { background: var(--bg-elevated); color: var(--text-primary); }
+      .subtool .chip {
+        padding: 3px 8px;
+        font-size: 10px;
+        background: rgba(77,159,255,0.12);
+        color: var(--accent-blue);
+        border-radius: 999px;
+        font-weight: 500;
+      }
+
+      /* Editor pane */
+      .editor-pane { flex: 1; min-height: 0; background: var(--bg-panel); }
+      .editor-surface { padding: 12px 0; }
+
+      /* Status bar */
+      .statusbar {
+        height: 24px;
+        background: var(--bg-primary);
+        border-top: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 12px;
+        font-size: 11px;
+        color: var(--text-secondary);
+        flex-shrink: 0;
+      }
+      .status-seg {
+        padding: 0 8px;
+        height: 100%;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-right: 1px solid var(--border);
+      }
+      .status-seg:last-child { border-right: none; }
+      .status-seg.muted { color: var(--text-muted); }
+      .status-left, .status-right { display: flex; align-items: center; height: 100%; }
+      .status-seg.run {
+        background: var(--accent-blue);
+        color: #fff;
+      }
+      .status-seg.run:hover { opacity: 0.9; }
+      .status-seg.warn {
+        background: rgba(255,195,0,0.12);
+        color: var(--accent-yellow);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <!-- Top shell -->
+      <div class="topshell">
+        <div class="brand">Wolf Den</div>
+        <div class="crumb">
+          <span>Editor</span>
+          <span class="sep">·</span>
+          <span>momentum</span>
+        </div>
+        <div class="palette">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+          <span>Go to algo, run command…</span>
+          <kbd>⌘K</kbd>
+        </div>
+      </div>
+
+      <!-- Frame -->
+      <div class="frame">
+        <!-- Activity bar -->
+        <div class="activity">
+          <button class="act-btn" title="Home">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12 12 3l9 9" /><path d="M5 10v10h14V10" /></svg>
+          </button>
+          <button class="act-btn active" title="Editor">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m18 16 4-4-4-4" /><path d="m6 8-4 4 4 4" /><path d="m14.5 4-5 16" /></svg>
+          </button>
+          <button class="act-btn" title="Runs">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18" /><path d="m7 14 4-4 4 4 5-5" /></svg>
+          </button>
+          <button class="act-btn" title="Market">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M2 12h20" /></svg>
+          </button>
+          <div class="act-spacer"></div>
+          <button class="act-btn" title="Settings">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 0 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 0 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 0 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 0 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" /></svg>
+          </button>
+        </div>
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+          <div class="side-head">
+            <span class="side-title">Explorer</span>
+            <div class="actions">
+              <button title="New algo">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3"><path d="M12 5v14M5 12h14" /></svg>
+              </button>
+              <button title="Create with AI">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z" /></svg>
+              </button>
+              <button title="Refresh">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 0 0-15-6.7L3 8" /><path d="M3 3v5h5" /><path d="M3 12a9 9 0 0 0 15 6.7l3-2.7" /><path d="M21 21v-5h-5" /></svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="algo-tree">
+            <div class="tree-group">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" style="transform: rotate(90deg);"><path d="m9 18 6-6-6-6" /></svg>
+              Algos
+            </div>
+            <div class="tree-item active">
+              <div class="left">
+                <span class="lang-tag">Py</span>
+                <span class="file">momentum.py</span>
+              </div>
+              <div class="meta">
+                <span class="pulse" title="AI active"></span>
+                <span class="dirty-dot" title="Unsaved"></span>
+              </div>
+            </div>
+            <div class="tree-item">
+              <div class="left">
+                <span class="lang-tag">Py</span>
+                <span class="file">mean-reversion.py</span>
+              </div>
+            </div>
+            <div class="tree-item">
+              <div class="left">
+                <span class="lang-tag">Py</span>
+                <span class="file">pairs-trade.py</span>
+              </div>
+              <div class="meta">
+                <span class="dirty-dot" style="background: var(--text-muted);" title="Open"></span>
+              </div>
+            </div>
+            <div class="tree-item">
+              <div class="left">
+                <span class="lang-tag">Py</span>
+                <span class="file">volatility-breakout.py</span>
+              </div>
+            </div>
+
+            <div class="tree-group" style="margin-top:10px;">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6"><path d="m9 18 6-6-6-6" /></svg>
+              Archive
+            </div>
+          </div>
+        </aside>
+
+        <!-- Editor column -->
+        <div class="editor-col">
+          <!-- Tabs -->
+          <div class="tabstrip">
+            <div class="tab active">
+              <span class="lang-tag">Py</span>
+              <span>momentum.py</span>
+              <span class="dirty-dot"></span>
+              <span class="close">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M18 6 6 18M6 6l12 12" /></svg>
+              </span>
+            </div>
+            <div class="tab">
+              <span class="lang-tag">Py</span>
+              <span>pairs-trade.py</span>
+              <span class="close">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M18 6 6 18M6 6l12 12" /></svg>
+              </span>
+            </div>
+            <div class="tabstrip-right">
+              <button class="tab-icon-btn" title="Split editor">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" /><path d="M12 3v18" /></svg>
+              </button>
+              <button class="tab-icon-btn" title="More">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Subtoolbar -->
+          <div class="subtool">
+            <div class="breadcrumb">
+              <span>Algos</span>
+              <span>/</span>
+              <strong>momentum.py</strong>
+              <span class="chip">deps · 3</span>
+            </div>
+            <div class="actions">
+              <button class="save">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><path d="M17 21v-8H7v8M7 3v5h8"/></svg>
+                Save
+              </button>
+              <button class="run">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                Backtest
+              </button>
+            </div>
+          </div>
+
+          <!-- Editor -->
+          <div class="editor-pane">
+            <div class="editor-surface" id="editor-surface"></div>
+          </div>
+
+          <!-- Status bar -->
+          <div class="statusbar">
+            <div class="status-left">
+              <span class="status-seg warn">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="6" /></svg>
+                Unsaved
+              </span>
+              <span class="status-seg">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 3 20 12 6 21z" /></svg>
+                main
+              </span>
+              <span class="status-seg muted">0 problems</span>
+              <span class="status-seg muted">AI: active</span>
+            </div>
+            <div class="status-right">
+              <span class="status-seg muted">Ln 12, Col 28</span>
+              <span class="status-seg muted">Spaces: 4</span>
+              <span class="status-seg muted">UTF-8</span>
+              <span class="status-seg muted">Python 3.11</span>
+              <span class="status-seg run">▶ Backtest</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="_shared.js"></script>
+    <script>
+      renderEditor(document.getElementById("editor-surface"), { activeLine: 12 });
+    </script>
+  </body>
+</html>

--- a/prototypes/editor-view/variant-c-focus.html
+++ b/prototypes/editor-view/variant-c-focus.html
@@ -1,0 +1,428 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Variant C · Focus · Editor Prototype</title>
+    <link rel="stylesheet" href="_shared.css" />
+    <style>
+      .app { display: flex; height: 100vh; position: relative; }
+
+      /* Collapsed rail */
+      .rail {
+        width: 44px;
+        flex-shrink: 0;
+        background: var(--bg-panel);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 14px 0;
+        gap: 10px;
+        position: relative;
+        z-index: 2;
+      }
+      .rail-logo {
+        width: 26px; height: 26px; border-radius: 8px;
+        background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+        display: inline-flex; align-items: center; justify-content: center;
+        font-weight: 800;
+        font-size: 11px;
+        color: #fff;
+      }
+      .rail-count {
+        writing-mode: vertical-rl;
+        transform: rotate(180deg);
+        font-size: 10px;
+        color: var(--text-secondary);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        margin-top: 8px;
+        padding: 8px 0;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .rail-count:hover { color: var(--text-primary); }
+      .rail-count .dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-yellow);
+        display: inline-block;
+        margin-right: 6px;
+      }
+      .rail-spacer { flex: 1; }
+      .rail-btn {
+        width: 28px; height: 28px;
+        border-radius: 7px;
+        color: var(--text-muted);
+        display: inline-flex; align-items: center; justify-content: center;
+      }
+      .rail-btn:hover { background: var(--bg-secondary); color: var(--text-primary); }
+
+      /* Peek panel (simulated always-open for demo) */
+      .peek {
+        position: absolute;
+        left: 44px;
+        top: 0;
+        bottom: 0;
+        width: 280px;
+        background: var(--bg-panel);
+        border-right: 1px solid var(--border);
+        box-shadow: 6px 0 40px rgba(0,0,0,0.5);
+        display: flex;
+        flex-direction: column;
+        z-index: 3;
+        transform: translateX(-305px);
+        transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+      .app:hover .peek,
+      .peek:hover { transform: translateX(0); }
+      .peek-head {
+        padding: 14px 16px 10px;
+        border-bottom: 1px solid var(--border);
+      }
+      .peek-title {
+        display: flex; align-items: center; justify-content: space-between;
+        margin-bottom: 10px;
+      }
+      .peek-title h2 {
+        margin: 0;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .peek-title button {
+        width: 24px; height: 24px;
+        border-radius: 6px;
+        color: var(--accent-blue);
+        display: inline-flex; align-items: center; justify-content: center;
+      }
+      .peek-title button:hover { background: rgba(77,159,255,0.1); }
+      .search {
+        width: 100%;
+        background: var(--bg-secondary);
+        border: 1px solid transparent;
+        border-radius: 8px;
+        padding: 7px 10px 7px 30px;
+        font-size: 12px;
+        color: var(--text-primary);
+        outline: none;
+        position: relative;
+      }
+      .search-wrap { position: relative; }
+      .search-wrap svg {
+        position: absolute;
+        left: 9px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-muted);
+      }
+      .peek-list { flex: 1; overflow: auto; padding: 6px; }
+      .p-item {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 7px 10px;
+        border-radius: 7px;
+        font-size: 13px;
+        color: var(--text-secondary);
+        cursor: pointer;
+      }
+      .p-item:hover { background: var(--bg-secondary); }
+      .p-item.active { background: rgba(77,159,255,0.1); color: var(--text-primary); }
+      .p-item .left { display: flex; align-items: center; gap: 8px; min-width: 0; }
+      .p-item .dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-yellow);
+      }
+      .p-item .file { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .p-item .meta { font-size: 10px; color: var(--text-muted); }
+
+      /* Main editor area */
+      .stage {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        background: var(--bg-panel);
+        position: relative;
+        min-width: 0;
+      }
+      .stage-top {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 24px;
+        border-bottom: 1px solid transparent;
+        position: relative;
+        min-height: 52px;
+      }
+      .title {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 14px;
+      }
+      .title .crumb {
+        color: var(--text-muted);
+        font-weight: 500;
+      }
+      .title .sep { color: var(--border-strong); }
+      .title strong {
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .title .dot {
+        width: 7px; height: 7px; border-radius: 50%;
+        background: var(--accent-yellow);
+      }
+      .title .pill {
+        padding: 2px 8px;
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        border-radius: 999px;
+        background: rgba(255,195,0,0.12);
+        color: var(--accent-yellow);
+        text-transform: uppercase;
+      }
+      .stage-top .left-actions,
+      .stage-top .right-actions {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .stage-top .left-actions { left: 20px; }
+      .stage-top .right-actions { right: 20px; }
+      .ghost-btn {
+        padding: 6px 10px;
+        font-size: 11px;
+        color: var(--text-secondary);
+        border-radius: 6px;
+        display: inline-flex; align-items: center; gap: 6px;
+      }
+      .ghost-btn:hover { background: var(--bg-secondary); color: var(--text-primary); }
+      .ghost-btn kbd {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 3px;
+        padding: 0 4px;
+        font-family: inherit;
+        font-size: 10px;
+        color: var(--text-muted);
+      }
+
+      .editor-wrap {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        justify-content: center;
+        overflow: hidden;
+      }
+      .editor-col {
+        width: 100%;
+        max-width: 980px;
+        height: 100%;
+        padding: 0 8px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .editor-surface { flex: 1; padding: 16px 0 40px; }
+
+      /* Floating command palette hint */
+      .palette-fab {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        z-index: 50;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 9px 14px;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-strong);
+        border-radius: 10px;
+        font-size: 12px;
+        color: var(--text-secondary);
+        box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+        backdrop-filter: blur(8px);
+      }
+      .palette-fab:hover { color: var(--text-primary); }
+      .palette-fab kbd {
+        padding: 1px 5px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border);
+        border-radius: 3px;
+        font-family: inherit;
+        font-size: 10px;
+        color: var(--text-muted);
+      }
+
+      /* Thin bottom status strip */
+      .status-thin {
+        height: 24px;
+        flex-shrink: 0;
+        border-top: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 20px;
+        font-size: 11px;
+        color: var(--text-muted);
+      }
+      .status-thin .group { display: flex; gap: 16px; align-items: center; }
+      .status-thin .saved-state {
+        color: var(--accent-yellow);
+      }
+      .status-thin .saved-dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--accent-yellow);
+        display: inline-block;
+        margin-right: 6px;
+      }
+
+      .hover-hint {
+        position: fixed;
+        left: 56px;
+        bottom: 50px;
+        font-size: 10px;
+        color: var(--text-muted);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        background: var(--bg-elevated);
+        padding: 4px 8px;
+        border-radius: 6px;
+        border: 1px solid var(--border);
+        z-index: 40;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <!-- Collapsed rail -->
+      <div class="rail">
+        <div class="rail-logo">W</div>
+        <div class="rail-count">
+          <span class="dot"></span>4 Algos
+        </div>
+        <div class="rail-spacer"></div>
+        <button class="rail-btn" title="Home">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12 12 3l9 9" /><path d="M5 10v10h14V10" /></svg>
+        </button>
+        <button class="rail-btn" title="Runs">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18" /><path d="m7 14 4-4 4 4 5-5" /></svg>
+        </button>
+        <button class="rail-btn" title="Settings">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3" /></svg>
+        </button>
+      </div>
+
+      <!-- Peek panel (slides in on hover over rail/peek) -->
+      <div class="peek">
+        <div class="peek-head">
+          <div class="peek-title">
+            <h2>Algos</h2>
+            <button>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3"><path d="M12 5v14M5 12h14" /></svg>
+            </button>
+          </div>
+          <div class="search-wrap">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+            <input class="search" placeholder="Find an algo…" />
+          </div>
+        </div>
+        <div class="peek-list">
+          <div class="p-item active">
+            <div class="left">
+              <span class="dot"></span>
+              <span class="file">momentum.py</span>
+            </div>
+            <span class="meta">2m</span>
+          </div>
+          <div class="p-item">
+            <div class="left">
+              <span class="file">mean-reversion.py</span>
+            </div>
+            <span class="meta">1h</span>
+          </div>
+          <div class="p-item">
+            <div class="left">
+              <span class="file">pairs-trade.py</span>
+            </div>
+            <span class="meta">yesterday</span>
+          </div>
+          <div class="p-item">
+            <div class="left">
+              <span class="file">volatility-breakout.py</span>
+            </div>
+            <span class="meta">3d</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Stage -->
+      <div class="stage">
+        <div class="stage-top">
+          <div class="left-actions">
+            <button class="ghost-btn" title="Expand sidebar">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" /><path d="M9 3v18" /></svg>
+            </button>
+          </div>
+
+          <div class="title">
+            <span class="crumb">Algos</span>
+            <span class="sep">/</span>
+            <strong>momentum.py</strong>
+            <span class="dot" title="Unsaved"></span>
+            <span class="pill">Draft</span>
+          </div>
+
+          <div class="right-actions">
+            <button class="ghost-btn" title="Deps">
+              deps · 3
+            </button>
+            <button class="ghost-btn">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+              Backtest
+              <kbd>⌘R</kbd>
+            </button>
+          </div>
+        </div>
+
+        <div class="editor-wrap">
+          <div class="editor-col">
+            <div class="editor-surface" id="editor-surface"></div>
+          </div>
+        </div>
+
+        <div class="status-thin">
+          <div class="group">
+            <span class="saved-state"><span class="saved-dot"></span>Saving…</span>
+            <span>Python 3.11</span>
+          </div>
+          <div class="group">
+            <span>Ln 12, Col 28</span>
+            <span>Spaces 4</span>
+            <span>UTF-8</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hover hint: tells user that peek slides in -->
+    <div class="hover-hint">Hover rail to open algo list</div>
+
+    <!-- Floating palette -->
+    <button class="palette-fab">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+      Quick switch
+      <kbd>⌘K</kbd>
+    </button>
+
+    <script src="_shared.js"></script>
+    <script>
+      renderEditor(document.getElementById("editor-surface"), { activeLine: 12 });
+    </script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,6 +204,23 @@ export const App = () => {
     });
   };
 
+  const handleRequestCloseMany = (ids: number[]) => {
+    const dirtyIds = ids.filter((id) => tabs.isDirty(id));
+    if (dirtyIds.length === 0) {
+      for (const id of ids) tabs.forceCloseTab(id);
+      return;
+    }
+    const noun = dirtyIds.length === 1 ? "tab" : "tabs";
+    setConfirmDialog({
+      message: `Close ${dirtyIds.length} ${noun} with unsaved changes?`,
+      confirmLabel: "Close All",
+      onConfirm: () => {
+        for (const id of ids) tabs.forceCloseTab(id);
+        setConfirmDialog(null);
+      },
+    });
+  };
+
   const handleCreateAlgo = async () => {
     try {
       const name = `algo_${Date.now()}`;
@@ -388,6 +405,7 @@ export const App = () => {
             onCreateAlgoWithAi={handleCreateAlgoWithAi}
             onOpenAiTerminal={handleOpenAiTerminal}
             onRequestCloseTab={handleRequestCloseTab}
+            onRequestCloseMany={handleRequestCloseMany}
             onDeleteAlgo={handleDeleteAlgo}
             onRenameAlgo={handleRenameAlgo}
             onSaveAlgo={handleSaveAlgo}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { useTradingSimulation } from "./hooks/useTradingSimulation";
 import { useAlgoErrors } from "./hooks/useAlgoErrors";
 import { useAlgoLogs } from "./hooks/useAlgoLogs";
 import { useAlgoHealth } from "./hooks/useAlgoHealth";
+import { useEditorTabs } from "./hooks/useEditorTabs";
 import type { DataSource } from "./hooks/useTradingSimulation";
 import { VenvSetupModal } from "./components/VenvSetupModal";
 import type { Algo, AlgoRun, View, NavOptions, NavContext } from "./types";
@@ -26,15 +27,18 @@ export const App = () => {
   const [accounts, setAccounts] = useState<Record<string, { buying_power: number; cash: number; realized_pnl: number }>>({});
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
   const [algos, setAlgos] = useState<Algo[]>([]);
-  const [selectedAlgoId, setSelectedAlgoId] = useState<number | null>(null);
-  const [editorCode, setEditorCode] = useState(DEFAULT_ALGO);
-  const [editorDeps, setEditorDeps] = useState("");
   const [activeRuns, setActiveRuns] = useState<AlgoRun[]>([]);
 
-  const selectedAlgoIdRef = useRef(selectedAlgoId);
+  const tabs = useEditorTabs();
+  const tabsRef = useRef(tabs);
   useEffect(() => {
-    selectedAlgoIdRef.current = selectedAlgoId;
-  }, [selectedAlgoId]);
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  const algosRef = useRef(algos);
+  useEffect(() => {
+    algosRef.current = algos;
+  }, [algos]);
 
   const activeRunsRef = useRef(activeRuns);
   useEffect(() => {
@@ -60,7 +64,6 @@ export const App = () => {
   const { logsByInstance, clearLogs } = useAlgoLogs();
   const { healthByInstance } = useAlgoHealth();
 
-  const selectedAlgo = algos.find((a) => a.id === selectedAlgoId) ?? null;
   const aiTerminalAlgos = algos.filter((a) => aiTerminalAlgoIds.has(a.id));
 
   const loadAlgos = useCallback(async () => {
@@ -72,7 +75,6 @@ export const App = () => {
     }
   }, []);
 
-  // Load algos and running instances on startup
   const loadRunningInstances = useCallback(async () => {
     try {
       type Instance = { id: string; algo_id: number; data_source_id: string; account: string; mode: string; status: string };
@@ -139,8 +141,6 @@ export const App = () => {
     const u5 = listen<string>("nt-chart-removed", (event) => {
       const removedId = event.payload;
       setDataSources((prev) => prev.filter((ds) => ds.id !== removedId));
-
-      // Stop any algos running on the disconnected chart
       const toStop = activeRunsRef.current.filter((r) => r.data_source_id === removedId);
       for (const run of toStop) {
         invoke("stop_algo_instance", { instanceId: run.instance_id }).catch((e) =>
@@ -151,12 +151,15 @@ export const App = () => {
     });
     const u6 = listen<{ algo_id: number; code: string }>("algo-code-updated", (event) => {
       const { algo_id, code } = event.payload;
+      const algo = algosRef.current.find((a) => a.id === algo_id);
+      const deps = algo?.dependencies ?? "";
       setAlgos((prev) =>
         prev.map((a) => (a.id === algo_id ? { ...a, code, updated_at: new Date().toISOString() } : a))
       );
-      // If the updated algo is currently selected in the editor, update editorCode
-      if (algo_id === selectedAlgoIdRef.current) {
-        setEditorCode(code);
+      const result = tabsRef.current.onAlgoExternallyUpdated(algo_id, code, deps);
+      if (result.conflicted) {
+        const name = algosRef.current.find((a) => a.id === algo_id)?.name ?? `algo ${algo_id}`;
+        toast.error(`External update to ${name}. Your unsaved edits will overwrite it on save.`);
       }
     });
     return () => {
@@ -169,12 +172,37 @@ export const App = () => {
     };
   }, []);
 
-  useEffect(() => {
-    if (selectedAlgo) {
-      setEditorCode(selectedAlgo.code);
-      setEditorDeps(selectedAlgo.dependencies);
-    }
-  }, [selectedAlgo?.id]);
+  const [confirmDialog, setConfirmDialog] = useState<{ message: string; confirmLabel?: string; onConfirm: () => void } | null>(null);
+
+  const handleNavigate = (view: View, options?: NavOptions) => {
+    if (view === activeView && !options) return;
+    setPendingNavContext(options ? { ...options, targetView: view } : null);
+    setActiveView(view);
+  };
+
+  const clearPendingNavContext = useCallback(() => {
+    setPendingNavContext(null);
+  }, []);
+
+  const handleSelectAlgo = (id: number) => {
+    const algo = algos.find((a) => a.id === id);
+    if (!algo) return;
+    tabs.openTab(algo);
+  };
+
+  const handleRequestCloseTab = (id: number) => {
+    const { dirty } = tabs.closeTab(id);
+    if (!dirty) return;
+    const name = algos.find((a) => a.id === id)?.name ?? `algo ${id}`;
+    setConfirmDialog({
+      message: `Close ${name}? Unsaved changes will be lost.`,
+      confirmLabel: "Close",
+      onConfirm: () => {
+        tabs.forceCloseTab(id);
+        setConfirmDialog(null);
+      },
+    });
+  };
 
   const handleCreateAlgo = async () => {
     try {
@@ -185,25 +213,30 @@ export const App = () => {
         dependencies: "",
       });
       setAlgos((prev) => [algo, ...prev]);
-      setSelectedAlgoId(algo.id);
-      setEditorCode(algo.code);
+      tabs.openTab(algo);
     } catch (e) {
       console.error("Failed to create algo:", e);
+      toast.error("Failed to create algo: " + e);
     }
   };
 
   const handleSaveAlgo = async () => {
-    if (!selectedAlgo) return;
+    const activeId = tabs.activeTabId;
+    if (activeId === null) return;
+    const algo = algos.find((a) => a.id === activeId);
+    if (!algo) return;
     try {
       await invoke("update_algo", {
-        id: selectedAlgo.id,
-        name: selectedAlgo.name,
-        code: editorCode,
-        dependencies: editorDeps,
+        id: algo.id,
+        name: algo.name,
+        code: tabs.activeCode,
+        dependencies: tabs.activeDeps,
       });
+      tabs.markActiveSaved();
       await loadAlgos();
     } catch (e) {
       console.error("Failed to save algo:", e);
+      toast.error("Failed to save: " + e);
     }
   };
 
@@ -223,49 +256,15 @@ export const App = () => {
     }
   };
 
-  const hasUnsavedChanges = selectedAlgo ? editorCode !== selectedAlgo.code || editorDeps !== selectedAlgo.dependencies : false;
-  const [confirmDialog, setConfirmDialog] = useState<{ message: string; confirmLabel?: string; onConfirm: () => void } | null>(null);
-
-  const handleNavigate = (view: View, options?: NavOptions) => {
-    if (view === activeView && !options) return;
-    if (activeView === "editor" && hasUnsavedChanges) {
-      setConfirmDialog({
-        message: "You have unsaved changes. Leave without saving?",
-        confirmLabel: "Leave",
-        onConfirm: () => {
-          if (selectedAlgo) {
-            setEditorCode(selectedAlgo.code);
-            setEditorDeps(selectedAlgo.dependencies);
-          }
-          setPendingNavContext(options ? { ...options, targetView: view } : null);
-          setActiveView(view);
-          setConfirmDialog(null);
-        },
-      });
-      return;
+  const handleRenameActiveAlgo = () => {
+    const activeId = tabs.activeTabId;
+    if (activeId === null) return;
+    const algo = algos.find((a) => a.id === activeId);
+    if (!algo) return;
+    const newName = window.prompt("Rename algo", algo.name);
+    if (newName && newName.trim() && newName.trim() !== algo.name) {
+      handleRenameAlgo(activeId, newName.trim());
     }
-    setPendingNavContext(options ? { ...options, targetView: view } : null);
-    setActiveView(view);
-  };
-
-  const clearPendingNavContext = useCallback(() => {
-    setPendingNavContext(null);
-  }, []);
-
-  const handleSelectAlgo = (id: number) => {
-    if (id === selectedAlgoId) return;
-    if (hasUnsavedChanges) {
-      setConfirmDialog({
-        message: "You have unsaved changes. Leave without saving?",
-        confirmLabel: "Leave",
-        onConfirm: () => {
-          setSelectedAlgoId(id);
-          setConfirmDialog(null);
-        },
-      });
-      return;
-    }
-    setSelectedAlgoId(id);
   };
 
   const handleDeleteAlgo = (id: number) => {
@@ -276,10 +275,7 @@ export const App = () => {
         setConfirmDialog(null);
         try {
           await invoke("delete_algo", { id });
-          if (selectedAlgoId === id) {
-            setSelectedAlgoId(null);
-            setEditorCode(DEFAULT_ALGO);
-          }
+          tabs.onAlgoDeleted(id);
           await loadAlgos();
         } catch (e) {
           console.error("Failed to delete algo:", e);
@@ -297,19 +293,16 @@ export const App = () => {
         dependencies: "",
       });
       setAlgos((prev) => [algo, ...prev]);
-      setSelectedAlgoId(algo.id);
+      tabs.openTab(algo);
       setAiTerminalAlgoIds((prev) => new Set(prev).add(algo.id));
     } catch (e) {
       console.error("Failed to create algo:", e);
       toast.error("Failed to create algo: " + e);
     }
-  }, []);
+  }, [tabs]);
 
   const handleOpenAiTerminal = useCallback((algoId: number) => {
-    if (aiTerminalAlgoIds.has(algoId)) {
-      // Terminal already running — just show the panel
-      return;
-    }
+    if (aiTerminalAlgoIds.has(algoId)) return;
     setAiTerminalAlgoIds((prev) => new Set(prev).add(algoId));
   }, [aiTerminalAlgoIds]);
 
@@ -324,7 +317,6 @@ export const App = () => {
   const handleStartAlgo = async (id: number, mode: "live" | "shadow", account: string, dataSourceId: string) => {
     let instanceId: string | null = null;
     try {
-      // Create the instance in the DB first
       const instance = await invoke<{ id: string }>("create_algo_instance", {
         algoId: id,
         dataSourceId: dataSourceId,
@@ -332,23 +324,16 @@ export const App = () => {
         mode,
       });
       instanceId = instance.id;
-
-      // Show "installing" status while deps install + process starts
       setActiveRuns((prev) => [...prev, {
         algo_id: id, status: "installing", mode, account,
         data_source_id: dataSourceId, instance_id: instanceId!,
       }]);
-
-      // start_algo_instance now handles dep installation before spawning
       await invoke("start_algo_instance", { instanceId });
-
-      // Update status to running
       setActiveRuns((prev) => prev.map((r) =>
         r.instance_id === instanceId ? { ...r, status: "running" } : r
       ));
     } catch (e) {
       console.error("Failed to start algo:", e);
-      // Remove the "installing" entry on failure (if instance was created)
       if (instanceId) {
         setActiveRuns((prev) => prev.filter((r) => r.instance_id !== instanceId));
       }
@@ -362,7 +347,6 @@ export const App = () => {
     } catch (e) {
       console.error("Failed to stop algo:", e);
     }
-    // Always remove from UI even if backend call fails
     setActiveRuns((prev) => prev.filter((r) => r.instance_id !== instanceId));
     clearErrors(instanceId);
     clearLogs(instanceId);
@@ -372,94 +356,93 @@ export const App = () => {
     <div className="flex flex-col h-screen bg-[var(--bg-primary)]">
       <TitleBar title="Wolf Den" />
       <div className="flex flex-1 min-h-0">
-      {/* Sidebar Navigation */}
-      <Sidebar
-        activeView={activeView}
-        onNavigate={handleNavigate}
-        connectionStatus={connectionStatus}
-      />
-
-      {/* View Content */}
-      {activeView === "home" && (
-        <HomeView
-          connectionStatus={connectionStatus}
-          accounts={accounts}
-          algos={algos}
-          activeRuns={activeRuns}
-          stats={simulation.stats}
-          positions={simulation.positions}
-          pnlHistory={simulation.pnlHistory}
-          runPnlHistories={simulation.runPnlHistories}
-          algoStats={simulation.algoStats}
+        <Sidebar
+          activeView={activeView}
           onNavigate={handleNavigate}
-          onStopAlgo={handleStopAlgo}
+          connectionStatus={connectionStatus}
         />
-      )}
 
-      {activeView === "editor" && (
-        <EditorView
-          algos={algos}
-          selectedAlgoId={selectedAlgoId}
-          editorCode={editorCode}
-          editorDeps={editorDeps}
-          onSelectAlgo={handleSelectAlgo}
-          onCreateAlgo={handleCreateAlgo}
-          onCreateAlgoWithAi={handleCreateAlgoWithAi}
-          onOpenAiTerminal={handleOpenAiTerminal}
-          aiTerminalAlgoIds={aiTerminalAlgoIds}
-          onDeleteAlgo={handleDeleteAlgo}
-          onRenameAlgo={handleRenameAlgo}
-          onEditorChange={setEditorCode}
-          onDepsChange={setEditorDeps}
-          onSaveAlgo={handleSaveAlgo}
-        />
-      )}
+        {activeView === "home" && (
+          <HomeView
+            connectionStatus={connectionStatus}
+            accounts={accounts}
+            algos={algos}
+            activeRuns={activeRuns}
+            stats={simulation.stats}
+            positions={simulation.positions}
+            pnlHistory={simulation.pnlHistory}
+            runPnlHistories={simulation.runPnlHistories}
+            algoStats={simulation.algoStats}
+            onNavigate={handleNavigate}
+            onStopAlgo={handleStopAlgo}
+          />
+        )}
 
-      {activeView === "algos" && (
-        <AlgosView
-          algos={algos}
-          dataSources={dataSources}
-          activeRuns={activeRuns}
-          algoStats={simulation.algoStats}
-          errorsByInstance={errorsByInstance}
-          logsByInstance={logsByInstance}
-          healthByInstance={healthByInstance}
-          onStartAlgo={handleStartAlgo}
-          onStopAlgo={handleStopAlgo}
-          onClearLogs={clearLogs}
-          onOpenAiTerminal={handleOpenAiTerminal}
-          aiTerminalAlgoIds={aiTerminalAlgoIds}
-          initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
-          onInstanceFocused={clearPendingNavContext}
-        />
-      )}
+        {activeView === "editor" && (
+          <EditorView
+            algos={algos}
+            tabs={tabs}
+            aiTerminalAlgoIds={aiTerminalAlgoIds}
+            onSelectAlgo={handleSelectAlgo}
+            onCreateAlgo={handleCreateAlgo}
+            onCreateAlgoWithAi={handleCreateAlgoWithAi}
+            onOpenAiTerminal={handleOpenAiTerminal}
+            onRequestCloseTab={handleRequestCloseTab}
+            onDeleteAlgo={handleDeleteAlgo}
+            onRenameAlgo={handleRenameAlgo}
+            onSaveAlgo={handleSaveAlgo}
+            onRenameActiveAlgo={handleRenameActiveAlgo}
+          />
+        )}
 
-      {activeView === "trading" && (
-        <TradingView
-          simulation={simulation}
-          algos={algos}
-          activeRuns={activeRuns}
-          initialContext={pendingNavContext}
-          onContextConsumed={clearPendingNavContext}
-        />
-      )}
+        {activeView === "algos" && (
+          <AlgosView
+            algos={algos}
+            dataSources={dataSources}
+            activeRuns={activeRuns}
+            algoStats={simulation.algoStats}
+            errorsByInstance={errorsByInstance}
+            logsByInstance={logsByInstance}
+            healthByInstance={healthByInstance}
+            onStartAlgo={handleStartAlgo}
+            onStopAlgo={handleStopAlgo}
+            onClearLogs={clearLogs}
+            onOpenAiTerminal={handleOpenAiTerminal}
+            aiTerminalAlgoIds={aiTerminalAlgoIds}
+            initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
+            onInstanceFocused={clearPendingNavContext}
+          />
+        )}
 
-      {aiTerminalAlgos.length > 0 && (
-        <AiTerminalPanel
-          tabs={aiTerminalAlgos.map((a) => ({ algoId: a.id, algoName: a.name }))}
-          selectedAlgoId={selectedAlgoId}
-          onSelectAlgo={setSelectedAlgoId}
-          onClose={handleCloseAiTerminal}
-          onSpawnError={(algoId, error) => {
-            handleCloseAiTerminal(algoId);
-            if (error.includes("not found")) {
-              toast.error("Claude Code CLI not found. Install it with: npm install -g @anthropic-ai/claude-code");
-            } else {
-              toast.error("Failed to start AI terminal: " + error);
-            }
-          }}
-        />
-      )}
+        {activeView === "trading" && (
+          <TradingView
+            simulation={simulation}
+            algos={algos}
+            activeRuns={activeRuns}
+            initialContext={pendingNavContext}
+            onContextConsumed={clearPendingNavContext}
+          />
+        )}
+
+        {aiTerminalAlgos.length > 0 && (
+          <AiTerminalPanel
+            tabs={aiTerminalAlgos.map((a) => ({ algoId: a.id, algoName: a.name }))}
+            selectedAlgoId={tabs.activeTabId}
+            onSelectAlgo={(id) => {
+              const algo = algos.find((a) => a.id === id);
+              if (algo) tabs.openTab(algo);
+            }}
+            onClose={handleCloseAiTerminal}
+            onSpawnError={(algoId, error) => {
+              handleCloseAiTerminal(algoId);
+              if (error.includes("not found")) {
+                toast.error("Claude Code CLI not found. Install it with: npm install -g @anthropic-ai/claude-code");
+              } else {
+                toast.error("Failed to start AI terminal: " + error);
+              }
+            }}
+          />
+        )}
       </div>
 
       {venvReady === false && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { AlgosView } from "./views/AlgosView";
 import { TradingView } from "./views/TradingView";
 import { TitleBar } from "./components/TitleBar";
 import { ConfirmDialog } from "./components/ConfirmDialog";
+import { RenameDialog } from "./components/RenameDialog";
 import { AiTerminalPanel } from "./components/AiTerminalPanel";
 import { ToastContainer, toast } from "./components/Toast";
 import { useTradingSimulation } from "./hooks/useTradingSimulation";
@@ -173,6 +174,7 @@ export const App = () => {
   }, []);
 
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; confirmLabel?: string; onConfirm: () => void } | null>(null);
+  const [renameDialog, setRenameDialog] = useState<{ algoId: number; currentName: string } | null>(null);
 
   const handleNavigate = (view: View, options?: NavOptions) => {
     if (view === activeView && !options) return;
@@ -278,10 +280,7 @@ export const App = () => {
     if (activeId === null) return;
     const algo = algos.find((a) => a.id === activeId);
     if (!algo) return;
-    const newName = window.prompt("Rename algo", algo.name);
-    if (newName && newName.trim() && newName.trim() !== algo.name) {
-      handleRenameAlgo(activeId, newName.trim());
-    }
+    setRenameDialog({ algoId: activeId, currentName: algo.name });
   };
 
   const handleDeleteAlgo = (id: number) => {
@@ -473,6 +472,17 @@ export const App = () => {
           confirmLabel={confirmDialog.confirmLabel}
           onConfirm={confirmDialog.onConfirm}
           onCancel={() => setConfirmDialog(null)}
+        />
+      )}
+
+      {renameDialog !== null && (
+        <RenameDialog
+          currentName={renameDialog.currentName}
+          onRename={(newName) => {
+            handleRenameAlgo(renameDialog.algoId, newName);
+            setRenameDialog(null);
+          }}
+          onCancel={() => setRenameDialog(null)}
         />
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,6 +233,7 @@ export const App = () => {
       });
       setAlgos((prev) => [algo, ...prev]);
       tabs.openTab(algo);
+      setAiTerminalAlgoIds((prev) => new Set(prev).add(algo.id));
     } catch (e) {
       console.error("Failed to create algo:", e);
       toast.error("Failed to create algo: " + e);
@@ -299,23 +300,6 @@ export const App = () => {
       },
     });
   };
-
-  const handleCreateAlgoWithAi = useCallback(async () => {
-    try {
-      const name = `algo_${Date.now()}`;
-      const algo = await invoke<Algo>("create_algo", {
-        name,
-        code: DEFAULT_ALGO,
-        dependencies: "",
-      });
-      setAlgos((prev) => [algo, ...prev]);
-      tabs.openTab(algo);
-      setAiTerminalAlgoIds((prev) => new Set(prev).add(algo.id));
-    } catch (e) {
-      console.error("Failed to create algo:", e);
-      toast.error("Failed to create algo: " + e);
-    }
-  }, [tabs]);
 
   const handleOpenAiTerminal = useCallback((algoId: number) => {
     if (aiTerminalAlgoIds.has(algoId)) return;
@@ -401,7 +385,6 @@ export const App = () => {
             aiTerminalAlgoIds={aiTerminalAlgoIds}
             onSelectAlgo={handleSelectAlgo}
             onCreateAlgo={handleCreateAlgo}
-            onCreateAlgoWithAi={handleCreateAlgoWithAi}
             onOpenAiTerminal={handleOpenAiTerminal}
             onRequestCloseTab={handleRequestCloseTab}
             onRequestCloseMany={handleRequestCloseMany}

--- a/src/components/AlgoEditor.tsx
+++ b/src/components/AlgoEditor.tsx
@@ -66,11 +66,11 @@ export const AlgoEditor = ({
 
   return (
     <div
-      className="flex flex-col h-full"
+      className="flex flex-col h-full min-h-0"
       onKeyDown={handleKeyDown as unknown as React.KeyboardEventHandler}
     >
       {showDeps && (
-        <div className="px-4 py-3 border-b border-[var(--border)] bg-[var(--bg-secondary)]">
+        <div className="px-4 py-3 border-b border-[var(--border)] bg-[var(--bg-secondary)] flex-shrink-0">
           <label className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold block mb-1.5">
             Pip Dependencies
           </label>
@@ -86,7 +86,7 @@ export const AlgoEditor = ({
           </p>
         </div>
       )}
-      <div className="flex-1 p-0.5">
+      <div className="flex-1 min-h-0 p-0.5">
         <Editor
           height="100%"
           defaultLanguage="python"

--- a/src/components/AlgoEditor.tsx
+++ b/src/components/AlgoEditor.tsx
@@ -1,15 +1,19 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import Editor from "@monaco-editor/react";
+import type { Monaco } from "@monaco-editor/react";
+import { defineWolfDenTheme, WOLF_DEN_THEME } from "../lib/monacoTheme";
 
 type AlgoEditorProps = {
   code: string;
-  dependencies: string;
+  deps: string;
+  showDeps: boolean;
   onChange: (value: string) => void;
   onDepsChange: (value: string) => void;
   onSave: () => void;
+  onCursorChange: (line: number, col: number) => void;
 };
 
-const DEFAULT_ALGO = `from wolf_types import AlgoResult, market_buy, market_sell
+export const DEFAULT_ALGO = `from wolf_types import AlgoResult, market_buy, market_sell
 
 
 def create_algo():
@@ -26,11 +30,15 @@ def create_algo():
     return {'init': init, 'on_tick': on_tick}
 `;
 
-export { DEFAULT_ALGO };
-
-export const AlgoEditor = ({ code, dependencies, onChange, onDepsChange, onSave }: AlgoEditorProps) => {
-  const [showDeps, setShowDeps] = useState(false);
-
+export const AlgoEditor = ({
+  code,
+  deps,
+  showDeps,
+  onChange,
+  onDepsChange,
+  onSave,
+  onCursorChange,
+}: AlgoEditorProps) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "s") {
@@ -41,33 +49,26 @@ export const AlgoEditor = ({ code, dependencies, onChange, onDepsChange, onSave 
     [onSave],
   );
 
+  const beforeMount = useCallback((monaco: Monaco) => {
+    defineWolfDenTheme(monaco);
+  }, []);
+
+  const onMount = useCallback(
+    (editor: Parameters<NonNullable<React.ComponentProps<typeof Editor>["onMount"]>>[0]) => {
+      editor.onDidChangeCursorPosition((e) => {
+        onCursorChange(e.position.lineNumber, e.position.column);
+      });
+      const pos = editor.getPosition();
+      if (pos) onCursorChange(pos.lineNumber, pos.column);
+    },
+    [onCursorChange],
+  );
+
   return (
-    <div className="flex flex-col h-full" onKeyDown={handleKeyDown as unknown as React.KeyboardEventHandler}>
-      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)]">
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-            Algo Editor
-          </span>
-          <button
-            onClick={() => setShowDeps(!showDeps)}
-            className={`text-[10px] px-2 py-0.5 rounded-md font-medium transition-colors ${
-              showDeps
-                ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
-                : dependencies
-                  ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
-                  : "bg-[var(--bg-secondary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-            }`}
-          >
-            {dependencies ? `deps: ${dependencies.split(/\s+/).filter(Boolean).length}` : "deps"}
-          </button>
-        </div>
-        <button
-          onClick={onSave}
-          className="px-4 py-1.5 text-xs bg-[var(--accent-blue)] text-white rounded-md hover:opacity-90 transition-opacity"
-        >
-          Save
-        </button>
-      </div>
+    <div
+      className="flex flex-col h-full"
+      onKeyDown={handleKeyDown as unknown as React.KeyboardEventHandler}
+    >
       {showDeps && (
         <div className="px-4 py-3 border-b border-[var(--border)] bg-[var(--bg-secondary)]">
           <label className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold block mb-1.5">
@@ -75,7 +76,7 @@ export const AlgoEditor = ({ code, dependencies, onChange, onDepsChange, onSave 
           </label>
           <input
             type="text"
-            value={dependencies}
+            value={deps}
             onChange={(e) => onDepsChange(e.target.value)}
             placeholder="e.g. tensorflow pandas scikit-learn"
             className="w-full px-3 py-2 text-xs bg-[var(--bg-primary)] border border-[var(--border)] rounded-md text-[var(--text-primary)] placeholder:text-[var(--text-secondary)]/50 focus:outline-none focus:border-[var(--accent-blue)]/50"
@@ -89,7 +90,9 @@ export const AlgoEditor = ({ code, dependencies, onChange, onDepsChange, onSave 
         <Editor
           height="100%"
           defaultLanguage="python"
-          theme="vs-dark"
+          theme={WOLF_DEN_THEME}
+          beforeMount={beforeMount}
+          onMount={onMount}
           value={code}
           onChange={(value) => onChange(value ?? "")}
           options={{

--- a/src/components/AlgoManager.tsx
+++ b/src/components/AlgoManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { MoreHorizontal, Pencil, Plus, Search, Sparkles, Terminal, Trash2 } from "lucide-react";
+import { MoreHorizontal, Pencil, Plus, Search, Terminal, Trash2 } from "lucide-react";
 import type { Algo } from "../types";
 
 type AlgoManagerProps = {
@@ -8,7 +8,6 @@ type AlgoManagerProps = {
   dirtyAlgoIds?: Set<number>;
   onSelectAlgo: (id: number) => void;
   onCreateAlgo: () => void;
-  onCreateAlgoWithAi?: () => void;
   onOpenAiTerminal?: (algoId: number) => void;
   aiTerminalAlgoIds?: Set<number>;
   onDeleteAlgo: (id: number) => void;
@@ -21,7 +20,6 @@ export const AlgoManager = ({
   dirtyAlgoIds,
   onSelectAlgo,
   onCreateAlgo,
-  onCreateAlgoWithAi,
   onOpenAiTerminal,
   aiTerminalAlgoIds,
   onDeleteAlgo,
@@ -83,24 +81,13 @@ export const AlgoManager = ({
           <span className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
             Algos · {algos.length}
           </span>
-          <div className="flex items-center gap-1">
-            {onCreateAlgoWithAi && (
-              <button
-                onClick={onCreateAlgoWithAi}
-                title="New algo with AI"
-                className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
-              >
-                <Sparkles size={13} />
-              </button>
-            )}
-            <button
-              onClick={onCreateAlgo}
-              title="New algo"
-              className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
-            >
-              <Plus size={14} />
-            </button>
-          </div>
+          <button
+            onClick={onCreateAlgo}
+            title="New algo (opens AI terminal)"
+            className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
+          >
+            <Plus size={14} />
+          </button>
         </div>
         <div className="relative">
           <Search

--- a/src/components/AlgoManager.tsx
+++ b/src/components/AlgoManager.tsx
@@ -1,10 +1,11 @@
-
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MoreHorizontal, Pencil, Plus, Search, Sparkles, Terminal, Trash2 } from "lucide-react";
 import type { Algo } from "../types";
 
 type AlgoManagerProps = {
   algos: Algo[];
   selectedAlgoId: number | null;
+  dirtyAlgoIds?: Set<number>;
   onSelectAlgo: (id: number) => void;
   onCreateAlgo: () => void;
   onCreateAlgoWithAi?: () => void;
@@ -17,6 +18,7 @@ type AlgoManagerProps = {
 export const AlgoManager = ({
   algos,
   selectedAlgoId,
+  dirtyAlgoIds,
   onSelectAlgo,
   onCreateAlgo,
   onCreateAlgoWithAi,
@@ -27,7 +29,10 @@ export const AlgoManager = ({
 }: AlgoManagerProps) => {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingName, setEditingName] = useState("");
+  const [filter, setFilter] = useState("");
+  const [menuOpenId, setMenuOpenId] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (editingId !== null && inputRef.current) {
@@ -36,7 +41,19 @@ export const AlgoManager = ({
     }
   }, [editingId]);
 
+  useEffect(() => {
+    if (menuOpenId === null) return;
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        setMenuOpenId(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpenId]);
+
   const startRename = (algo: Algo) => {
+    setMenuOpenId(null);
     setEditingId(algo.id);
     setEditingName(algo.name);
   };
@@ -50,129 +67,189 @@ export const AlgoManager = ({
     setEditingId(null);
   };
 
-  const cancelRename = () => {
-    setEditingId(null);
-  };
+  const cancelRename = () => setEditingId(null);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return algos;
+    return algos.filter((a) => a.name.toLowerCase().includes(q));
+  }, [algos, filter]);
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)]">
-        <span className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-          Algo Manager
-        </span>
-        <div className="flex items-center gap-2">
-          {onCreateAlgoWithAi && (
+      <div className="px-4 py-3 border-b border-[var(--border)]">
+        <div className="flex items-center justify-between mb-2.5">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Algos · {algos.length}
+          </span>
+          <div className="flex items-center gap-1">
+            {onCreateAlgoWithAi && (
+              <button
+                onClick={onCreateAlgoWithAi}
+                title="New algo with AI"
+                className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
+              >
+                <Sparkles size={13} />
+              </button>
+            )}
             <button
-              onClick={onCreateAlgoWithAi}
-              className="px-3 py-1.5 text-xs bg-[var(--accent-blue)]/15 text-[var(--accent-blue)] rounded-md hover:bg-[var(--accent-blue)]/25 transition-colors font-medium"
+              onClick={onCreateAlgo}
+              title="New algo"
+              className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/10 transition-colors"
             >
-              + AI
+              <Plus size={14} />
             </button>
-          )}
-          <button
-            onClick={onCreateAlgo}
-            className="px-4 py-1.5 text-xs bg-[var(--accent-green)] text-black rounded-md hover:opacity-90 transition-opacity font-medium"
-          >
-            + New
-          </button>
+          </div>
+        </div>
+        <div className="relative">
+          <Search
+            size={12}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
+          />
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter algos…"
+            className="w-full bg-[var(--bg-secondary)] border border-transparent rounded-md pl-8 pr-2.5 py-1.5 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--border)]"
+          />
         </div>
       </div>
-      <div className="flex-1 overflow-auto">
+
+      <div className="flex-1 overflow-auto p-1.5">
         {algos.length === 0 ? (
           <div className="p-4 text-sm text-[var(--text-secondary)]">
-            No algos yet. Click "+ New" to create one.
+            No algos yet. Click <span className="inline-block align-middle"><Plus size={12} /></span> to create one.
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="p-4 text-sm text-[var(--text-secondary)]">
+            No algos match "{filter}".
           </div>
         ) : (
-          <div className="divide-y divide-[var(--border)]">
-            {algos.map((algo) => {
-              const isSelected = algo.id === selectedAlgoId;
-              const isEditing = editingId === algo.id;
+          filtered.map((algo) => {
+            const isSelected = algo.id === selectedAlgoId;
+            const isEditing = editingId === algo.id;
+            const isDirty = dirtyAlgoIds?.has(algo.id) ?? false;
+            const hasActiveTerminal = aiTerminalAlgoIds?.has(algo.id) ?? false;
+            const menuOpen = menuOpenId === algo.id;
 
-              const hasActiveTerminal = aiTerminalAlgoIds?.has(algo.id) ?? false;
-
-              return (
-                <div
-                  key={algo.id}
-                  onClick={() => onSelectAlgo(algo.id)}
-                  className={`group/algo flex items-center justify-between px-4 py-3 cursor-pointer transition-colors ${
-                    isSelected
-                      ? "bg-[var(--accent-blue)]/10 border-l-2 border-l-[var(--accent-blue)]"
-                      : "hover:bg-[var(--bg-secondary)]"
-                  }`}
-                >
-                  <div className="flex items-center gap-2 min-w-0 flex-1">
-                    {isEditing ? (
-                      <input
-                        ref={inputRef}
-                        value={editingName}
-                        onChange={(e) => setEditingName(e.target.value)}
-                        onBlur={commitRename}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") commitRename();
-                          if (e.key === "Escape") cancelRename();
-                        }}
-                        onClick={(e) => e.stopPropagation()}
-                        className="text-sm bg-[var(--bg-primary)] text-[var(--text-primary)] border border-[var(--accent-blue)] rounded px-2 py-0.5 outline-none w-full min-w-0"
-                      />
-                    ) : (
-                      <span className="text-sm truncate">
-                        {algo.name}
-                      </span>
-                    )}
-                    {hasActiveTerminal && (
-                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse flex-shrink-0" title="AI terminal active" />
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover/algo:opacity-100 transition-opacity">
-                    {!isEditing && onOpenAiTerminal && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSelectAlgo(algo.id);
-                          onOpenAiTerminal(algo.id);
-                        }}
-                        disabled={hasActiveTerminal}
-                        className={`px-2 py-1 text-[11px] transition-colors ${
-                          hasActiveTerminal
-                            ? "text-[var(--accent-blue)]/50 cursor-not-allowed"
-                            : "text-[var(--text-secondary)] hover:text-[var(--accent-blue)]"
-                        }`}
-                      >
-                        AI
-                      </button>
-                    )}
-                    {!isEditing && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSelectAlgo(algo.id);
-                          startRename(algo);
-                        }}
-                        className="px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:text-[var(--accent-blue)] transition-colors"
-                      >
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-                          <path d="m15 5 4 4" />
-                        </svg>
-                      </button>
-                    )}
+            return (
+              <div
+                key={algo.id}
+                onClick={() => !isEditing && onSelectAlgo(algo.id)}
+                className={`group/algo relative flex items-center justify-between px-2.5 py-2 rounded-md cursor-pointer transition-colors ${
+                  isSelected
+                    ? "bg-[var(--accent-blue)]/10 text-[var(--text-primary)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  {isDirty && !isEditing && (
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-yellow)] flex-shrink-0"
+                      title="Unsaved"
+                    />
+                  )}
+                  {isEditing ? (
+                    <input
+                      ref={inputRef}
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename();
+                        if (e.key === "Escape") cancelRename();
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      className="text-sm bg-[var(--bg-primary)] text-[var(--text-primary)] border border-[var(--accent-blue)] rounded px-2 py-0.5 outline-none w-full min-w-0"
+                    />
+                  ) : (
+                    <span className="text-sm truncate">{algo.name}</span>
+                  )}
+                  {hasActiveTerminal && !isEditing && (
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse flex-shrink-0"
+                      title="AI terminal active"
+                    />
+                  )}
+                </div>
+                {!isEditing && (
+                  <div className="relative flex-shrink-0">
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        onSelectAlgo(algo.id);
-                        onDeleteAlgo(algo.id);
+                        setMenuOpenId(menuOpen ? null : algo.id);
                       }}
-                      className="px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:text-[var(--accent-red)] transition-colors"
+                      className="w-6 h-6 inline-flex items-center justify-center rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors"
+                      title="More actions"
                     >
-                      x
+                      <MoreHorizontal size={13} />
                     </button>
+                    {menuOpen && (
+                      <div
+                        ref={menuRef}
+                        className="absolute right-0 top-full mt-1 z-30 w-44 bg-[var(--bg-elevated)] border border-[var(--border)] rounded-md shadow-xl py-1 text-xs"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <MenuRow
+                          icon={<Pencil size={11} />}
+                          label="Rename"
+                          onClick={() => startRename(algo)}
+                        />
+                        {onOpenAiTerminal && (
+                          <MenuRow
+                            icon={<Terminal size={11} />}
+                            label="AI terminal"
+                            disabled={hasActiveTerminal}
+                            onClick={() => {
+                              setMenuOpenId(null);
+                              onSelectAlgo(algo.id);
+                              onOpenAiTerminal(algo.id);
+                            }}
+                          />
+                        )}
+                        <div className="h-px bg-[var(--border)] my-1" />
+                        <MenuRow
+                          icon={<Trash2 size={11} />}
+                          label="Delete"
+                          danger
+                          onClick={() => {
+                            setMenuOpenId(null);
+                            onSelectAlgo(algo.id);
+                            onDeleteAlgo(algo.id);
+                          }}
+                        />
+                      </div>
+                    )}
                   </div>
-                </div>
-              );
-            })}
-          </div>
+                )}
+              </div>
+            );
+          })
         )}
       </div>
     </div>
   );
 };
+
+type MenuRowProps = {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+};
+
+const MenuRow = ({ icon, label, onClick, disabled, danger }: MenuRowProps) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`w-full flex items-center gap-2 px-3 py-1.5 text-left transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+      danger
+        ? "text-[var(--accent-red)] hover:bg-[var(--accent-red)]/10"
+        : "text-[var(--text-primary)] hover:bg-[var(--bg-panel)]"
+    }`}
+  >
+    <span className="text-[var(--text-muted)]">{icon}</span>
+    <span>{label}</span>
+  </button>
+);

--- a/src/components/AlgoManager.tsx
+++ b/src/components/AlgoManager.tsx
@@ -33,7 +33,6 @@ export const AlgoManager = ({
   const [menuOpenId, setMenuOpenId] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (editingId !== null && inputRef.current) {
@@ -45,12 +44,10 @@ export const AlgoManager = ({
   useEffect(() => {
     if (menuOpenId === null) return;
     const handler = (e: MouseEvent) => {
-      if (
-        !menuRef.current?.contains(e.target as Node) &&
-        !menuButtonRef.current?.contains(e.target as Node)
-      ) {
-        setMenuOpenId(null);
-      }
+      const target = e.target as Element | null;
+      if (menuRef.current?.contains(target as Node)) return;
+      if (target?.closest("[data-menu-button]")) return;
+      setMenuOpenId(null);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
@@ -179,7 +176,7 @@ export const AlgoManager = ({
                 {!isEditing && (
                   <div className="relative flex-shrink-0">
                     <button
-                      ref={menuButtonRef}
+                      data-menu-button
                       onClick={(e) => {
                         e.stopPropagation();
                         setMenuOpenId(menuOpen ? null : algo.id);

--- a/src/components/AlgoManager.tsx
+++ b/src/components/AlgoManager.tsx
@@ -33,6 +33,7 @@ export const AlgoManager = ({
   const [menuOpenId, setMenuOpenId] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (editingId !== null && inputRef.current) {
@@ -44,7 +45,10 @@ export const AlgoManager = ({
   useEffect(() => {
     if (menuOpenId === null) return;
     const handler = (e: MouseEvent) => {
-      if (!menuRef.current?.contains(e.target as Node)) {
+      if (
+        !menuRef.current?.contains(e.target as Node) &&
+        !menuButtonRef.current?.contains(e.target as Node)
+      ) {
         setMenuOpenId(null);
       }
     };
@@ -175,6 +179,7 @@ export const AlgoManager = ({
                 {!isEditing && (
                   <div className="relative flex-shrink-0">
                     <button
+                      ref={menuButtonRef}
                       onClick={(e) => {
                         e.stopPropagation();
                         setMenuOpenId(menuOpen ? null : algo.id);

--- a/src/components/EditorStatusBar.tsx
+++ b/src/components/EditorStatusBar.tsx
@@ -1,0 +1,57 @@
+type EditorStatusBarProps = {
+  isDirty: boolean;
+  depsCount: number;
+  cursorLine: number;
+  cursorCol: number;
+  onSave: () => void;
+  onToggleDeps: () => void;
+};
+
+export const EditorStatusBar = ({
+  isDirty,
+  depsCount,
+  cursorLine,
+  cursorCol,
+  onSave,
+  onToggleDeps,
+}: EditorStatusBarProps) => {
+  return (
+    <div className="flex items-center justify-between h-[26px] px-4 border-t border-[var(--border)] bg-[var(--bg-panel)] text-[11px] text-[var(--text-secondary)] select-none">
+      {/* Left group */}
+      <div className="flex items-center gap-4">
+        {isDirty ? (
+          <button
+            onClick={onSave}
+            className="flex items-center gap-2 px-1 -mx-1 rounded hover:bg-[var(--bg-secondary)] transition-colors text-[var(--accent-yellow)]"
+            title="Save changes"
+          >
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-yellow)]" />
+            <span>Unsaved · ⌘S</span>
+          </button>
+        ) : (
+          <span className="flex items-center gap-2">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-green)]" />
+            <span>Saved</span>
+          </span>
+        )}
+        <span className="text-[var(--text-muted)]">Python 3.11</span>
+        <button
+          onClick={onToggleDeps}
+          className="px-1 -mx-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-secondary)] transition-colors"
+          title="Toggle dependencies"
+        >
+          deps: {depsCount}
+        </button>
+      </div>
+
+      {/* Right group */}
+      <div className="flex items-center gap-4 text-[var(--text-muted)]">
+        <span>
+          Ln {cursorLine}, Col {cursorCol}
+        </span>
+        <span>Spaces: 4</span>
+        <span>UTF-8</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/EditorTabs.tsx
+++ b/src/components/EditorTabs.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from "react";
+import { MoreHorizontal, Plus, Sparkles, X } from "lucide-react";
+
+export type EditorTab = {
+  id: number;
+  name: string;
+  isDirty: boolean;
+  hasAiTerminal: boolean;
+};
+
+type EditorTabsProps = {
+  tabs: EditorTab[];
+  activeTabId: number | null;
+  onSelect: (id: number) => void;
+  onClose: (id: number) => void;
+  onCreateAlgo: () => void;
+  onCreateAlgoWithAi: () => void;
+  onRenameActive: () => void;
+  onDeleteActive: () => void;
+  onCloseOthers: (id: number) => void;
+  onCloseAll: () => void;
+};
+
+export const EditorTabs = ({
+  tabs,
+  activeTabId,
+  onSelect,
+  onClose,
+  onCreateAlgo,
+  onCreateAlgoWithAi,
+  onRenameActive,
+  onDeleteActive,
+  onCloseOthers,
+  onCloseAll,
+}: EditorTabsProps) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  const menuAction = (fn: () => void) => () => {
+    setMenuOpen(false);
+    fn();
+  };
+
+  return (
+    <div className="flex items-stretch h-[38px] bg-[var(--bg-secondary)] border-b border-[var(--border)]">
+      <div className="flex items-stretch overflow-x-auto flex-1 min-w-0">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              onClick={() => onSelect(tab.id)}
+              className={`group/tab relative flex items-center gap-2 px-3 text-xs cursor-pointer flex-shrink-0 border-r border-[var(--border)] transition-colors ${
+                isActive
+                  ? "bg-[var(--bg-panel)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)]/30"
+              }`}
+            >
+              {isActive && (
+                <span className="absolute top-0 left-0 right-0 h-[2px] bg-[var(--accent-blue)]" />
+              )}
+              <span className="inline-flex items-center justify-center w-[14px] h-[14px] rounded-[3px] bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)] text-[9px] font-bold flex-shrink-0">
+                Py
+              </span>
+              <span className="max-w-[180px] truncate">{tab.name}</span>
+              {tab.hasAiTerminal && (
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse flex-shrink-0"
+                  title="AI terminal active"
+                />
+              )}
+              {tab.isDirty && !tab.hasAiTerminal && (
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-yellow)] flex-shrink-0 group-hover/tab:hidden"
+                  title="Unsaved"
+                />
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(tab.id);
+                }}
+                className="inline-flex items-center justify-center w-4 h-4 rounded opacity-0 group-hover/tab:opacity-100 hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] transition-opacity flex-shrink-0"
+                title="Close tab"
+              >
+                <X size={10} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-1 px-2 flex-shrink-0 border-l border-[var(--border)]">
+        <button
+          onClick={onCreateAlgo}
+          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors"
+          title="New algo"
+        >
+          <Plus size={14} />
+        </button>
+        <button
+          onClick={onCreateAlgoWithAi}
+          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--accent-blue)] hover:bg-[var(--bg-panel)] transition-colors"
+          title="New algo with AI"
+        >
+          <Sparkles size={13} />
+        </button>
+        <div ref={menuRef} className="relative">
+          <button
+            onClick={() => setMenuOpen((v) => !v)}
+            disabled={activeTabId === null}
+            className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            title="More actions"
+          >
+            <MoreHorizontal size={14} />
+          </button>
+          {menuOpen && activeTabId !== null && (
+            <div className="absolute right-0 top-full mt-1 z-30 w-44 bg-[var(--bg-elevated)] border border-[var(--border)] rounded-md shadow-xl py-1 text-xs">
+              <MenuItem label="Rename" onClick={menuAction(onRenameActive)} />
+              <MenuItem
+                label="Close others"
+                onClick={menuAction(() => onCloseOthers(activeTabId))}
+                disabled={tabs.length < 2}
+              />
+              <MenuItem
+                label="Close all"
+                onClick={menuAction(onCloseAll)}
+              />
+              <div className="h-px bg-[var(--border)] my-1" />
+              <MenuItem
+                label="Delete algo"
+                onClick={menuAction(onDeleteActive)}
+                danger
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type MenuItemProps = {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+};
+
+const MenuItem = ({ label, onClick, disabled, danger }: MenuItemProps) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`w-full text-left px-3 py-1.5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+      danger
+        ? "text-[var(--accent-red)] hover:bg-[var(--accent-red)]/10"
+        : "text-[var(--text-primary)] hover:bg-[var(--bg-panel)]"
+    }`}
+  >
+    {label}
+  </button>
+);

--- a/src/components/EditorTabs.tsx
+++ b/src/components/EditorTabs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { MoreHorizontal, Plus, Sparkles, X } from "lucide-react";
+import { MoreHorizontal, Sparkles, X } from "lucide-react";
 
 export type EditorTab = {
   id: number;
@@ -13,8 +13,7 @@ type EditorTabsProps = {
   activeTabId: number | null;
   onSelect: (id: number) => void;
   onClose: (id: number) => void;
-  onCreateAlgo: () => void;
-  onCreateAlgoWithAi: () => void;
+  onOpenAiTerminalForActive: () => void;
   onRenameActive: () => void;
   onDeleteActive: () => void;
   onCloseOthers: (id: number) => void;
@@ -26,13 +25,14 @@ export const EditorTabs = ({
   activeTabId,
   onSelect,
   onClose,
-  onCreateAlgo,
-  onCreateAlgoWithAi,
+  onOpenAiTerminalForActive,
   onRenameActive,
   onDeleteActive,
   onCloseOthers,
   onCloseAll,
 }: EditorTabsProps) => {
+  const activeTab = activeTabId !== null ? tabs.find((t) => t.id === activeTabId) : null;
+  const activeHasAiTerminal = activeTab?.hasAiTerminal ?? false;
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -103,16 +103,16 @@ export const EditorTabs = ({
 
       <div className="flex items-center gap-1 px-2 flex-shrink-0 border-l border-[var(--border)]">
         <button
-          onClick={onCreateAlgo}
-          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel)] transition-colors"
-          title="New algo"
-        >
-          <Plus size={14} />
-        </button>
-        <button
-          onClick={onCreateAlgoWithAi}
-          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--accent-blue)] hover:bg-[var(--bg-panel)] transition-colors"
-          title="New algo with AI"
+          onClick={onOpenAiTerminalForActive}
+          disabled={activeTabId === null || activeHasAiTerminal}
+          className="w-7 h-7 inline-flex items-center justify-center rounded-md text-[var(--text-secondary)] hover:text-[var(--accent-blue)] hover:bg-[var(--bg-panel)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-[var(--text-secondary)] disabled:hover:bg-transparent"
+          title={
+            activeTabId === null
+              ? "Open AI terminal (select an algo first)"
+              : activeHasAiTerminal
+                ? "AI terminal already open for this algo"
+                : "Open AI terminal for this algo"
+          }
         >
           <Sparkles size={13} />
         </button>

--- a/src/components/RenameDialog.tsx
+++ b/src/components/RenameDialog.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from "react";
+
+type RenameDialogProps = {
+  currentName: string;
+  onRename: (newName: string) => void;
+  onCancel: () => void;
+};
+
+export const RenameDialog = ({ currentName, onRename, onCancel }: RenameDialogProps) => {
+  const [value, setValue] = useState(currentName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const commit = () => {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === currentName) {
+      onCancel();
+      return;
+    }
+    onRename(trimmed);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-[var(--bg-panel)] border border-[var(--border)] rounded-lg p-6 max-w-sm w-full mx-4 shadow-xl">
+        <label className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-semibold block mb-2">
+          Rename algo
+        </label>
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit();
+            if (e.key === "Escape") onCancel();
+          }}
+          className="w-full px-3 py-2 text-sm bg-[var(--bg-primary)] border border-[var(--border)] rounded-md text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-blue)] mb-6"
+        />
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-xs text-[var(--text-secondary)] bg-[var(--bg-secondary)] rounded-md hover:opacity-90 transition-opacity"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={commit}
+            className="px-4 py-2 text-xs bg-[var(--accent-blue)] text-white rounded-md hover:opacity-90 transition-opacity"
+          >
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,63 +32,60 @@ const openGuideWindow = async () => {
 };
 
 export const Sidebar = ({ activeView, onNavigate, connectionStatus }: SidebarProps) => {
+  const statusTitle =
+    connectionStatus === "connected"
+      ? "NinjaTrader Connected"
+      : connectionStatus === "error"
+        ? "Connection Error"
+        : "Waiting for NinjaTrader...";
+
   return (
-    <div className="flex flex-col w-20 bg-[var(--bg-secondary)] border-r border-[var(--border)] select-none">
+    <div className="relative flex flex-col w-[52px] bg-[var(--bg-secondary)] border-r border-[var(--border)] select-none">
       {/* Logo */}
-      <div className="flex items-center justify-center h-20 border-b border-[var(--border)] p-1">
-        <img src="/wolf-den-logo.svg" alt="Wolf Den" className="w-full h-full object-contain" />
+      <div className="flex items-center justify-center h-12 border-b border-[var(--border)] p-1.5">
+        <img src="/wolf-den-logo.svg" alt="Wolf Den" className="w-8 h-8 object-contain" />
       </div>
 
       {/* Nav Items */}
-      <nav className="flex-1 flex flex-col items-center pt-6 gap-4">
+      <nav className="flex-1 flex flex-col items-center pt-3 gap-1">
         {NAV_ITEMS.map(({ view, label, icon }) => (
           <button
             key={view}
             onClick={() => onNavigate(view)}
-            className={`flex flex-col items-center justify-center w-14 h-14 rounded-xl transition-colors ${
+            title={label}
+            className={`flex items-center justify-center w-9 h-9 rounded-lg transition-colors ${
               activeView === view
                 ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
                 : "text-[var(--text-secondary)] hover:bg-[var(--bg-panel)] hover:text-[var(--text-primary)]"
             }`}
-            title={label}
           >
-            <span className="text-lg leading-none">{icon}</span>
-            <span className="text-[9px] mt-1.5 font-medium uppercase tracking-wider">{label}</span>
+            <span className="text-base leading-none">{icon}</span>
           </button>
         ))}
       </nav>
 
       {/* Guide (bottom) */}
-      <div className="flex flex-col items-center pb-4 gap-4">
+      <div className="flex flex-col items-center pb-2 gap-1">
         <button
           onClick={openGuideWindow}
-          className="flex flex-col items-center justify-center w-14 h-14 rounded-xl transition-colors text-[var(--text-secondary)] hover:bg-[var(--bg-panel)] hover:text-[var(--text-primary)]"
           title="Guide"
+          className="flex items-center justify-center w-9 h-9 rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--bg-panel)] hover:text-[var(--text-primary)]"
         >
-          <span className="text-lg leading-none">?</span>
-          <span className="text-[9px] mt-1.5 font-medium uppercase tracking-wider">Guide</span>
+          <span className="text-base leading-none">?</span>
         </button>
       </div>
 
-      {/* Connection Status */}
-      <div className="flex items-center justify-center pb-6">
-        <div
-          className={`w-3 h-3 rounded-full ${
-            connectionStatus === "connected"
-              ? "bg-[var(--accent-green)]"
-              : connectionStatus === "error"
-                ? "bg-[var(--accent-red)]"
-                : "bg-[var(--accent-yellow)] animate-pulse"
-          }`}
-          title={
-            connectionStatus === "connected"
-              ? "NinjaTrader Connected"
-              : connectionStatus === "error"
-                ? "Connection Error"
-                : "Waiting for NinjaTrader..."
-          }
-        />
-      </div>
+      {/* Connection Status — bottom-right corner */}
+      <div
+        title={statusTitle}
+        className={`absolute bottom-2 right-2 w-2 h-2 rounded-full ${
+          connectionStatus === "connected"
+            ? "bg-[var(--accent-green)]"
+            : connectionStatus === "error"
+              ? "bg-[var(--accent-red)]"
+              : "bg-[var(--accent-yellow)] animate-pulse"
+        }`}
+      />
     </div>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -40,7 +40,7 @@ export const Sidebar = ({ activeView, onNavigate, connectionStatus }: SidebarPro
         : "Waiting for NinjaTrader...";
 
   return (
-    <div className="relative flex flex-col w-[52px] bg-[var(--bg-secondary)] border-r border-[var(--border)] select-none">
+    <div className="flex flex-col w-[52px] bg-[var(--bg-secondary)] border-r border-[var(--border)] select-none">
       {/* Logo */}
       <div className="flex items-center justify-center h-12 border-b border-[var(--border)] p-1.5">
         <img src="/wolf-den-logo.svg" alt="Wolf Den" className="w-8 h-8 object-contain" />
@@ -64,8 +64,8 @@ export const Sidebar = ({ activeView, onNavigate, connectionStatus }: SidebarPro
         ))}
       </nav>
 
-      {/* Guide (bottom) */}
-      <div className="flex flex-col items-center pb-2 gap-1">
+      {/* Guide + Connection Status (bottom, centered) */}
+      <div className="flex flex-col items-center pb-3 gap-2">
         <button
           onClick={openGuideWindow}
           title="Guide"
@@ -73,19 +73,17 @@ export const Sidebar = ({ activeView, onNavigate, connectionStatus }: SidebarPro
         >
           <span className="text-base leading-none">?</span>
         </button>
+        <div
+          title={statusTitle}
+          className={`w-2 h-2 rounded-full ${
+            connectionStatus === "connected"
+              ? "bg-[var(--accent-green)]"
+              : connectionStatus === "error"
+                ? "bg-[var(--accent-red)]"
+                : "bg-[var(--accent-yellow)] animate-pulse"
+          }`}
+        />
       </div>
-
-      {/* Connection Status — bottom-right corner */}
-      <div
-        title={statusTitle}
-        className={`absolute bottom-2 right-2 w-2 h-2 rounded-full ${
-          connectionStatus === "connected"
-            ? "bg-[var(--accent-green)]"
-            : connectionStatus === "error"
-              ? "bg-[var(--accent-red)]"
-              : "bg-[var(--accent-yellow)] animate-pulse"
-        }`}
-      />
     </div>
   );
 };

--- a/src/hooks/useEditorTabs.ts
+++ b/src/hooks/useEditorTabs.ts
@@ -1,0 +1,210 @@
+import { useCallback, useMemo, useState } from "react";
+import type { Algo } from "../types";
+
+export type TabBuffer = {
+  code: string;
+  deps: string;
+  savedCode: string;
+  savedDeps: string;
+};
+
+type State = {
+  openTabIds: number[];
+  activeTabId: number | null;
+  buffers: Record<number, TabBuffer>;
+};
+
+const EMPTY: State = {
+  openTabIds: [],
+  activeTabId: null,
+  buffers: {},
+};
+
+export type UseEditorTabs = ReturnType<typeof useEditorTabs>;
+
+export const useEditorTabs = () => {
+  const [state, setState] = useState<State>(EMPTY);
+
+  const isDirty = useCallback(
+    (id: number): boolean => {
+      const b = state.buffers[id];
+      if (!b) return false;
+      return b.code !== b.savedCode || b.deps !== b.savedDeps;
+    },
+    [state.buffers],
+  );
+
+  const hasAnyDirty = useMemo(
+    () => state.openTabIds.some((id) => {
+      const b = state.buffers[id];
+      return !!b && (b.code !== b.savedCode || b.deps !== b.savedDeps);
+    }),
+    [state.openTabIds, state.buffers],
+  );
+
+  const openTab = useCallback((algo: Algo) => {
+    setState((s) => {
+      const alreadyOpen = s.openTabIds.includes(algo.id);
+      if (alreadyOpen) {
+        return { ...s, activeTabId: algo.id };
+      }
+      return {
+        openTabIds: [...s.openTabIds, algo.id],
+        activeTabId: algo.id,
+        buffers: {
+          ...s.buffers,
+          [algo.id]: {
+            code: algo.code,
+            deps: algo.dependencies,
+            savedCode: algo.code,
+            savedDeps: algo.dependencies,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const switchTab = useCallback((id: number) => {
+    setState((s) => (s.openTabIds.includes(id) ? { ...s, activeTabId: id } : s));
+  }, []);
+
+  const pickNextActive = (openTabIds: number[], closingId: number): number | null => {
+    const idx = openTabIds.indexOf(closingId);
+    if (idx === -1) return null;
+    // right neighbor
+    if (idx + 1 < openTabIds.length) return openTabIds[idx + 1];
+    // left neighbor
+    if (idx - 1 >= 0) return openTabIds[idx - 1];
+    return null;
+  };
+
+  const forceCloseTab = useCallback((id: number) => {
+    setState((s) => {
+      if (!s.openTabIds.includes(id)) return s;
+      const nextOpen = s.openTabIds.filter((x) => x !== id);
+      const nextActive =
+        s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
+      const { [id]: _removed, ...nextBuffers } = s.buffers;
+      return {
+        openTabIds: nextOpen,
+        activeTabId: nextActive,
+        buffers: nextBuffers,
+      };
+    });
+  }, []);
+
+  const closeTab = useCallback(
+    (id: number): { dirty: boolean } => {
+      const dirty = isDirty(id);
+      if (!dirty) {
+        forceCloseTab(id);
+      }
+      return { dirty };
+    },
+    [isDirty, forceCloseTab],
+  );
+
+  const updateCode = useCallback((code: string) => {
+    setState((s) => {
+      if (s.activeTabId === null) return s;
+      const b = s.buffers[s.activeTabId];
+      if (!b) return s;
+      return {
+        ...s,
+        buffers: { ...s.buffers, [s.activeTabId]: { ...b, code } },
+      };
+    });
+  }, []);
+
+  const updateDeps = useCallback((deps: string) => {
+    setState((s) => {
+      if (s.activeTabId === null) return s;
+      const b = s.buffers[s.activeTabId];
+      if (!b) return s;
+      return {
+        ...s,
+        buffers: { ...s.buffers, [s.activeTabId]: { ...b, deps } },
+      };
+    });
+  }, []);
+
+  const markActiveSaved = useCallback(() => {
+    setState((s) => {
+      if (s.activeTabId === null) return s;
+      const b = s.buffers[s.activeTabId];
+      if (!b) return s;
+      return {
+        ...s,
+        buffers: {
+          ...s.buffers,
+          [s.activeTabId]: { ...b, savedCode: b.code, savedDeps: b.deps },
+        },
+      };
+    });
+  }, []);
+
+  const onAlgoDeleted = useCallback((id: number) => {
+    setState((s) => {
+      if (!s.openTabIds.includes(id)) return s;
+      const nextOpen = s.openTabIds.filter((x) => x !== id);
+      const nextActive =
+        s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
+      const { [id]: _removed, ...nextBuffers } = s.buffers;
+      return {
+        openTabIds: nextOpen,
+        activeTabId: nextActive,
+        buffers: nextBuffers,
+      };
+    });
+  }, []);
+
+  type ExternalUpdateResult = { synced: boolean; conflicted: boolean };
+
+  const onAlgoExternallyUpdated = useCallback(
+    (id: number, code: string, deps: string): ExternalUpdateResult => {
+      let result: ExternalUpdateResult = { synced: false, conflicted: false };
+      setState((s) => {
+        const b = s.buffers[id];
+        if (!b) {
+          result = { synced: false, conflicted: false };
+          return s;
+        }
+        const dirty = b.code !== b.savedCode || b.deps !== b.savedDeps;
+        if (dirty) {
+          result = { synced: false, conflicted: true };
+          return s;
+        }
+        result = { synced: true, conflicted: false };
+        return {
+          ...s,
+          buffers: {
+            ...s.buffers,
+            [id]: { code, deps, savedCode: code, savedDeps: deps },
+          },
+        };
+      });
+      return result;
+    },
+    [],
+  );
+
+  const activeBuffer = state.activeTabId !== null ? state.buffers[state.activeTabId] : null;
+
+  return {
+    openTabIds: state.openTabIds,
+    activeTabId: state.activeTabId,
+    activeCode: activeBuffer?.code ?? "",
+    activeDeps: activeBuffer?.deps ?? "",
+    isDirty,
+    hasAnyDirty,
+    openTab,
+    switchTab,
+    closeTab,
+    forceCloseTab,
+    updateCode,
+    updateDeps,
+    markActiveSaved,
+    onAlgoDeleted,
+    onAlgoExternallyUpdated,
+  };
+};

--- a/src/hooks/useEditorTabs.ts
+++ b/src/hooks/useEditorTabs.ts
@@ -146,6 +146,10 @@ export const useEditorTabs = () => {
     setState((s) => removeTab(s, id));
   }, []);
 
+  // Reads state.buffers via closure (not functional updater) so the caller can
+  // branch on the result synchronously. Tradeoff: a Tauri event arriving during
+  // the micro-gap before tabsRef syncs could read one-render-stale buffers. Accepted
+  // for v1 — narrow window, non-catastrophic outcome.
   const onAlgoExternallyUpdated = useCallback(
     (id: number, code: string, deps: string): ExternalUpdateResult => {
       const b = state.buffers[id];

--- a/src/hooks/useEditorTabs.ts
+++ b/src/hooks/useEditorTabs.ts
@@ -8,6 +8,8 @@ export type TabBuffer = {
   savedDeps: string;
 };
 
+type ExternalUpdateResult = { synced: boolean; conflicted: boolean };
+
 type State = {
   openTabIds: number[];
   activeTabId: number | null;
@@ -18,6 +20,24 @@ const EMPTY: State = {
   openTabIds: [],
   activeTabId: null,
   buffers: {},
+};
+
+const pickNextActive = (openTabIds: number[], closingId: number): number | null => {
+  const idx = openTabIds.indexOf(closingId);
+  if (idx === -1) return null;
+  // right neighbor
+  if (idx + 1 < openTabIds.length) return openTabIds[idx + 1];
+  // left neighbor
+  if (idx - 1 >= 0) return openTabIds[idx - 1];
+  return null;
+};
+
+const removeTab = (s: State, id: number): State => {
+  if (!s.openTabIds.includes(id)) return s;
+  const nextOpen = s.openTabIds.filter((x) => x !== id);
+  const nextActive = s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
+  const { [id]: _removed, ...nextBuffers } = s.buffers;
+  return { openTabIds: nextOpen, activeTabId: nextActive, buffers: nextBuffers };
 };
 
 export type UseEditorTabs = ReturnType<typeof useEditorTabs>;
@@ -68,29 +88,8 @@ export const useEditorTabs = () => {
     setState((s) => (s.openTabIds.includes(id) ? { ...s, activeTabId: id } : s));
   }, []);
 
-  const pickNextActive = (openTabIds: number[], closingId: number): number | null => {
-    const idx = openTabIds.indexOf(closingId);
-    if (idx === -1) return null;
-    // right neighbor
-    if (idx + 1 < openTabIds.length) return openTabIds[idx + 1];
-    // left neighbor
-    if (idx - 1 >= 0) return openTabIds[idx - 1];
-    return null;
-  };
-
   const forceCloseTab = useCallback((id: number) => {
-    setState((s) => {
-      if (!s.openTabIds.includes(id)) return s;
-      const nextOpen = s.openTabIds.filter((x) => x !== id);
-      const nextActive =
-        s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
-      const { [id]: _removed, ...nextBuffers } = s.buffers;
-      return {
-        openTabIds: nextOpen,
-        activeTabId: nextActive,
-        buffers: nextBuffers,
-      };
-    });
+    setState((s) => removeTab(s, id));
   }, []);
 
   const closeTab = useCallback(
@@ -144,48 +143,25 @@ export const useEditorTabs = () => {
   }, []);
 
   const onAlgoDeleted = useCallback((id: number) => {
-    setState((s) => {
-      if (!s.openTabIds.includes(id)) return s;
-      const nextOpen = s.openTabIds.filter((x) => x !== id);
-      const nextActive =
-        s.activeTabId === id ? pickNextActive(s.openTabIds, id) : s.activeTabId;
-      const { [id]: _removed, ...nextBuffers } = s.buffers;
-      return {
-        openTabIds: nextOpen,
-        activeTabId: nextActive,
-        buffers: nextBuffers,
-      };
-    });
+    setState((s) => removeTab(s, id));
   }, []);
-
-  type ExternalUpdateResult = { synced: boolean; conflicted: boolean };
 
   const onAlgoExternallyUpdated = useCallback(
     (id: number, code: string, deps: string): ExternalUpdateResult => {
-      let result: ExternalUpdateResult = { synced: false, conflicted: false };
-      setState((s) => {
-        const b = s.buffers[id];
-        if (!b) {
-          result = { synced: false, conflicted: false };
-          return s;
-        }
-        const dirty = b.code !== b.savedCode || b.deps !== b.savedDeps;
-        if (dirty) {
-          result = { synced: false, conflicted: true };
-          return s;
-        }
-        result = { synced: true, conflicted: false };
-        return {
-          ...s,
-          buffers: {
-            ...s.buffers,
-            [id]: { code, deps, savedCode: code, savedDeps: deps },
-          },
-        };
-      });
-      return result;
+      const b = state.buffers[id];
+      if (!b) return { synced: false, conflicted: false };
+      const dirty = b.code !== b.savedCode || b.deps !== b.savedDeps;
+      if (dirty) return { synced: false, conflicted: true };
+      setState((s) => ({
+        ...s,
+        buffers: {
+          ...s.buffers,
+          [id]: { code, deps, savedCode: code, savedDeps: deps },
+        },
+      }));
+      return { synced: true, conflicted: false };
     },
-    [],
+    [state.buffers],
   );
 
   const activeBuffer = state.activeTabId !== null ? state.buffers[state.activeTabId] : null;

--- a/src/lib/monacoTheme.ts
+++ b/src/lib/monacoTheme.ts
@@ -1,0 +1,43 @@
+import type { Monaco } from "@monaco-editor/react";
+
+export const WOLF_DEN_THEME = "wolf-den-dark";
+
+export const defineWolfDenTheme = (monaco: Monaco): void => {
+  monaco.editor.defineTheme(WOLF_DEN_THEME, {
+    base: "vs-dark",
+    inherit: true,
+    rules: [
+      { token: "keyword", foreground: "c792ea" },
+      { token: "keyword.flow", foreground: "c792ea" },
+      { token: "operator", foreground: "89ddff" },
+      { token: "delimiter", foreground: "89ddff" },
+      { token: "string", foreground: "c3e88d" },
+      { token: "string.escape", foreground: "c3e88d" },
+      { token: "number", foreground: "f78c6c" },
+      { token: "comment", foreground: "546e7a", fontStyle: "italic" },
+      { token: "type", foreground: "ffcb6b" },
+      { token: "type.identifier", foreground: "ffcb6b" },
+      { token: "identifier", foreground: "e0e0e8" },
+      { token: "keyword.python", foreground: "c792ea" },
+      { token: "function", foreground: "82aaff" },
+      { token: "function.call", foreground: "82aaff" },
+      { token: "identifier.function", foreground: "82aaff" },
+    ],
+    colors: {
+      "editor.background": "#1a1a28",
+      "editor.foreground": "#e0e0e8",
+      "editorLineNumber.foreground": "#55556a",
+      "editorLineNumber.activeForeground": "#e0e0e8",
+      "editor.selectionBackground": "#4d9fff33",
+      "editor.lineHighlightBackground": "#4d9fff0d",
+      "editor.lineHighlightBorder": "#00000000",
+      "editorCursor.foreground": "#4d9fff",
+      "editorWidget.background": "#20202e",
+      "editorWidget.border": "#2a2a3a",
+      "editorIndentGuide.background": "#2a2a3a",
+      "editorIndentGuide.activeBackground": "#3a3a4e",
+      "editorBracketMatch.background": "#4d9fff26",
+      "editorBracketMatch.border": "#4d9fff",
+    },
+  });
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,9 +4,11 @@
   --bg-primary: #0a0a0f;
   --bg-secondary: #12121a;
   --bg-panel: #1a1a28;
+  --bg-elevated: #20202e;
   --border: #2a2a3a;
   --text-primary: #e0e0e8;
   --text-secondary: #8888a0;
+  --text-muted: #55556a;
   --accent-green: #00d68f;
   --accent-red: #ff4d6a;
   --accent-yellow: #ffc107;

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -12,7 +12,6 @@ type EditorViewProps = {
   aiTerminalAlgoIds: Set<number>;
   onSelectAlgo: (id: number) => void;
   onCreateAlgo: () => void;
-  onCreateAlgoWithAi: () => void;
   onOpenAiTerminal: (algoId: number) => void;
   onRequestCloseTab: (id: number) => void;
   onRequestCloseMany: (ids: number[]) => void;
@@ -28,7 +27,6 @@ export const EditorView = ({
   aiTerminalAlgoIds,
   onSelectAlgo,
   onCreateAlgo,
-  onCreateAlgoWithAi,
   onOpenAiTerminal,
   onRequestCloseTab,
   onRequestCloseMany,
@@ -81,7 +79,6 @@ export const EditorView = ({
           dirtyAlgoIds={dirtyAlgoIds}
           onSelectAlgo={onSelectAlgo}
           onCreateAlgo={onCreateAlgo}
-          onCreateAlgoWithAi={onCreateAlgoWithAi}
           onOpenAiTerminal={onOpenAiTerminal}
           aiTerminalAlgoIds={aiTerminalAlgoIds}
           onDeleteAlgo={onDeleteAlgo}

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -15,6 +15,7 @@ type EditorViewProps = {
   onCreateAlgoWithAi: () => void;
   onOpenAiTerminal: (algoId: number) => void;
   onRequestCloseTab: (id: number) => void;
+  onRequestCloseMany: (ids: number[]) => void;
   onDeleteAlgo: (id: number) => void;
   onRenameAlgo: (id: number, newName: string) => void;
   onSaveAlgo: () => void;
@@ -30,6 +31,7 @@ export const EditorView = ({
   onCreateAlgoWithAi,
   onOpenAiTerminal,
   onRequestCloseTab,
+  onRequestCloseMany,
   onDeleteAlgo,
   onRenameAlgo,
   onSaveAlgo,
@@ -55,15 +57,14 @@ export const EditorView = ({
   const isActiveDirty = activeTabId !== null ? tabs.isDirty(activeTabId) : false;
 
   const handleCloseOthers = (keepId: number) => {
-    for (const id of [...tabs.openTabIds]) {
-      if (id !== keepId) onRequestCloseTab(id);
-    }
+    const ids = tabs.openTabIds.filter((id) => id !== keepId);
+    if (ids.length === 0) return;
+    onRequestCloseMany(ids);
   };
 
   const handleCloseAll = () => {
-    for (const id of [...tabs.openTabIds]) {
-      onRequestCloseTab(id);
-    }
+    if (tabs.openTabIds.length === 0) return;
+    onRequestCloseMany([...tabs.openTabIds]);
   };
 
   const handleDeleteActive = () => {

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -96,8 +96,9 @@ export const EditorView = ({
           activeTabId={activeTabId}
           onSelect={(id) => tabs.switchTab(id)}
           onClose={onRequestCloseTab}
-          onCreateAlgo={onCreateAlgo}
-          onCreateAlgoWithAi={onCreateAlgoWithAi}
+          onOpenAiTerminalForActive={() => {
+            if (activeTabId !== null) onOpenAiTerminal(activeTabId);
+          }}
           onRenameActive={onRenameActiveAlgo}
           onDeleteActive={handleDeleteActive}
           onCloseOthers={handleCloseOthers}

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,47 +1,83 @@
+import { useState } from "react";
 import { AlgoEditor } from "../components/AlgoEditor";
 import { AlgoManager } from "../components/AlgoManager";
+import { EditorTabs, type EditorTab } from "../components/EditorTabs";
+import { EditorStatusBar } from "../components/EditorStatusBar";
+import type { UseEditorTabs } from "../hooks/useEditorTabs";
 import type { Algo } from "../types";
 
 type EditorViewProps = {
   algos: Algo[];
-  selectedAlgoId: number | null;
-  editorCode: string;
-  editorDeps: string;
+  tabs: UseEditorTabs;
+  aiTerminalAlgoIds: Set<number>;
   onSelectAlgo: (id: number) => void;
   onCreateAlgo: () => void;
-  onCreateAlgoWithAi?: () => void;
-  onOpenAiTerminal?: (algoId: number) => void;
-  aiTerminalAlgoIds?: Set<number>;
+  onCreateAlgoWithAi: () => void;
+  onOpenAiTerminal: (algoId: number) => void;
+  onRequestCloseTab: (id: number) => void;
   onDeleteAlgo: (id: number) => void;
   onRenameAlgo: (id: number, newName: string) => void;
-  onEditorChange: (code: string) => void;
-  onDepsChange: (deps: string) => void;
   onSaveAlgo: () => void;
+  onRenameActiveAlgo: () => void;
 };
 
 export const EditorView = ({
   algos,
-  selectedAlgoId,
-  editorCode,
-  editorDeps,
+  tabs,
+  aiTerminalAlgoIds,
   onSelectAlgo,
   onCreateAlgo,
   onCreateAlgoWithAi,
   onOpenAiTerminal,
-  aiTerminalAlgoIds,
+  onRequestCloseTab,
   onDeleteAlgo,
   onRenameAlgo,
-  onEditorChange,
-  onDepsChange,
   onSaveAlgo,
+  onRenameActiveAlgo,
 }: EditorViewProps) => {
+  const [showDeps, setShowDeps] = useState(false);
+  const [cursor, setCursor] = useState({ line: 1, col: 1 });
+
+  const activeTabId = tabs.activeTabId;
+  const dirtyAlgoIds = new Set(tabs.openTabIds.filter((id) => tabs.isDirty(id)));
+
+  const tabItems: EditorTab[] = tabs.openTabIds.map((id) => {
+    const algo = algos.find((a) => a.id === id);
+    return {
+      id,
+      name: algo?.name ?? `algo_${id}`,
+      isDirty: tabs.isDirty(id),
+      hasAiTerminal: aiTerminalAlgoIds.has(id),
+    };
+  });
+
+  const depsCount = tabs.activeDeps.split(/\s+/).filter(Boolean).length;
+  const isActiveDirty = activeTabId !== null ? tabs.isDirty(activeTabId) : false;
+
+  const handleCloseOthers = (keepId: number) => {
+    for (const id of [...tabs.openTabIds]) {
+      if (id !== keepId) onRequestCloseTab(id);
+    }
+  };
+
+  const handleCloseAll = () => {
+    for (const id of [...tabs.openTabIds]) {
+      onRequestCloseTab(id);
+    }
+  };
+
+  const handleDeleteActive = () => {
+    if (activeTabId !== null) onDeleteAlgo(activeTabId);
+  };
+
   return (
     <div className="flex-1 flex gap-3 p-4 overflow-hidden">
       {/* Left: Algo List */}
       <div className="w-72 flex-shrink-0 bg-[var(--bg-panel)] rounded-lg overflow-hidden">
         <AlgoManager
           algos={algos}
-          selectedAlgoId={selectedAlgoId}
+          selectedAlgoId={activeTabId}
+          dirtyAlgoIds={dirtyAlgoIds}
           onSelectAlgo={onSelectAlgo}
           onCreateAlgo={onCreateAlgo}
           onCreateAlgoWithAi={onCreateAlgoWithAi}
@@ -52,18 +88,45 @@ export const EditorView = ({
         />
       </div>
 
-      {/* Right: Editor */}
-      <div className="flex-1 bg-[var(--bg-panel)] rounded-lg overflow-hidden">
-        {selectedAlgoId !== null ? (
-          <AlgoEditor
-            code={editorCode}
-            dependencies={editorDeps}
-            onChange={onEditorChange}
-            onDepsChange={onDepsChange}
-            onSave={onSaveAlgo}
-          />
+      {/* Right: Editor column */}
+      <div className="flex-1 bg-[var(--bg-panel)] rounded-lg overflow-hidden flex flex-col">
+        <EditorTabs
+          tabs={tabItems}
+          activeTabId={activeTabId}
+          onSelect={(id) => tabs.switchTab(id)}
+          onClose={onRequestCloseTab}
+          onCreateAlgo={onCreateAlgo}
+          onCreateAlgoWithAi={onCreateAlgoWithAi}
+          onRenameActive={onRenameActiveAlgo}
+          onDeleteActive={handleDeleteActive}
+          onCloseOthers={handleCloseOthers}
+          onCloseAll={handleCloseAll}
+        />
+
+        {activeTabId !== null ? (
+          <>
+            <div className="flex-1 min-h-0">
+              <AlgoEditor
+                code={tabs.activeCode}
+                deps={tabs.activeDeps}
+                showDeps={showDeps}
+                onChange={tabs.updateCode}
+                onDepsChange={tabs.updateDeps}
+                onSave={onSaveAlgo}
+                onCursorChange={(line, col) => setCursor({ line, col })}
+              />
+            </div>
+            <EditorStatusBar
+              isDirty={isActiveDirty}
+              depsCount={depsCount}
+              cursorLine={cursor.line}
+              cursorCol={cursor.col}
+              onSave={onSaveAlgo}
+              onToggleDeps={() => setShowDeps((v) => !v)}
+            />
+          </>
         ) : (
-          <div className="flex items-center justify-center h-full text-sm text-[var(--text-secondary)]">
+          <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)]">
             {algos.length === 0
               ? "Create an algo to get started"
               : "Select an algo to edit"}


### PR DESCRIPTION
## Summary

Turns the single-algo editor into a multi-tab workspace (Variant B "Workspace" direction from the prototypes). Core changes:

- **Multi-tab editing** — several algos open at once, independent dirty buffers, zero-friction tab switching. Tab buffers persist across view navigation (no more "unsaved changes, leave?" dialog on nav).
- **New chrome** — tab strip with filename + dirty dot + AI pulse + close; 26px footer status bar (save state, language, deps count, cursor position, encoding).
- **Restyled left rail** — 52px icon-only, status dot centered under Guide button.
- **Refreshed algo list** — filter input, per-item dirty dot, always-visible `⋯` overflow menu (rename / AI terminal / delete).
- **Custom Monaco theme** (`wolf-den-dark`) aligned with the app's design tokens; replaces the generic `vs-dark`.
- **External-update reconciliation** — fixes an existing latent issue where the `algo-code-updated` event unconditionally overwrote unsaved edits.
- **Single "new algo" button** that always spawns an AI terminal (consolidates the previous two-button flow).

No backend / Tauri-command / schema changes. New files: `useEditorTabs` hook, `monacoTheme`, `EditorTabs`, `EditorStatusBar`, `RenameDialog`. Modified: `Sidebar`, `AlgoManager`, `AlgoEditor`, `EditorView`, `App`.

## Design docs

- Spec: `docs/superpowers/specs/2026-04-19-editor-view-redesign-design.md`
- Plan: `docs/superpowers/plans/2026-04-19-editor-view-redesign.md`
- Prototypes: `prototypes/editor-view/index.html` (three variants — this PR implements variant B)

## Test plan

The project has no automated test framework; verification is `npm run build` + manual smoke. All items below pass after interactive testing:

- [x] `npm run build` clean (TypeScript type-check + Vite bundle)
- [x] Open 3 tabs; switch between them — each retains buffer + dirty state
- [x] Edit A, switch to B, back to A — edits preserved, dirty dots accurate in tab + sidebar + status bar
- [x] ⌘S saves; status-bar "Unsaved · ⌘S" chip also saves
- [x] Deps chip toggles the deps strip; Monaco resizes cleanly
- [x] Close clean tab silently; close dirty tab prompts via `ConfirmDialog`
- [x] Close-all / close-others on dirty tabs → one aggregate confirm (not N stacked)
- [x] Close active tab → right neighbor activates (left if no right)
- [x] Delete algo with tab open → single delete confirm, tab closes on confirm
- [x] Rename from sidebar inline or from tab `⋯` (via new `RenameDialog`)
- [x] Editor → Home → Editor — tabs survive, no nav prompt
- [x] New algo via sidebar `+` → tab opens + AI terminal spawns
- [x] Tab-strip Sparkles → opens AI terminal for active algo (disabled when no active tab or terminal already open)
- [x] Monaco theme matches app tokens (no `vs-dark` charcoal showing)
- [x] Other views (Home, Algos, Trading, Guide) render correctly with the new 52px rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-tab editor workspace: open and edit multiple algorithms simultaneously with horizontal tab bar
  * Tab indicators for unsaved changes and active AI terminals
  * Algorithm search/filter in the manager panel
  * Per-algorithm and per-tab action menus (rename, close, delete)
  * Custom "Wolf Den Dark" editor theme with improved syntax highlighting
  * Dedicated status bar displaying save state, cursor position, and dependencies count

* **Bug Fixes**
  * Enhanced conflict detection when external code updates overwrite unsaved edits; now displays alerts

* **Style**
  * Redesigned sidebar as compact icon-only rail with tooltips
  * Refactored status bar layout and controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->