### PR TITLE
feat: algos view redesign — grouped list + detail panel + slide-over launcher

### DIFF
--- a/docs/superpowers/plans/2026-04-19-algos-view-redesign.md
+++ b/docs/superpowers/plans/2026-04-19-algos-view-redesign.md
@@ -1,0 +1,1858 @@
+# Algos View Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the Algos view as a single grouped instance list + always-visible detail panel + slide-over launcher, per `docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md`.
+
+**Architecture:** A pure helper module (`src/lib/algoInstanceView.ts`) owns grouping / filtering / aggregation / sparkline derivation. `AlgosView.tsx` becomes a layout-only orchestrator that composes new small components: `AlgosCommandBar`, `AlgosFilterBar`, `AlgosInstanceList` (built from `AlgoGroupHeader` + `AlgoInstanceRow`), `AlgoDetailPanel`, and `RunAlgoSlideOver`. The existing `LogPanel` is reused inside the detail panel's Logs tab. `App.tsx` adds one prop (`runPnlHistories`) to the Algos mount. No backend / Tauri-command / schema changes.
+
+**Tech Stack:** React 19, TypeScript 6, Tailwind 4 + CSS vars (`src/styles.css`), no new dependencies.
+
+---
+
+## Project has no test framework — adapted task template
+
+The standard `superpowers:writing-plans` template uses a TDD flow. This project has no vitest / jest setup (see `package.json`), and the spec's verification plan is `tsc` + manual smoke. Every task here replaces the "write failing test → run → implement → pass" cycle with:
+
+1. **Implement** — write the code.
+2. **Type-check** — run `npx tsc --noEmit` from the repo root; expect zero TypeScript errors. (Running `npm run build` is also valid but slower — it additionally produces a Vite bundle.)
+3. **Smoke** — a targeted manual walk-through described per task. For pure-helper tasks, smoke = just type-check.
+4. **Commit** — Conventional Commits.
+
+Do not introduce a test framework in this plan. It's out of scope.
+
+---
+
+## Task dependency map
+
+Tasks 1–7 produce self-contained new files. Task 8 is the coordinated rewire (`AlgosView.tsx` full rewrite + `App.tsx` one-line prop addition) where everything meets. Task 9 is final smoke + polish.
+
+```
+1 (helpers) ──┬──▶ 2 (row + group header) ─┐
+              │                            ├──▶ 6 (InstanceList) ─┐
+              ├──▶ 4 (DetailPanel)         │                       │
+              │                            │                       ├──▶ 8 (rewire) ──▶ 9 (smoke)
+              └──▶ 5 (Slide-over)          │                       │
+                                           3 (CommandBar + FilterBar) ──▶ ┘
+```
+
+Tasks 2, 3, 4, 5, 6 can be done in parallel by a subagent runner once 1 is done.
+
+---
+
+### Task 1: Create `src/lib/algoInstanceView.ts` (pure helpers)
+
+**Files:**
+- Create: `src/lib/algoInstanceView.ts`
+
+- [ ] **Step 1: Write the helper module**
+
+Create `src/lib/algoInstanceView.ts` with this exact content:
+
+```ts
+import type { Algo, AlgoRun } from "../types";
+import type { AlgoStats, DataSource } from "../hooks/useTradingSimulation";
+import type { InstanceErrors } from "../hooks/useAlgoErrors";
+
+export type GroupBy = "chart" | "algo" | "none";
+export type ModeFilter = "all" | "live" | "shadow";
+export type StatusFilter = "all" | "running" | "halted" | "warning";
+export type InstanceStatus = "running" | "halted" | "warning";
+
+export type ViewFilters = {
+  mode: ModeFilter;
+  status: StatusFilter;
+  search: string;
+};
+
+export type InstanceView = {
+  run: AlgoRun;
+  algo: Algo;
+  dataSource: DataSource;
+  stats: AlgoStats | undefined;
+  errors: InstanceErrors | undefined;
+  status: InstanceStatus;
+  pnlHistory: number[];
+};
+
+export type GroupView = {
+  key: string;
+  label: string;
+  meta: string;
+  aggregatePnl: number;
+  instances: InstanceView[];
+  groupBy: GroupBy;
+  // Deep-link payloads — populated per-pivot:
+  chartId?: string;
+  account?: string;
+  algoId?: number;
+};
+
+export const computeStatus = (errors: InstanceErrors | undefined): InstanceStatus => {
+  if (!errors) return "running";
+  if (errors.autoStopped) return "halted";
+  if (errors.warningCount > 0 || errors.errorCount > 0) return "warning";
+  return "running";
+};
+
+export const aggregatePnl = (instances: InstanceView[]): number =>
+  instances.reduce((sum, i) => sum + (i.stats?.pnl ?? 0), 0);
+
+export const sparklinePoints = (history: number[], width: number, height: number): string => {
+  if (history.length <= 1) return "";
+  const min = Math.min(...history);
+  const max = Math.max(...history);
+  const range = max - min || 1;
+  const stepX = width / (history.length - 1);
+  return history
+    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
+    .join(" ");
+};
+
+export const passesFilters = (inst: InstanceView, filters: ViewFilters): boolean => {
+  if (filters.mode !== "all" && inst.run.mode !== filters.mode) return false;
+  if (filters.status !== "all" && inst.status !== filters.status) return false;
+  if (filters.search.trim()) {
+    const q = filters.search.trim().toLowerCase();
+    const hay = [
+      inst.algo.name,
+      inst.dataSource.instrument,
+      inst.dataSource.timeframe,
+      inst.run.account,
+    ]
+      .join(" ")
+      .toLowerCase();
+    if (!hay.includes(q)) return false;
+  }
+  return true;
+};
+
+// Halted rows sort to the bottom of their group; running / warning in original order.
+const sortInstances = (instances: InstanceView[]): InstanceView[] => {
+  const rank = (s: InstanceStatus) => (s === "halted" ? 1 : 0);
+  return [...instances].sort((a, b) => rank(a.status) - rank(b.status));
+};
+
+type BuildArgs = {
+  activeRuns: AlgoRun[];
+  algos: Algo[];
+  dataSources: DataSource[];
+  algoStats: Record<string, AlgoStats>;
+  errorsByInstance: Record<string, InstanceErrors>;
+  runPnlHistories: Record<string, number[]>;
+  dismissedInstanceIds: Set<string>;
+  groupBy: GroupBy;
+  filters: ViewFilters;
+};
+
+export const buildInstanceViews = ({
+  activeRuns,
+  algos,
+  dataSources,
+  algoStats,
+  errorsByInstance,
+  runPnlHistories,
+  dismissedInstanceIds,
+}: Pick<
+  BuildArgs,
+  | "activeRuns"
+  | "algos"
+  | "dataSources"
+  | "algoStats"
+  | "errorsByInstance"
+  | "runPnlHistories"
+  | "dismissedInstanceIds"
+>): InstanceView[] => {
+  const views: InstanceView[] = [];
+  for (const run of activeRuns) {
+    if (dismissedInstanceIds.has(run.instance_id)) continue;
+    const algo = algos.find((a) => a.id === run.algo_id);
+    const dataSource = dataSources.find((d) => d.id === run.data_source_id);
+    if (!algo || !dataSource) continue;
+    const errors = errorsByInstance[run.instance_id];
+    views.push({
+      run,
+      algo,
+      dataSource,
+      stats: algoStats[run.instance_id],
+      errors,
+      status: computeStatus(errors),
+      pnlHistory: runPnlHistories[run.instance_id] ?? [],
+    });
+  }
+  return views;
+};
+
+export const buildGroups = (args: BuildArgs): GroupView[] => {
+  const allViews = buildInstanceViews(args);
+  const filtered = allViews.filter((v) => passesFilters(v, args.filters));
+
+  if (args.groupBy === "none") {
+    const sorted = sortInstances(filtered);
+    return [
+      {
+        key: "__all__",
+        label: "All instances",
+        meta: `${sorted.length} instance${sorted.length === 1 ? "" : "s"}`,
+        aggregatePnl: aggregatePnl(sorted),
+        instances: sorted,
+        groupBy: "none",
+      },
+    ];
+  }
+
+  if (args.groupBy === "chart") {
+    const groups: GroupView[] = [];
+    for (const ds of args.dataSources) {
+      const dsInstances = sortInstances(filtered.filter((v) => v.dataSource.id === ds.id));
+      if (dsInstances.length === 0) continue;
+      groups.push({
+        key: `chart:${ds.id}`,
+        label: `${ds.instrument} ${ds.timeframe}`,
+        meta: `${ds.account} · ${dsInstances.length} algo${dsInstances.length === 1 ? "" : "s"}`,
+        aggregatePnl: aggregatePnl(dsInstances),
+        instances: dsInstances,
+        groupBy: "chart",
+        chartId: ds.id,
+        account: ds.account,
+      });
+    }
+    return groups;
+  }
+
+  // group by algo
+  const byAlgo = new Map<number, InstanceView[]>();
+  for (const v of filtered) {
+    const existing = byAlgo.get(v.algo.id) ?? [];
+    existing.push(v);
+    byAlgo.set(v.algo.id, existing);
+  }
+  const groups: GroupView[] = [];
+  const algoNameOrder = [...byAlgo.keys()].sort((a, b) => {
+    const na = args.algos.find((x) => x.id === a)?.name ?? "";
+    const nb = args.algos.find((x) => x.id === b)?.name ?? "";
+    return na.localeCompare(nb);
+  });
+  for (const algoId of algoNameOrder) {
+    const algo = args.algos.find((x) => x.id === algoId);
+    if (!algo) continue;
+    const instances = sortInstances(byAlgo.get(algoId) ?? []);
+    groups.push({
+      key: `algo:${algoId}`,
+      label: algo.name,
+      meta: `${instances.length} instance${instances.length === 1 ? "" : "s"}`,
+      aggregatePnl: aggregatePnl(instances),
+      instances,
+      groupBy: "algo",
+      algoId,
+    });
+  }
+  return groups;
+};
+
+export const formatPnl = (value: number): string => {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}$${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+export const pnlColorClass = (value: number): string =>
+  value > 0
+    ? "text-[var(--accent-green)]"
+    : value < 0
+      ? "text-[var(--accent-red)]"
+      : "text-[var(--text-primary)]";
+
+export const formatDurationShort = (msElapsed: number): string => {
+  if (msElapsed < 0) return "0s";
+  const totalSeconds = Math.floor(msElapsed / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/algoInstanceView.ts
+git commit -m "feat(algos): pure helpers for grouping, filtering, and view derivation"
+```
+
+---
+
+### Task 2: Create `AlgoGroupHeader` + `AlgoInstanceRow`
+
+**Files:**
+- Create: `src/components/AlgoGroupHeader.tsx`
+- Create: `src/components/AlgoInstanceRow.tsx`
+
+- [ ] **Step 1: Write `AlgoGroupHeader.tsx`**
+
+Create `src/components/AlgoGroupHeader.tsx` with this exact content:
+
+```tsx
+import type { GroupView } from "../lib/algoInstanceView";
+import { formatPnl, pnlColorClass } from "../lib/algoInstanceView";
+
+type AlgoGroupHeaderProps = {
+  group: GroupView;
+  onDeepLink: () => void;
+  onAddAlgo: () => void;
+};
+
+export const AlgoGroupHeader = ({ group, onDeepLink, onAddAlgo }: AlgoGroupHeaderProps) => {
+  if (group.groupBy === "none") return null;
+
+  const linkLabel = group.groupBy === "chart" ? "→ chart" : "→ editor";
+  const linkTitle =
+    group.groupBy === "chart"
+      ? "Open Trading view for this account"
+      : "Open this algo in Editor";
+
+  return (
+    <div className="group flex items-center gap-3 px-4 py-2 bg-[var(--bg-secondary)] border-b border-[var(--border)] sticky top-0 z-10">
+      <span className="text-[var(--text-secondary)] text-xs">▼</span>
+      <span className="text-xs font-semibold">{group.label}</span>
+      <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+        {group.meta}
+      </span>
+      <div className="ml-auto flex items-center gap-3 text-[11px]">
+        <span className={`font-mono tabular-nums ${pnlColorClass(group.aggregatePnl)}`}>
+          {formatPnl(group.aggregatePnl)}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAddAlgo();
+          }}
+          className="opacity-0 group-hover:opacity-100 text-[10px] px-2 py-0.5 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)] transition-all"
+          title="Run a new algo in this group"
+        >
+          + add
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeepLink();
+          }}
+          className="text-[10px] text-[var(--accent-blue)] hover:underline"
+          title={linkTitle}
+        >
+          {linkLabel}
+        </button>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `AlgoInstanceRow.tsx`**
+
+Create `src/components/AlgoInstanceRow.tsx` with this exact content:
+
+```tsx
+import type { InstanceView } from "../lib/algoInstanceView";
+import {
+  formatPnl,
+  pnlColorClass,
+  sparklinePoints,
+} from "../lib/algoInstanceView";
+
+type AlgoInstanceRowProps = {
+  instance: InstanceView;
+  isSelected: boolean;
+  onSelect: () => void;
+  onClear: () => void;
+};
+
+const pillClass = (status: InstanceView["status"], mode: string): string => {
+  if (status === "halted") {
+    return "bg-[var(--accent-red)]/15 text-[var(--accent-red)]";
+  }
+  if (mode === "live") {
+    return "bg-[var(--accent-green)]/15 text-[var(--accent-green)]";
+  }
+  return "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+};
+
+const dotClass = (status: InstanceView["status"]): string => {
+  if (status === "halted") return "bg-[var(--accent-red)]";
+  if (status === "warning") return "bg-[var(--accent-yellow)]";
+  return "bg-[var(--accent-green)]";
+};
+
+const SPARK_W = 80;
+const SPARK_H = 18;
+
+export const AlgoInstanceRow = ({
+  instance,
+  isSelected,
+  onSelect,
+  onClear,
+}: AlgoInstanceRowProps) => {
+  const { run, algo, dataSource, stats, errors, status, pnlHistory } = instance;
+  const pnl = stats?.pnl ?? 0;
+  const points = sparklinePoints(pnlHistory, SPARK_W, SPARK_H);
+  const strokeColor = pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+
+  const statusLabel =
+    status === "halted"
+      ? "halted"
+      : errors && errors.warningCount > 0
+        ? `${errors.warningCount} warn`
+        : null;
+
+  const pillLabel = status === "halted" ? "Halted" : run.mode === "live" ? "Live" : "Shadow";
+
+  return (
+    <div
+      onClick={onSelect}
+      className={`group grid items-center gap-3 px-4 py-2.5 border-b border-[var(--border)] cursor-pointer transition-colors ${
+        isSelected
+          ? "bg-[var(--accent-blue)]/10 border-l-2 border-l-[var(--accent-blue)] pl-[14px]"
+          : "hover:bg-[var(--bg-secondary)]"
+      } ${status === "halted" ? "opacity-75" : ""}`}
+      style={{ gridTemplateColumns: "18px 1fr 76px 80px 110px 96px 28px" }}
+    >
+      <span className={`w-2 h-2 rounded-full ${dotClass(status)}`} />
+
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium truncate">{algo.name}</span>
+          {statusLabel && (
+            <span
+              className={`text-[10px] ${
+                status === "halted" ? "text-[var(--accent-red)]" : "text-[var(--accent-yellow)]"
+              }`}
+            >
+              {statusLabel}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-[10px] text-[var(--text-secondary)] truncate">
+          <span className="truncate">
+            {dataSource.instrument} {dataSource.timeframe}
+          </span>
+          <span>·</span>
+          <span className="truncate">{run.account}</span>
+        </div>
+      </div>
+
+      <span
+        className={`text-[9px] uppercase tracking-wider px-2 py-0.5 rounded font-semibold text-center ${pillClass(
+          status,
+          run.mode,
+        )}`}
+      >
+        {pillLabel}
+      </span>
+
+      <div className="flex items-center justify-center h-[18px]">
+        {points ? (
+          <svg
+            viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+            preserveAspectRatio="none"
+            width={SPARK_W}
+            height={SPARK_H}
+            aria-hidden
+          >
+            <polyline fill="none" stroke={strokeColor} strokeWidth="1.2" points={points} />
+          </svg>
+        ) : (
+          <span className="text-[var(--text-secondary)] text-xs">—</span>
+        )}
+      </div>
+
+      <span className={`text-sm font-mono tabular-nums text-right ${pnlColorClass(pnl)}`}>
+        {formatPnl(pnl)}
+      </span>
+
+      <span className="text-[11px] text-[var(--text-secondary)] text-right font-mono tabular-nums">
+        {stats && stats.totalTrades > 0
+          ? `${stats.totalTrades} · ${stats.winRate}%`
+          : "— · —"}
+      </span>
+
+      {status === "halted" ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClear();
+          }}
+          className="opacity-0 group-hover:opacity-100 text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent-red)] transition-all"
+          title="Clear this row from the list"
+        >
+          ✕
+        </button>
+      ) : (
+        <span />
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/AlgoGroupHeader.tsx src/components/AlgoInstanceRow.tsx
+git commit -m "feat(algos): group header + instance row components"
+```
+
+---
+
+### Task 3: Create `AlgosCommandBar` + `AlgosFilterBar`
+
+**Files:**
+- Create: `src/components/AlgosCommandBar.tsx`
+- Create: `src/components/AlgosFilterBar.tsx`
+
+- [ ] **Step 1: Write `AlgosCommandBar.tsx`**
+
+Create `src/components/AlgosCommandBar.tsx` with this exact content:
+
+```tsx
+import { formatPnl, pnlColorClass } from "../lib/algoInstanceView";
+
+type AlgosCommandBarProps = {
+  chartCount: number;
+  instanceCount: number;
+  runningCount: number;
+  haltedCount: number;
+  sessionPnl: number;
+  onRunNewAlgo: () => void;
+};
+
+export const AlgosCommandBar = ({
+  chartCount,
+  instanceCount,
+  runningCount,
+  haltedCount,
+  sessionPnl,
+  onRunNewAlgo,
+}: AlgosCommandBarProps) => {
+  const metaParts = [
+    `${chartCount} chart${chartCount === 1 ? "" : "s"}`,
+    `${instanceCount} instance${instanceCount === 1 ? "" : "s"}`,
+    `${runningCount} running`,
+  ];
+  if (haltedCount > 0) metaParts.push(`${haltedCount} halted`);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-3 bg-[var(--bg-panel)] border-b border-[var(--border)]">
+      <div className="flex items-baseline gap-3 min-w-0">
+        <h2 className="text-[15px] font-semibold tracking-tight">Algos</h2>
+        <span className="text-[11px] text-[var(--text-secondary)] truncate">
+          {metaParts.join(" · ")}
+        </span>
+      </div>
+      <div className="flex items-center gap-4">
+        <div className="flex items-baseline gap-2">
+          <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+            Session
+          </span>
+          <span className={`text-sm font-mono font-semibold tabular-nums ${pnlColorClass(sessionPnl)}`}>
+            {formatPnl(sessionPnl)}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onRunNewAlgo}
+          className="px-3.5 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90 transition-opacity"
+        >
+          + Run new algo
+        </button>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `AlgosFilterBar.tsx`**
+
+Create `src/components/AlgosFilterBar.tsx` with this exact content:
+
+```tsx
+import type { GroupBy, ModeFilter, StatusFilter } from "../lib/algoInstanceView";
+
+type AlgosFilterBarProps = {
+  groupBy: GroupBy;
+  onGroupByChange: (v: GroupBy) => void;
+  modeFilter: ModeFilter;
+  onModeFilterChange: (v: ModeFilter) => void;
+  statusFilter: StatusFilter;
+  onStatusFilterChange: (v: StatusFilter) => void;
+  searchQuery: string;
+  onSearchQueryChange: (v: string) => void;
+};
+
+type SegItem<T extends string> = { value: T; label: string };
+
+const GROUP_BY_OPTIONS: SegItem<GroupBy>[] = [
+  { value: "chart", label: "Chart" },
+  { value: "algo", label: "Algo" },
+  { value: "none", label: "None" },
+];
+
+const MODE_OPTIONS: SegItem<ModeFilter>[] = [
+  { value: "all", label: "All" },
+  { value: "live", label: "Live" },
+  { value: "shadow", label: "Shadow" },
+];
+
+const STATUS_OPTIONS: SegItem<StatusFilter>[] = [
+  { value: "all", label: "All" },
+  { value: "running", label: "Running" },
+  { value: "warning", label: "Warning" },
+  { value: "halted", label: "Halted" },
+];
+
+const Segmented = <T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T;
+  options: SegItem<T>[];
+  onChange: (v: T) => void;
+}) => (
+  <div className="flex bg-[var(--bg-secondary)] border border-[var(--border)] rounded-md overflow-hidden">
+    {options.map((opt) => (
+      <button
+        key={opt.value}
+        type="button"
+        onClick={() => onChange(opt.value)}
+        className={`px-2.5 py-1 text-[11px] transition-colors ${
+          value === opt.value
+            ? "bg-[var(--bg-panel)] text-[var(--text-primary)]"
+            : "text-[var(--text-secondary)] hover:bg-[var(--bg-panel)]"
+        }`}
+      >
+        {opt.label}
+      </button>
+    ))}
+  </div>
+);
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">
+    {children}
+  </span>
+);
+
+export const AlgosFilterBar = ({
+  groupBy,
+  onGroupByChange,
+  modeFilter,
+  onModeFilterChange,
+  statusFilter,
+  onStatusFilterChange,
+  searchQuery,
+  onSearchQueryChange,
+}: AlgosFilterBarProps) => (
+  <div className="flex items-center gap-3 px-4 py-2 bg-[var(--bg-panel)] border-b border-[var(--border)]">
+    <Label>Group by</Label>
+    <Segmented value={groupBy} options={GROUP_BY_OPTIONS} onChange={onGroupByChange} />
+
+    <Label>Mode</Label>
+    <Segmented value={modeFilter} options={MODE_OPTIONS} onChange={onModeFilterChange} />
+
+    <Label>Status</Label>
+    <Segmented value={statusFilter} options={STATUS_OPTIONS} onChange={onStatusFilterChange} />
+
+    <div className="flex-1" />
+
+    <input
+      type="search"
+      value={searchQuery}
+      onChange={(e) => onSearchQueryChange(e.target.value)}
+      placeholder="Search algo, instrument, account…"
+      className="w-[220px] px-2.5 py-1 text-[11px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-blue)]"
+    />
+  </div>
+);
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/AlgosCommandBar.tsx src/components/AlgosFilterBar.tsx
+git commit -m "feat(algos): command + filter bars"
+```
+
+---
+
+### Task 4: Create `AlgoDetailPanel.tsx`
+
+**Files:**
+- Create: `src/components/AlgoDetailPanel.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/AlgoDetailPanel.tsx` with this exact content:
+
+```tsx
+import { useEffect, useState } from "react";
+import type { InstanceView } from "../lib/algoInstanceView";
+import { formatPnl, pnlColorClass } from "../lib/algoInstanceView";
+import type { LogEntry } from "../hooks/useAlgoLogs";
+import type { AlgoHealth } from "../hooks/useAlgoHealth";
+import type { AlgoError } from "../hooks/useAlgoErrors";
+import { LogPanel } from "./LogPanel";
+
+type Tab = "logs" | "errors" | "config";
+
+type AlgoDetailPanelProps = {
+  instance: InstanceView | null;
+  logs: LogEntry[];
+  health: AlgoHealth | undefined;
+  onClearLogs: () => void;
+  onStop: () => void;
+  onOpenInEditor: () => void;
+  onViewTrades: () => void;
+  onOpenAiTerminal?: () => void;
+  hasActiveAiTerminal: boolean;
+  onRunNewAlgo: () => void;
+};
+
+const formatErrorTime = (ts: number) => {
+  const date = new Date(ts);
+  return date.toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+};
+
+const ErrorRow = ({ error }: { error: AlgoError }) => {
+  const [expanded, setExpanded] = useState(false);
+  const severityColor =
+    error.severity === "warning"
+      ? "text-[var(--accent-yellow)]"
+      : "text-[var(--accent-red)]";
+  return (
+    <div className="border-b border-[var(--border)] last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left px-4 py-2 hover:bg-[var(--bg-secondary)] transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-[10px] text-[var(--text-secondary)] font-mono shrink-0">
+            {formatErrorTime(error.timestamp)}
+          </span>
+          <span className={`text-[10px] uppercase font-medium shrink-0 ${severityColor}`}>
+            {error.severity}
+          </span>
+          <span className="text-xs text-[var(--text-primary)] truncate">{error.message}</span>
+          {error.handler && (
+            <span className="text-[10px] text-[var(--text-secondary)] shrink-0 font-mono">
+              {error.handler}
+            </span>
+          )}
+        </div>
+      </button>
+      {expanded && error.traceback && (
+        <div className="px-4 pb-3">
+          <pre className="text-[10px] text-[var(--text-secondary)] bg-[var(--bg-primary)] rounded-md p-3 overflow-x-auto font-mono whitespace-pre-wrap">
+            {error.traceback}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Stat = ({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) => (
+  <div className="flex flex-col gap-0.5">
+    <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+      {label}
+    </span>
+    <span className={`text-sm font-mono font-medium tabular-nums ${color ?? ""}`}>
+      {value}
+    </span>
+  </div>
+);
+
+const EmptyState = ({
+  title,
+  body,
+  cta,
+  onCta,
+}: {
+  title: string;
+  body: string;
+  cta?: string;
+  onCta?: () => void;
+}) => (
+  <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 text-center gap-3">
+    <h3 className="text-sm font-medium">{title}</h3>
+    <p className="text-xs text-[var(--text-secondary)] max-w-[280px]">{body}</p>
+    {cta && onCta && (
+      <button
+        type="button"
+        onClick={onCta}
+        className="mt-2 px-3 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90"
+      >
+        {cta}
+      </button>
+    )}
+  </div>
+);
+
+export const AlgoDetailPanel = ({
+  instance,
+  logs,
+  health,
+  onClearLogs,
+  onStop,
+  onOpenInEditor,
+  onViewTrades,
+  onOpenAiTerminal,
+  hasActiveAiTerminal,
+  onRunNewAlgo,
+}: AlgoDetailPanelProps) => {
+  const [tab, setTab] = useState<Tab>("logs");
+
+  // Reset tab when selection changes: Errors if there are any, otherwise Logs.
+  // We intentionally depend only on the instance id so that live error updates
+  // on the currently-selected instance don't yank the user back to the Errors tab.
+  const selId = instance?.run.instance_id ?? null;
+  useEffect(() => {
+    if (!instance) return;
+    if (instance.errors && instance.errors.errorCount > 0) {
+      setTab("errors");
+    } else {
+      setTab("logs");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selId]);
+
+  if (!instance) {
+    return (
+      <div className="w-[380px] border-l border-[var(--border)] bg-[var(--bg-panel)] flex flex-col">
+        <EmptyState
+          title="Select an instance to see details"
+          body="Click a running algo on the left to see its stats, logs, errors, and quick actions."
+          cta="Run your first algo"
+          onCta={onRunNewAlgo}
+        />
+      </div>
+    );
+  }
+
+  const { run, algo, dataSource, stats, errors, status } = instance;
+  const pnl = stats?.pnl ?? 0;
+  const errorCount = errors?.errorCount ?? 0;
+  const warnCount = errors?.warningCount ?? 0;
+
+  const pillClass =
+    status === "halted"
+      ? "bg-[var(--accent-red)]/15 text-[var(--accent-red)]"
+      : run.mode === "live"
+        ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
+        : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+
+  const pillLabel = status === "halted" ? "Halted" : run.mode === "live" ? "Live" : "Shadow";
+
+  return (
+    <div className="w-[380px] border-l border-[var(--border)] bg-[var(--bg-panel)] flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-[var(--border)]">
+        <div className="flex items-start justify-between gap-3 mb-1">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold truncate">{algo.name}</h3>
+            <div className="text-[11px] text-[var(--text-secondary)] truncate">
+              on {dataSource.instrument} {dataSource.timeframe}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onStop}
+            disabled={status === "halted" || run.status === "installing"}
+            className="px-2.5 py-1 text-[11px] rounded-md font-medium bg-[var(--accent-red)] text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {run.status === "installing" ? "Installing…" : "Stop"}
+          </button>
+        </div>
+        <div className="flex items-center gap-2 text-[11px]">
+          <span
+            className={`text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded ${pillClass}`}
+          >
+            {pillLabel}
+          </span>
+          <span className="text-[var(--text-secondary)]">{run.account}</span>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-1.5 px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-secondary)]">
+        <button
+          type="button"
+          onClick={onOpenInEditor}
+          className="px-2.5 py-1 text-[11px] rounded-md font-medium bg-[var(--bg-panel)] border border-[var(--border)] text-[var(--text-primary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)] transition-colors"
+        >
+          λ Open in Editor
+        </button>
+        <button
+          type="button"
+          onClick={onViewTrades}
+          className="px-2.5 py-1 text-[11px] rounded-md font-medium bg-[var(--bg-panel)] border border-[var(--border)] text-[var(--text-primary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)] transition-colors"
+        >
+          ⇅ View trades
+        </button>
+        {onOpenAiTerminal && (
+          <button
+            type="button"
+            onClick={onOpenAiTerminal}
+            disabled={hasActiveAiTerminal}
+            className={`px-2.5 py-1 text-[11px] rounded-md font-medium border border-[var(--border)] transition-colors ${
+              hasActiveAiTerminal
+                ? "bg-[var(--bg-panel)] text-[var(--text-secondary)] cursor-not-allowed opacity-60"
+                : "bg-[var(--bg-panel)] text-[var(--text-primary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)]"
+            }`}
+          >
+            ◎ AI terminal
+          </button>
+        )}
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 px-4 py-3 border-b border-[var(--border)]">
+        <Stat label="P&L" value={formatPnl(pnl)} color={pnlColorClass(pnl)} />
+        <Stat
+          label="Win rate"
+          value={stats && stats.totalTrades > 0 ? `${stats.winRate}%` : "—"}
+        />
+        <Stat label="Sharpe" value={stats?.sharpe ?? "—"} />
+        <Stat label="Profit factor" value={stats?.profitFactor ?? "—"} />
+        <Stat
+          label="Avg win"
+          value={stats && stats.totalTrades > 0 ? formatPnl(stats.avgWin) : "—"}
+          color={stats && stats.totalTrades > 0 ? "text-[var(--accent-green)]" : undefined}
+        />
+        <Stat
+          label="Avg loss"
+          value={stats && stats.totalTrades > 0 ? formatPnl(stats.avgLoss) : "—"}
+          color={stats && stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+        />
+        <Stat
+          label="Max DD"
+          value={stats && stats.totalTrades > 0 ? formatPnl(-Math.abs(stats.maxDrawdown)) : "—"}
+          color={stats && stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+        />
+        <Stat label="Trades" value={`${stats?.totalTrades ?? 0}`} />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-[var(--border)] px-2">
+        {(
+          [
+            { id: "logs", label: "Logs" },
+            { id: "errors", label: "Errors", count: errorCount + warnCount },
+            { id: "config", label: "Config" },
+          ] as { id: Tab; label: string; count?: number }[]
+        ).map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={`px-3 py-2 text-[11px] font-medium transition-colors border-b-2 ${
+              tab === t.id
+                ? "text-[var(--text-primary)] border-[var(--accent-blue)]"
+                : "text-[var(--text-secondary)] border-transparent hover:text-[var(--text-primary)]"
+            }`}
+          >
+            {t.label}
+            {typeof t.count === "number" && t.count > 0 && (
+              <span className="ml-1 text-[9px] px-1 py-0.5 rounded bg-[var(--accent-red)]/15 text-[var(--accent-red)]">
+                {t.count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab body */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {tab === "logs" && (
+          <LogPanel logs={logs} health={health} onClear={onClearLogs} />
+        )}
+        {tab === "errors" &&
+          (errors && errors.errors.length > 0 ? (
+            <div className="overflow-auto">
+              {errors.autoStopped && (
+                <div className="px-4 py-2 bg-[var(--accent-red)]/10 text-[var(--accent-red)] text-xs font-medium">
+                  Algo halted due to repeated errors
+                </div>
+              )}
+              {errors.errors.map((e) => (
+                <ErrorRow key={e.id} error={e} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex-1 flex items-center justify-center text-xs text-[var(--text-secondary)] py-8">
+              No errors recorded
+            </div>
+          ))}
+        {tab === "config" && (
+          <div className="flex-1 overflow-auto p-4">
+            {algo.config ? (
+              <pre className="text-[11px] font-mono whitespace-pre-wrap bg-[var(--bg-primary)] rounded-md p-3 border border-[var(--border)]">
+                {algo.config}
+              </pre>
+            ) : (
+              <div className="text-xs text-[var(--text-secondary)]">
+                No config defined. Edit in the Editor view.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/AlgoDetailPanel.tsx
+git commit -m "feat(algos): always-visible detail panel with stats, logs, errors, config tabs"
+```
+
+---
+
+### Task 5: Create `RunAlgoSlideOver.tsx`
+
+**Files:**
+- Create: `src/components/RunAlgoSlideOver.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/RunAlgoSlideOver.tsx` with this exact content:
+
+```tsx
+import { useEffect, useState } from "react";
+import type { Algo, AlgoRun } from "../types";
+import type { DataSource } from "../hooks/useTradingSimulation";
+
+type Mode = "live" | "shadow";
+
+type RunAlgoSlideOverProps = {
+  open: boolean;
+  algos: Algo[];
+  dataSources: DataSource[];
+  activeRuns: AlgoRun[];
+  prefill: { algoId?: number; chartId?: string } | null;
+  onClose: () => void;
+  onStart: (algoId: number, mode: Mode, account: string, dataSourceId: string) => void;
+};
+
+export const RunAlgoSlideOver = ({
+  open,
+  algos,
+  dataSources,
+  activeRuns,
+  prefill,
+  onClose,
+  onStart,
+}: RunAlgoSlideOverProps) => {
+  const [algoId, setAlgoId] = useState<number | null>(null);
+  const [chartId, setChartId] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>("shadow");
+  const [accountOverride, setAccountOverride] = useState<string>("");
+
+  // Reset on open, respecting prefill.
+  useEffect(() => {
+    if (!open) return;
+    setAlgoId(prefill?.algoId ?? null);
+    setChartId(prefill?.chartId ?? null);
+    setMode("shadow");
+    setAccountOverride("");
+  }, [open, prefill]);
+
+  // Esc to close.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const chart = dataSources.find((d) => d.id === chartId) ?? null;
+  const algo = algos.find((a) => a.id === algoId) ?? null;
+  const effectiveAccount = accountOverride.trim() || chart?.account || "";
+  const duplicate =
+    algo &&
+    chart &&
+    activeRuns.some((r) => r.algo_id === algo.id && r.data_source_id === chart.id);
+
+  const canSubmit = !!algo && !!chart && !!effectiveAccount && !duplicate;
+
+  const handleSubmit = () => {
+    if (!canSubmit || !algo || !chart) return;
+    onStart(algo.id, mode, effectiveAccount, chart.id);
+    onClose();
+  };
+
+  return (
+    <>
+      {/* Scrim */}
+      <div
+        onClick={onClose}
+        className="absolute inset-0 bg-black/30 z-20"
+        aria-hidden
+      />
+
+      {/* Panel */}
+      <aside
+        className="absolute top-0 right-0 bottom-0 w-[380px] bg-[var(--bg-panel)] border-l border-[var(--border)] z-30 flex flex-col shadow-2xl"
+        role="dialog"
+        aria-label="Run a new algo"
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)]">
+          <h3 className="text-sm font-semibold">Run a new algo</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-sm leading-none"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4 flex flex-col gap-4">
+          <Field label="Algo">
+            <select
+              value={algoId ?? ""}
+              onChange={(e) => setAlgoId(e.target.value ? Number(e.target.value) : null)}
+              className="w-full px-2.5 py-1.5 text-[12px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-blue)]"
+            >
+              <option value="">Select an algo…</option>
+              {algos.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Chart">
+            <select
+              value={chartId ?? ""}
+              onChange={(e) => setChartId(e.target.value || null)}
+              className="w-full px-2.5 py-1.5 text-[12px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-blue)]"
+            >
+              <option value="">Select a chart…</option>
+              {dataSources.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.instrument} {d.timeframe} · {d.account}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Mode">
+            <div className="grid grid-cols-2 gap-2">
+              <ModeChip
+                tone="yellow"
+                selected={mode === "shadow"}
+                label="◐ Shadow"
+                onClick={() => setMode("shadow")}
+              />
+              <ModeChip
+                tone="green"
+                selected={mode === "live"}
+                label="● Live"
+                onClick={() => setMode("live")}
+              />
+            </div>
+          </Field>
+
+          <Field label="Account override (optional)">
+            <input
+              type="text"
+              value={accountOverride}
+              onChange={(e) => setAccountOverride(e.target.value)}
+              placeholder={chart ? `use chart's account · ${chart.account}` : "pick a chart first"}
+              className="w-full px-2.5 py-1.5 text-[12px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-blue)]"
+            />
+          </Field>
+
+          {duplicate && (
+            <div className="text-[11px] text-[var(--accent-yellow)]">
+              This algo is already running on the selected chart.
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-3 border-t border-[var(--border)] bg-[var(--bg-secondary)]">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded-md text-[var(--text-secondary)] border border-[var(--border)] hover:text-[var(--text-primary)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="px-3.5 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Start
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex flex-col gap-1.5">
+    <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">
+      {label}
+    </span>
+    {children}
+  </div>
+);
+
+const ModeChip = ({
+  tone,
+  selected,
+  label,
+  onClick,
+}: {
+  tone: "yellow" | "green";
+  selected: boolean;
+  label: string;
+  onClick: () => void;
+}) => {
+  const base = "px-3 py-1.5 text-xs rounded-md font-medium border transition-colors";
+  const toneClass =
+    tone === "green"
+      ? selected
+        ? "bg-[var(--accent-green)]/15 border-[var(--accent-green)] text-[var(--accent-green)]"
+        : "bg-transparent border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent-green)]"
+      : selected
+        ? "bg-[var(--accent-yellow)]/15 border-[var(--accent-yellow)] text-[var(--accent-yellow)]"
+        : "bg-transparent border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent-yellow)]";
+  return (
+    <button type="button" onClick={onClick} className={`${base} ${toneClass}`}>
+      {label}
+    </button>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/RunAlgoSlideOver.tsx
+git commit -m "feat(algos): run-new-algo slide-over launcher"
+```
+
+---
+
+### Task 6: Create `AlgosInstanceList.tsx`
+
+**Files:**
+- Create: `src/components/AlgosInstanceList.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/AlgosInstanceList.tsx` with this exact content:
+
+```tsx
+import type { GroupView, InstanceView } from "../lib/algoInstanceView";
+import { AlgoGroupHeader } from "./AlgoGroupHeader";
+import { AlgoInstanceRow } from "./AlgoInstanceRow";
+
+type AlgosInstanceListProps = {
+  groups: GroupView[];
+  hasAnyCharts: boolean;
+  hasAnyInstances: boolean;
+  selectedInstanceId: string | null;
+  onSelect: (instance: InstanceView) => void;
+  onClear: (instance: InstanceView) => void;
+  onGroupDeepLink: (group: GroupView) => void;
+  onGroupAddAlgo: (group: GroupView) => void;
+  onClearFilters: () => void;
+  onRunNewAlgo: () => void;
+};
+
+export const AlgosInstanceList = ({
+  groups,
+  hasAnyCharts,
+  hasAnyInstances,
+  selectedInstanceId,
+  onSelect,
+  onClear,
+  onGroupDeepLink,
+  onGroupAddAlgo,
+  onClearFilters,
+  onRunNewAlgo,
+}: AlgosInstanceListProps) => {
+  if (!hasAnyCharts) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="max-w-[380px] text-center text-xs text-[var(--text-secondary)]">
+          No charts connected. Add the WolfDenBridge indicator to a NinjaTrader chart to get
+          started.
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasAnyInstances) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center">
+        <h3 className="text-sm font-medium">No algos running</h3>
+        <p className="text-xs text-[var(--text-secondary)] max-w-[320px]">
+          Charts are connected but no algos are running. Start one to see it here.
+        </p>
+        <button
+          type="button"
+          onClick={onRunNewAlgo}
+          className="mt-1 px-3 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90"
+        >
+          + Run new algo
+        </button>
+      </div>
+    );
+  }
+
+  if (groups.length === 0 || groups.every((g) => g.instances.length === 0)) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="text-xs text-[var(--text-secondary)] flex items-center gap-3">
+          <span>No instances match these filters</span>
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="text-[var(--accent-blue)] hover:underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      {groups.map((group) => (
+        <div key={group.key}>
+          <AlgoGroupHeader
+            group={group}
+            onDeepLink={() => onGroupDeepLink(group)}
+            onAddAlgo={() => onGroupAddAlgo(group)}
+          />
+          {group.instances.map((inst) => (
+            <AlgoInstanceRow
+              key={inst.run.instance_id}
+              instance={inst}
+              isSelected={selectedInstanceId === inst.run.instance_id}
+              onSelect={() => onSelect(inst)}
+              onClear={() => onClear(inst)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/AlgosInstanceList.tsx
+git commit -m "feat(algos): grouped instance list with empty states"
+```
+
+---
+
+### Task 7: Delete now-unused AI-terminal inline affordance code (none) — skipped
+
+This task is intentionally empty. All soon-to-be-deleted code in the current `AlgosView.tsx` is internal to that file (its sub-components `ChartCard`, `AddAlgoPanel`, `RunningInstanceRow`, `PerformanceStats`, `ErrorBadge`, `ErrorRow`, `ErrorList`). They are removed as part of Task 8's full rewrite — no separate deletion step is needed.
+
+Skip to Task 8.
+
+---
+
+### Task 8: Coordinated rewire — rewrite `AlgosView.tsx` + update `App.tsx`
+
+This is the only task that touches multiple files at once because the new `AlgosViewProps` gains one field (`runPnlHistories`), which `App.tsx` must supply.
+
+**Files:**
+- Rewrite: `src/views/AlgosView.tsx`
+- Modify: `src/App.tsx` (single line addition — pass `runPnlHistories`)
+
+- [ ] **Step 1: Rewrite `src/views/AlgosView.tsx`**
+
+Overwrite `src/views/AlgosView.tsx` with this exact content:
+
+```tsx
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Algo, AlgoRun, NavOptions, View } from "../types";
+import { type AlgoStats, type DataSource } from "../hooks/useTradingSimulation";
+import { type InstanceErrors } from "../hooks/useAlgoErrors";
+import { type LogEntry } from "../hooks/useAlgoLogs";
+import { type AlgoHealth } from "../hooks/useAlgoHealth";
+import {
+  buildGroups,
+  type GroupBy,
+  type GroupView,
+  type InstanceView,
+  type ModeFilter,
+  type StatusFilter,
+} from "../lib/algoInstanceView";
+import { AlgosCommandBar } from "../components/AlgosCommandBar";
+import { AlgosFilterBar } from "../components/AlgosFilterBar";
+import { AlgosInstanceList } from "../components/AlgosInstanceList";
+import { AlgoDetailPanel } from "../components/AlgoDetailPanel";
+import { RunAlgoSlideOver } from "../components/RunAlgoSlideOver";
+
+type AlgosViewProps = {
+  algos: Algo[];
+  dataSources: DataSource[];
+  activeRuns: AlgoRun[];
+  algoStats: Record<string, AlgoStats>;
+  runPnlHistories: Record<string, number[]>;
+  errorsByInstance: Record<string, InstanceErrors>;
+  logsByInstance: Record<string, LogEntry[]>;
+  healthByInstance: Record<string, AlgoHealth>;
+  onStartAlgo: (id: number, mode: "live" | "shadow", account: string, dataSourceId: string) => void;
+  onStopAlgo: (instanceId: string) => void;
+  onClearLogs: (instanceId: string) => void;
+  onOpenAiTerminal?: (algoId: number) => void;
+  aiTerminalAlgoIds?: Set<number>;
+  initialInstanceId?: string | null;
+  onInstanceFocused?: () => void;
+  onNavigate: (view: View, options?: NavOptions) => void;
+};
+
+export const AlgosView = ({
+  algos,
+  dataSources,
+  activeRuns,
+  algoStats,
+  runPnlHistories,
+  errorsByInstance,
+  logsByInstance,
+  healthByInstance,
+  onStartAlgo,
+  onStopAlgo,
+  onClearLogs,
+  onOpenAiTerminal,
+  aiTerminalAlgoIds,
+  initialInstanceId,
+  onInstanceFocused,
+  onNavigate,
+}: AlgosViewProps) => {
+  const [groupBy, setGroupBy] = useState<GroupBy>("chart");
+  const [modeFilter, setModeFilter] = useState<ModeFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
+  const [hasAutoSelected, setHasAutoSelected] = useState(false);
+  const [launcherOpen, setLauncherOpen] = useState(false);
+  const [launcherPrefill, setLauncherPrefill] = useState<{
+    algoId?: number;
+    chartId?: string;
+  } | null>(null);
+  const [dismissedInstanceIds, setDismissedInstanceIds] = useState<Set<string>>(() => new Set());
+
+  // Auto-select on mount: navigation-provided instance, else first running.
+  useEffect(() => {
+    if (hasAutoSelected) return;
+    if (initialInstanceId) {
+      const run = activeRuns.find((r) => r.instance_id === initialInstanceId);
+      if (run) {
+        setSelectedInstanceId(run.instance_id);
+      }
+      setHasAutoSelected(true);
+      onInstanceFocused?.();
+      return;
+    }
+    const firstRunning = activeRuns.find((r) => r.status === "running");
+    if (firstRunning) {
+      setSelectedInstanceId(firstRunning.instance_id);
+      setHasAutoSelected(true);
+    }
+  }, [activeRuns, hasAutoSelected, initialInstanceId, onInstanceFocused]);
+
+  const groups = useMemo(
+    () =>
+      buildGroups({
+        activeRuns,
+        algos,
+        dataSources,
+        algoStats,
+        errorsByInstance,
+        runPnlHistories,
+        dismissedInstanceIds,
+        groupBy,
+        filters: { mode: modeFilter, status: statusFilter, search: searchQuery },
+      }),
+    [
+      activeRuns,
+      algos,
+      dataSources,
+      algoStats,
+      errorsByInstance,
+      runPnlHistories,
+      dismissedInstanceIds,
+      groupBy,
+      modeFilter,
+      statusFilter,
+      searchQuery,
+    ],
+  );
+
+  const allInstances = useMemo(
+    () => groups.flatMap((g) => g.instances),
+    [groups],
+  );
+
+  const selectedInstance: InstanceView | null =
+    allInstances.find((i) => i.run.instance_id === selectedInstanceId) ?? null;
+
+  // Counts for the command bar — use activeRuns (not filtered) so headline numbers stay stable.
+  const runningCount = activeRuns.filter((r) => r.status === "running").length;
+  const haltedCount = activeRuns.filter(
+    (r) => errorsByInstance[r.instance_id]?.autoStopped,
+  ).length;
+  const sessionPnl = Object.values(algoStats).reduce((sum, s) => sum + s.pnl, 0);
+
+  const clearFilters = useCallback(() => {
+    setModeFilter("all");
+    setStatusFilter("all");
+    setSearchQuery("");
+  }, []);
+
+  const openLauncher = useCallback((prefill: { algoId?: number; chartId?: string } | null) => {
+    setLauncherPrefill(prefill);
+    setLauncherOpen(true);
+  }, []);
+
+  const handleGroupDeepLink = useCallback(
+    (group: GroupView) => {
+      if (group.groupBy === "chart" && group.account) {
+        onNavigate("trading", { accountFilter: group.account });
+      } else if (group.groupBy === "algo" && typeof group.algoId === "number") {
+        onNavigate("editor", { algoFilter: group.algoId });
+      }
+    },
+    [onNavigate],
+  );
+
+  const handleGroupAddAlgo = useCallback(
+    (group: GroupView) => {
+      if (group.groupBy === "chart" && group.chartId) {
+        openLauncher({ chartId: group.chartId });
+      } else if (group.groupBy === "algo" && typeof group.algoId === "number") {
+        openLauncher({ algoId: group.algoId });
+      } else {
+        openLauncher(null);
+      }
+    },
+    [openLauncher],
+  );
+
+  const handleStart = useCallback(
+    (algoId: number, mode: "live" | "shadow", account: string, dataSourceId: string) => {
+      onStartAlgo(algoId, mode, account, dataSourceId);
+    },
+    [onStartAlgo],
+  );
+
+  const clearInstance = useCallback((inst: InstanceView) => {
+    setDismissedInstanceIds((prev) => {
+      const next = new Set(prev);
+      next.add(inst.run.instance_id);
+      return next;
+    });
+    setSelectedInstanceId((sid) => (sid === inst.run.instance_id ? null : sid));
+  }, []);
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 bg-[var(--bg-primary)] relative">
+      <AlgosCommandBar
+        chartCount={dataSources.length}
+        instanceCount={activeRuns.length}
+        runningCount={runningCount}
+        haltedCount={haltedCount}
+        sessionPnl={sessionPnl}
+        onRunNewAlgo={() => openLauncher(null)}
+      />
+      <AlgosFilterBar
+        groupBy={groupBy}
+        onGroupByChange={setGroupBy}
+        modeFilter={modeFilter}
+        onModeFilterChange={setModeFilter}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+      />
+
+      <div className="flex-1 flex min-h-0">
+        <AlgosInstanceList
+          groups={groups}
+          hasAnyCharts={dataSources.length > 0}
+          hasAnyInstances={activeRuns.length > 0}
+          selectedInstanceId={selectedInstanceId}
+          onSelect={(inst) => setSelectedInstanceId(inst.run.instance_id)}
+          onClear={clearInstance}
+          onGroupDeepLink={handleGroupDeepLink}
+          onGroupAddAlgo={handleGroupAddAlgo}
+          onClearFilters={clearFilters}
+          onRunNewAlgo={() => openLauncher(null)}
+        />
+
+        <AlgoDetailPanel
+          instance={selectedInstance}
+          logs={
+            selectedInstance ? logsByInstance[selectedInstance.run.instance_id] ?? [] : []
+          }
+          health={
+            selectedInstance ? healthByInstance[selectedInstance.run.instance_id] : undefined
+          }
+          onClearLogs={() => {
+            if (selectedInstance) onClearLogs(selectedInstance.run.instance_id);
+          }}
+          onStop={() => {
+            if (selectedInstance) onStopAlgo(selectedInstance.run.instance_id);
+          }}
+          onOpenInEditor={() => {
+            if (selectedInstance) onNavigate("editor", { algoFilter: selectedInstance.algo.id });
+          }}
+          onViewTrades={() => {
+            if (selectedInstance)
+              onNavigate("trading", {
+                accountFilter: selectedInstance.run.account,
+                scrollTo: "positions",
+              });
+          }}
+          onOpenAiTerminal={
+            onOpenAiTerminal && selectedInstance
+              ? () => onOpenAiTerminal(selectedInstance.algo.id)
+              : undefined
+          }
+          hasActiveAiTerminal={
+            !!(selectedInstance && aiTerminalAlgoIds?.has(selectedInstance.algo.id))
+          }
+          onRunNewAlgo={() => openLauncher(null)}
+        />
+      </div>
+
+      <RunAlgoSlideOver
+        open={launcherOpen}
+        algos={algos}
+        dataSources={dataSources}
+        activeRuns={activeRuns}
+        prefill={launcherPrefill}
+        onClose={() => setLauncherOpen(false)}
+        onStart={handleStart}
+      />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Update `src/App.tsx`**
+
+Find the `<AlgosView` mount in `src/App.tsx` (around line 398) and add two new props: `runPnlHistories` and `onNavigate`.
+
+Replace this block:
+
+```tsx
+        {activeView === "algos" && (
+          <AlgosView
+            algos={algos}
+            dataSources={dataSources}
+            activeRuns={activeRuns}
+            algoStats={simulation.algoStats}
+            errorsByInstance={errorsByInstance}
+            logsByInstance={logsByInstance}
+            healthByInstance={healthByInstance}
+            onStartAlgo={handleStartAlgo}
+            onStopAlgo={handleStopAlgo}
+            onClearLogs={clearLogs}
+            onOpenAiTerminal={handleOpenAiTerminal}
+            aiTerminalAlgoIds={aiTerminalAlgoIds}
+            initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
+            onInstanceFocused={clearPendingNavContext}
+          />
+        )}
+```
+
+With:
+
+```tsx
+        {activeView === "algos" && (
+          <AlgosView
+            algos={algos}
+            dataSources={dataSources}
+            activeRuns={activeRuns}
+            algoStats={simulation.algoStats}
+            runPnlHistories={simulation.runPnlHistories}
+            errorsByInstance={errorsByInstance}
+            logsByInstance={logsByInstance}
+            healthByInstance={healthByInstance}
+            onStartAlgo={handleStartAlgo}
+            onStopAlgo={handleStopAlgo}
+            onClearLogs={clearLogs}
+            onOpenAiTerminal={handleOpenAiTerminal}
+            aiTerminalAlgoIds={aiTerminalAlgoIds}
+            initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
+            onInstanceFocused={clearPendingNavContext}
+            onNavigate={handleNavigate}
+          />
+        )}
+```
+
+Confirm that `handleNavigate` already exists in `App.tsx` by searching for `const handleNavigate` or `onNavigate={handleNavigate}` elsewhere in the file — it is passed to `HomeView` already and its signature is `(view: View, options?: NavOptions) => void`. If the local name differs (e.g. `navigateTo`), use the matching name.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+If a TypeScript error appears for the navigate prop name, check how `HomeView` receives it in `App.tsx` and mirror that exactly.
+
+- [ ] **Step 4: Smoke — full matrix**
+
+Run: `npm run dev`
+
+In the running app, walk through each case with NinjaTrader connected (or manually trigger runs if possible):
+
+1. **Group-by Chart (default)**: Groups render one per connected chart. Aggregate P&L and meta in each header. Running algos render as rows. Halted instances sink to the bottom of their group.
+2. **Group-by Algo**: Groups render one per algo that has any instance. Each header shows instance count + aggregate P&L. Instances labelled with their chart.
+3. **Group-by None**: A single virtual group (no visible header); all filtered instances in one list.
+4. **Mode filter**: Live / Shadow toggles remove non-matching rows.
+5. **Status filter**: Running / Warning / Halted filter correctly.
+6. **Search**: Type an algo name, instrument, or account — rows filter; clear → all return.
+7. **No results state**: Apply contradictory filters → "No instances match these filters · Clear filters" renders; Clear filters resets.
+8. **Detail panel selection**: Click different rows; header, actions, stats grid, tabs update. When an instance has errors, the Errors tab is pre-selected. When not, Logs is pre-selected. Manual tab switches stick until the selection changes.
+9. **Detail actions**:
+   - **Stop** calls `onStopAlgo` — disabled for halted rows and for `status === "installing"` runs.
+   - **Open in Editor** navigates to Editor with that algo loaded.
+   - **View trades** navigates to Trading with that account filter and scrolls to positions.
+   - **AI terminal** opens the existing AI terminal tab; button disables when one is already active for that algo.
+10. **Logs tab**: `LogPanel` renders inside the Logs tab with the correct logs + health. Clearing logs works.
+11. **Errors tab**: Error rows render with severity colour; clicking expands traceback; `autoStopped` banner shows when applicable.
+12. **Config tab**: Shows the algo's `config` string as a read-only `<pre>`; empty-state message when `config` is null / empty.
+13. **Top bar launcher**: `+ Run new algo` opens the slide-over empty. Esc / scrim / Cancel all dismiss. Submit disabled until Algo + Chart selected. Start fires `onStartAlgo` and the new instance auto-appears in the list.
+14. **Group-header launcher**: Hover a chart group → `+ add` appears on the right → opens the slide-over with Chart prefilled. Hover an algo group → `+ add` prefills Algo.
+15. **Duplicate guard**: Select an algo already running on the chosen chart — yellow "already running" notice and Submit disabled.
+16. **Halted row clear**: Hover a halted row → `✕` appears on the right → clicking removes the row locally. Re-selecting a dismissed row is impossible until it's re-added by `activeRuns` or via a view remount.
+17. **Nav-in context**: Navigate to Algos from Home by clicking an algo tape row (already wired via `initialInstanceId`) → detail panel auto-focuses that instance exactly once.
+18. **Empty states**:
+    - Disconnect NinjaTrader (or simulate): list renders the "No charts connected" message; detail panel shows "Select an instance to see details".
+    - Charts connected, no runs: list renders "No algos running · + Run new algo".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/AlgosView.tsx src/App.tsx
+git commit -m "feat(algos): rewrite view with grouped list + detail panel + launcher"
+```
+
+---
+
+### Task 9: Final smoke walk-through and polish
+
+**Files:**
+- Any polish adjustments as they surface — likely small tweaks in the new components.
+
+- [ ] **Step 1: Fresh smoke against the design spec**
+
+Run `npm run dev`. Open the Algos view. With the spec (`docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md`) open side-by-side, verify each Summary / Goals / User Flows bullet in the spec matches what you see.
+
+- [ ] **Step 2: Visual polish pass**
+
+Look for: inconsistent spacing, misaligned columns, off-color pills, missing hover states, detail panel overflow on narrow widths (≥1100px target — the Tauri default is wider, but resize-check down to 1100px). Tighten anything that looks off. Prefer the project's existing CSS variables — do not introduce new colors.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit any polish fixes**
+
+If nothing changed, skip the commit. Otherwise:
+
+```bash
+git add -p   # stage only the polish changes
+git commit -m "polish(algos): post-rewire visual fixes"
+```
+
+- [ ] **Step 5: Announce completion**
+
+Report back with a short summary: what was rewritten, what was added, what was removed from the old `AlgosView.tsx`, and a 2–3 line smoke summary.
+
+---
+
+## Self-review completed
+
+- Spec coverage: every section of the spec maps to a task — helpers (T1), row + group header (T2), command + filter bars (T3), detail panel incl. tabs & error drilldown (T4), slide-over (T5), list composition + empty states (T6), orchestrator rewrite + deep-link wiring + prop addition (T8), smoke (T9).
+- No placeholders in task bodies — every `Step` contains either the full file text, the exact replacement block, or a concrete smoke matrix.
+- Types are consistent across tasks: `InstanceView`, `GroupView`, `GroupBy`, `ModeFilter`, `StatusFilter`, `ViewFilters`, and helper function signatures are defined in T1 and used verbatim in T2, T6, and T8.
+- `AlgosViewProps` gains `runPnlHistories` and `onNavigate`; `App.tsx` supplies both. The spec framed this as "reuse existing contract" — calling the tiny addition out explicitly here.

--- a/docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md
@@ -199,21 +199,20 @@ No changes to `NavOptions` or `App.tsx` routing — these cases are already supp
 
 ## Testing Strategy
 
-Pure logic is covered with unit tests; UI wiring with React Testing Library equivalents or visual verification, per the project's existing pattern.
+The project has no test runner configured. Verification follows the convention used by the Home and Editor redesigns:
 
-- `src/lib/algoInstanceView.test.ts`:
-  - Chart grouping: orders groups by `dataSources` order; empty chart group suppressed when None is selected.
-  - Algo grouping: orders groups by algo name; halted instances sort to end of their group.
-  - Aggregate P&L: sums correctly; returns 0 for empty groups.
-  - Filtering: mode, status, and search each include/exclude correctly; combined filters AND together.
-- Visual / behavioral verification (manual):
-  - Selecting a row updates the detail panel.
-  - Slide-over opens, prefills from group-header `+ add`, cancels cleanly.
-  - Deep-link buttons invoke `onNavigate` with the expected arguments.
-  - Empty states render under each condition.
+- **Type-check**: `npx tsc --noEmit` must pass after each task.
+- **Manual smoke** against a running `npm run dev`, covering:
+  - Selecting a row updates the detail panel (stats, logs, errors, config tabs).
+  - Group-by toggle reshapes groups correctly for Chart / Algo / None.
+  - Mode, status, and search filters combine correctly; "No results" message appears when they exclude everything.
+  - Slide-over launcher: Run new algo (top bar) opens empty; group-header `+ add` prefills; Cancel / Esc / scrim dismiss; Start fires `onStartAlgo` and the new instance appears.
+  - Deep-link buttons invoke `onNavigate` with the expected view and options (verifiable by navigating and observing target-view state).
+  - Halted instances sort to bottom of group; `Clear` hides row locally.
+  - Empty states render for: no charts, no runs, no matches, no selection.
   - Auto-select on mount continues to honor `initialInstanceId`.
 
-Following the project's convention, no mocked hooks — tests exercise pure helpers with fixture data.
+The pure helpers in `src/lib/algoInstanceView.ts` are designed to be verifiable by inspection and through the manual smoke cases above. If unit tests are added later, they slot into these helpers cleanly.
 
 ## Implementation Notes
 

--- a/docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md
@@ -1,0 +1,237 @@
+# Algos View Redesign — Design
+
+**Date:** 2026-04-19
+**Direction:** Group-by toggle — single grouped list, slide-over launcher, always-visible detail panel
+**Brainstorm artifacts:** `.superpowers/brainstorm/` (mockups generated during brainstorming; not committed)
+
+## Summary
+
+Replace the current chart-scoped AlgosView (charts left → chart detail right, stacked chart header + running rows + add-algo panel + logs) with a single grouped instance list and an always-visible detail panel. A segmented control toggles the list's grouping between **Chart (default)**, **Algo**, and **None**, letting the view serve both the "per-chart dashboard" and "per-strategy rollup" mental models without mode-switching the layout. A new top command bar surfaces session aggregate P&L and a prominent `+ Run new algo` action; the launcher is a right-side slide-over. Deep-links from group headers and the detail panel make it easy to jump to Editor, Trading, and the AI terminal without leaving context.
+
+## Goals
+
+- One layout, two pivots — Group-by (Chart / Algo / None) swaps list groupings without swapping the page.
+- Scanable roster — health, mode, P&L, and trend visible at a glance per instance; aggregate P&L and status at each group.
+- Detail alongside the list — stats, logs, errors, and config live in a right-side panel so you never lose the list context when drilling in.
+- Fast "start a run" — slide-over launcher replaces the inline add-algo panel; default mode choice is one click away.
+- Outbound navigation — every meaningful row or group exposes a deep-link to the relevant Editor / Trading / AI terminal view.
+- Surgical refactor — no backend / Tauri-command / schema changes; PRable as one unit.
+
+## Non-Goals
+
+- Bulk actions across instances (multi-select stop, multi-select AI) — deferred.
+- Keyboard shortcuts / command palette — deferred to an app-wide project.
+- Persisting group-by / filter selections across app restarts — in-memory only.
+- Redesigning the logs panel itself — keep current `LogPanel` behavior; only its placement changes (now inside the detail panel's Logs tab).
+- Redesigning `AiTerminalPanel` — keep current right-side behavior.
+- Mobile / narrow-viewport responsiveness — this is a Tauri desktop app; assume ≥1100px width.
+- Changing the existing `NavOptions` contract or cross-view navigation mechanics — reuse `onNavigate` with the existing options surface.
+
+## Scope
+
+### In scope
+
+- Full rewrite of `src/views/AlgosView.tsx` into a composed layout.
+- New components:
+  - `AlgosCommandBar.tsx` — title, aggregate meta, session P&L, `+ Run new algo` trigger.
+  - `AlgosFilterBar.tsx` — group-by segmented, mode segmented, status select, search input.
+  - `AlgosInstanceList.tsx` — the grouped list itself.
+  - `AlgoInstanceRow.tsx` — a single row (health dot, name, account/duration, mode pill, sparkline, P&L, trades).
+  - `AlgoGroupHeader.tsx` — a group row (title, meta, aggregate P&L, deep-link icon).
+  - `AlgoDetailPanel.tsx` — right-side panel (header, actions, stats grid, tabs for Logs / Errors / Config).
+  - `RunAlgoSlideOver.tsx` — the launcher.
+- Small utility:
+  - `src/lib/algoInstanceView.ts` — pure helpers (grouping, filtering, aggregate P&L per group, sparkline point derivation).
+- Deletion (or repurposing) of inline `ChartCard`, `AddAlgoPanel`, `RunningInstanceRow`, `PerformanceStats`, `ErrorBadge`, `ErrorRow`, `ErrorList` sub-components inside the current `AlgosView.tsx` — their responsibilities fold into the new components above (nothing reused as-is; a clean rewrite).
+- Reuse of `LogPanel` inside `AlgoDetailPanel`'s Logs tab (no changes to `LogPanel` itself).
+
+### Out of scope
+
+- Other views (Home, Editor, Trading, Guide) — untouched.
+- `AiTerminalPanel`, `LogPanel`, and all hooks (`useTradingSimulation`, `useAlgoErrors`, `useAlgoLogs`, `useAlgoHealth`) — no changes.
+- `Sidebar.tsx`, `TitleBar.tsx` — no changes.
+- The NinjaTrader bridge / Rust side / Tauri commands — no changes.
+
+## Architecture
+
+### File layout
+
+```
+src/
+  lib/
+    algoInstanceView.ts         [new]   — pure grouping/filtering/aggregate helpers
+  components/
+    AlgosCommandBar.tsx         [new]
+    AlgosFilterBar.tsx          [new]
+    AlgosInstanceList.tsx       [new]
+    AlgoInstanceRow.tsx         [new]
+    AlgoGroupHeader.tsx         [new]
+    AlgoDetailPanel.tsx         [new]
+    RunAlgoSlideOver.tsx        [new]
+  views/
+    AlgosView.tsx               [rewrite] — layout-only orchestrator + local UI state
+```
+
+`AlgosView.tsx` keeps its existing props contract (`AlgosViewProps`) — no changes to how `App.tsx` mounts or hands it data.
+
+### State (inside `AlgosView`)
+
+Local `useState`:
+
+- `groupBy: "chart" | "algo" | "none"` — default `"chart"`.
+- `modeFilter: "all" | "live" | "shadow"` — default `"all"`.
+- `statusFilter: "all" | "running" | "halted" | "warning"` — default `"all"`.
+- `searchQuery: string` — default `""`.
+- `selectedInstanceId: string | null` — drives the detail panel. Auto-select logic preserved from today's implementation (honor `initialInstanceId`, else first running instance).
+- `launcherOpen: boolean` — controls the slide-over.
+- `launcherPrefill: { algoId?: number; chartId?: string } | null` — optional prefill when opened from a group header "+ add" action. Chart-pivot group headers prefill `chartId`; Algo-pivot group headers prefill `algoId`.
+- `dismissedInstanceIds: Set<string>` — local-only set of halted instance ids the user has cleared from the list.
+
+Group-by / filter / search state is in-memory only; it does not persist across sessions (non-goal).
+
+### Data derivation (pure, in `algoInstanceView.ts`)
+
+- `buildGroups(activeRuns, dataSources, algos, groupBy, filters, searchQuery)` → `{ groupKey, groupLabel, groupMeta, aggregatePnl, instances }[]`.
+  - Chart grouping: key = `data_source_id`; label = `<instrument> <timeframe>`; meta = account + count.
+  - Algo grouping: key = `algo_id`; label = `<algo.name>`; meta = instance count.
+  - None: single implicit group, no header rendered.
+- `aggregatePnl(instances, algoStats)` → sum of per-instance `stats.pnl` (0 when missing).
+- `sparklinePoints(history, width, height)` → `string` of polyline points; derived from `runPnlHistories` (reuse the same shape HomeView uses).
+- `passesFilters(run, errors, modeFilter, statusFilter, searchQuery, algoName)` → `boolean`.
+  - `status = "halted"` when `errors.autoStopped` is true.
+  - `status = "warning"` when `errors.warningCount > 0 && !errors.autoStopped`.
+  - `status = "running"` otherwise.
+  - Search matches algo name, instrument, or account (case-insensitive substring).
+
+All helpers are pure and independently testable.
+
+### Detail panel data
+
+- Selected run, algo, `algoStats[instanceId]`, `errorsByInstance[instanceId]`, `logsByInstance[instanceId]`, `healthByInstance[instanceId]` — all passed down from `AlgosView` (already received as props).
+- Tabs (`Logs` | `Errors` | `Config`) are local state inside `AlgoDetailPanel`. Default when a selection changes: `Errors` if the newly-selected instance has `errorCount > 0`, otherwise `Logs`. Switching tabs manually overrides until the next selection change.
+- The `Config` tab renders the algo's static `config` string in a read-only code block (today's `Algo` type already carries this). Non-goal: editing config here — that's the Editor's job.
+
+### Deep-link contract (reuses existing `NavOptions`)
+
+| Source | Action | `onNavigate(view, options)` |
+|---|---|---|
+| Group header (Chart pivot) → `→ chart` icon | View trading for that chart's account | `onNavigate("trading", { accountFilter: run.account })` |
+| Group header (Algo pivot) → `→ editor` icon | Open that algo in the editor | `onNavigate("editor", { algoFilter: algo.id })` |
+| Detail panel → `Open in Editor` | Same as above for the selected instance | `onNavigate("editor", { algoFilter: algo.id })` |
+| Detail panel → `View trades` | Trading view filtered to this account and scrolled to positions | `onNavigate("trading", { accountFilter: run.account, scrollTo: "positions" })` (instance-level filtering is not promised — matches what the `NavOptions` contract reliably supports today) |
+| Detail panel → `AI terminal` | Existing AI terminal handler | `onOpenAiTerminal?.(algo.id)` |
+
+No changes to `NavOptions` or `App.tsx` routing — these cases are already supported by the existing contract.
+
+### Run-new-algo slide-over
+
+- Overlay layer: fixed-position panel, 380px wide, slides from the right of the main content area (inside `AlgosView`'s frame — does not cover the app sidebar).
+- Backdrop: faint scrim (10% black) over the detail panel and list; clicking the scrim dismisses.
+- Close: Esc, scrim click, Cancel button, or successful Start.
+- Fields:
+  - **Algo** — select, populated from `algos`.
+  - **Chart** — select, populated from `dataSources`. Prefills from `launcherPrefill.chartId` if present. The algo select likewise prefills from `launcherPrefill.algoId` when set.
+  - **Mode** — two large chips: `◐ Shadow` (yellow tone), `● Live` (green tone). Mutually exclusive; defaults to `Shadow`.
+  - **Account override** — optional. Defaults to `"use chart's account"` which resolves to `ds.account`. A free-text override matches today's data shape (account strings are not constrained in `AlgoRun`).
+- Footer: `Cancel`, `Start`. `Start` calls `onStartAlgo(algo.id, mode, account, chart.id)` — the same signature used today.
+- Submit disabled until all required fields are chosen.
+
+### Halted & stopped instance handling
+
+- Halted instances (`errors.autoStopped === true`) remain in the list, sorted to the bottom of their group with muted styling and a "stopped Xm ago" label derived from the most recent error timestamp.
+- No automatic dismissal — the row stays until the user dismisses via a row-level `Clear` affordance or stops the instance.
+- `Clear` is visible on hover. It adds the instance id to a local `dismissedInstanceIds` Set in `AlgosView` state, which the list-rendering layer uses to hide the row. It does not call any handler or touch backend state. The set is in-memory; revisiting the view re-shows any halted rows still present in `activeRuns`.
+- If `activeRuns` no longer includes a halted instance (already gone from the hook), nothing to render — normal behavior.
+
+### Empty states
+
+- **No charts connected**: centered message in the list area — "No charts connected. Add the WolfDenBridge indicator to a NinjaTrader chart to get started." (same copy as today.) Detail panel shows an inert "Select an instance…" message.
+- **No running algos, charts present**: list area renders chart group headers with "No algos on this chart · + Run new algo" link; the detail panel shows a "Run your first algo" CTA that opens the slide-over prefilled with no chart selection.
+- **Filters exclude everything**: inline message "No instances match these filters · Clear filters".
+- **No selection**: detail panel shows "Select an instance to see details" with a subtle illustration placeholder (text-only for now).
+
+### Visual language
+
+- Colors pull from existing CSS variables (`--bg-primary`, `--bg-panel`, `--bg-secondary`, `--border`, `--text-primary`, `--text-secondary`, `--accent-blue`, `--accent-green`, `--accent-yellow`, `--accent-red`).
+- Row heights are compact: list rows ~48px; group headers ~36px; detail panel header ~64px.
+- Pills (Live/Shadow/Halted) follow the color conventions already used in `RunningInstanceRow` today.
+- Sparklines mirror the HomeView sparkline style (same stroke width, same green/red-based-on-pnl coloring).
+
+## User Flows
+
+### Monitor running algos
+
+1. Open Algos view → see grouped list defaulting to Chart pivot.
+2. Scan aggregate P&L per group in the headers; scan per-instance P&L and sparklines in rows.
+3. Click an instance → detail panel updates with stats, logs, errors.
+4. Repeat for adjacent instances without losing list context.
+
+### Triage a halted instance
+
+1. Halted instance is visually pushed down in its group with red dot and "halted · N errors" label.
+2. Click it → detail panel opens on Errors tab by default (when `errors.errorCount > 0`).
+3. Drill into individual error rows (traceback expand) inside the tab.
+4. Decide: open in editor to fix, or clear the stopped row.
+
+### Start a new algo
+
+1. Click `+ Run new algo` (top-right) → slide-over opens.
+2. Pick algo, chart, mode. Start.
+3. New instance appears in the list, auto-selected.
+
+### Start an algo from a chart group
+
+1. On a chart group header, click `+ add`.
+2. Slide-over opens with chart prefilled.
+3. Pick algo and mode. Start.
+
+### Compare a strategy across markets
+
+1. Switch group-by to Algo.
+2. Each algo header shows instance count + aggregate P&L across all its instances.
+3. Click any instance → detail panel isolates that run's numbers.
+
+### Jump to another view
+
+- From a chart group header, `→ chart` deep-links to Trading for that account.
+- From an algo header, `→ editor` opens the algo in Editor.
+- From the detail panel, use the three action buttons for Editor / Trading / AI terminal.
+
+## Testing Strategy
+
+Pure logic is covered with unit tests; UI wiring with React Testing Library equivalents or visual verification, per the project's existing pattern.
+
+- `src/lib/algoInstanceView.test.ts`:
+  - Chart grouping: orders groups by `dataSources` order; empty chart group suppressed when None is selected.
+  - Algo grouping: orders groups by algo name; halted instances sort to end of their group.
+  - Aggregate P&L: sums correctly; returns 0 for empty groups.
+  - Filtering: mode, status, and search each include/exclude correctly; combined filters AND together.
+- Visual / behavioral verification (manual):
+  - Selecting a row updates the detail panel.
+  - Slide-over opens, prefills from group-header `+ add`, cancels cleanly.
+  - Deep-link buttons invoke `onNavigate` with the expected arguments.
+  - Empty states render under each condition.
+  - Auto-select on mount continues to honor `initialInstanceId`.
+
+Following the project's convention, no mocked hooks — tests exercise pure helpers with fixture data.
+
+## Implementation Notes
+
+- Do not change `AlgosViewProps` or the hook surface — all inputs come in as props.
+- Keep the same `useEffect`-driven auto-select behavior from today (honor `initialInstanceId`, mark consumed, fall back to first running).
+- Do not regress the error-drilldown UX — the `Errors` tab must support per-error expansion with traceback, matching today's `ErrorRow`.
+- The slide-over must not cover the app's left `Sidebar` — it's scoped to the Algos view's frame.
+- All new components keep props explicit (no shared context) so each is independently testable and easy to reason about.
+
+## Risks & Open Questions
+
+- **Group-header "+ add" affordance** could feel noisy if repeated on every chart group. Mitigation: show only on hover.
+- **Config tab** adds surface area. If `algo.config` is typically unused, the tab can be hidden when empty — flagged for the implementation plan to decide.
+- **Slide-over vs. existing VenvSetupModal**: those are separate overlays and should not collide. Venv modal is global (from `App.tsx`); the slide-over is view-scoped. Safe to coexist.
+
+## References
+
+- Current implementation: `src/views/AlgosView.tsx`
+- Navigation contract: `src/types.ts` (`View`, `NavOptions`)
+- Shared hooks providing the data the view renders: `src/hooks/useTradingSimulation.ts`, `src/hooks/useAlgoErrors.ts`, `src/hooks/useAlgoLogs.ts`, `src/hooks/useAlgoHealth.ts`
+- Prior redesigns for style cues: `docs/superpowers/specs/2026-04-18-home-view-redesign-design.md`, `docs/superpowers/specs/2026-04-19-editor-view-redesign-design.md`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -401,6 +401,7 @@ export const App = () => {
             dataSources={dataSources}
             activeRuns={activeRuns}
             algoStats={simulation.algoStats}
+            runPnlHistories={simulation.runPnlHistories}
             errorsByInstance={errorsByInstance}
             logsByInstance={logsByInstance}
             healthByInstance={healthByInstance}
@@ -411,6 +412,7 @@ export const App = () => {
             aiTerminalAlgoIds={aiTerminalAlgoIds}
             initialInstanceId={pendingNavContext?.targetView === "algos" ? pendingNavContext.instanceId : null}
             onInstanceFocused={clearPendingNavContext}
+            onNavigate={handleNavigate}
           />
         )}
 

--- a/src/components/AlgoDetailPanel.tsx
+++ b/src/components/AlgoDetailPanel.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useState } from "react";
+import type { InstanceView } from "../lib/algoInstanceView";
+import { formatPnl, pnlColorClass } from "../lib/algoInstanceView";
+import type { LogEntry } from "../hooks/useAlgoLogs";
+import type { AlgoHealth } from "../hooks/useAlgoHealth";
+import type { AlgoError } from "../hooks/useAlgoErrors";
+import { LogPanel } from "./LogPanel";
+
+type Tab = "logs" | "errors" | "config";
+
+type AlgoDetailPanelProps = {
+  instance: InstanceView | null;
+  logs: LogEntry[];
+  health: AlgoHealth | undefined;
+  onClearLogs: () => void;
+  onStop: () => void;
+  onOpenInEditor: () => void;
+  onViewTrades: () => void;
+  onOpenAiTerminal?: () => void;
+  hasActiveAiTerminal: boolean;
+  onRunNewAlgo: () => void;
+};
+
+const formatErrorTime = (ts: number) => {
+  const date = new Date(ts);
+  return date.toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+};
+
+const ErrorRow = ({ error }: { error: AlgoError }) => {
+  const [expanded, setExpanded] = useState(false);
+  const severityColor =
+    error.severity === "warning"
+      ? "text-[var(--accent-yellow)]"
+      : "text-[var(--accent-red)]";
+  return (
+    <div className="border-b border-[var(--border)] last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left px-4 py-2 hover:bg-[var(--bg-secondary)] transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-[10px] text-[var(--text-secondary)] font-mono shrink-0">
+            {formatErrorTime(error.timestamp)}
+          </span>
+          <span className={`text-[10px] uppercase font-medium shrink-0 ${severityColor}`}>
+            {error.severity}
+          </span>
+          <span className="text-xs text-[var(--text-primary)] truncate">{error.message}</span>
+          {error.handler && (
+            <span className="text-[10px] text-[var(--text-secondary)] shrink-0 font-mono">
+              {error.handler}
+            </span>
+          )}
+        </div>
+      </button>
+      {expanded && error.traceback && (
+        <div className="px-4 pb-3">
+          <pre className="text-[10px] text-[var(--text-secondary)] bg-[var(--bg-primary)] rounded-md p-3 overflow-x-auto font-mono whitespace-pre-wrap">
+            {error.traceback}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Stat = ({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) => (
+  <div className="flex flex-col gap-0.5">
+    <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+      {label}
+    </span>
+    <span className={`text-sm font-mono font-medium tabular-nums ${color ?? ""}`}>
+      {value}
+    </span>
+  </div>
+);
+
+const EmptyState = ({
+  title,
+  body,
+  cta,
+  onCta,
+}: {
+  title: string;
+  body: string;
+  cta?: string;
+  onCta?: () => void;
+}) => (
+  <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 text-center gap-3">
+    <h3 className="text-sm font-medium">{title}</h3>
+    <p className="text-xs text-[var(--text-secondary)] max-w-[280px]">{body}</p>
+    {cta && onCta && (
+      <button
+        type="button"
+        onClick={onCta}
+        className="mt-2 px-3 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90"
+      >
+        {cta}
+      </button>
+    )}
+  </div>
+);
+
+export const AlgoDetailPanel = ({
+  instance,
+  logs,
+  health,
+  onClearLogs,
+  onStop,
+  onOpenInEditor,
+  onViewTrades,
+  onOpenAiTerminal,
+  hasActiveAiTerminal,
+  onRunNewAlgo,
+}: AlgoDetailPanelProps) => {
+  const [tab, setTab] = useState<Tab>("logs");
+
+  // Reset tab when selection changes: Errors if there are any, otherwise Logs.
+  // We intentionally depend only on the instance id so that live error updates
+  // on the currently-selected instance don't yank the user back to the Errors tab.
+  const selId = instance?.run.instance_id ?? null;
+  useEffect(() => {
+    if (!instance) return;
+    if (instance.errors && instance.errors.errorCount > 0) {
+      setTab("errors");
+    } else {
+      setTab("logs");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selId]);
+
+  if (!instance) {
+    return (
+      <div className="w-[380px] border-l border-[var(--border)] bg-[var(--bg-panel)] flex flex-col">
+        <EmptyState
+          title="Select an instance to see details"
+          body="Click a running algo on the left to see its stats, logs, errors, and quick actions."
+          cta="Run your first algo"
+          onCta={onRunNewAlgo}
+        />
+      </div>
+    );
+  }
+
+  const { run, algo, dataSource, stats, errors, status } = instance;
+  const pnl = stats?.pnl ?? 0;
+  const errorCount = errors?.errorCount ?? 0;
+  const warnCount = errors?.warningCount ?? 0;
+
+  const pillClass =
+    status === "halted"
+      ? "bg-[var(--accent-red)]/15 text-[var(--accent-red)]"
+      : run.mode === "live"
+        ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
+        : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+
+  const pillLabel = status === "halted" ? "Halted" : run.mode === "live" ? "Live" : "Shadow";
+
+  return (
+    <div className="w-[380px] border-l border-[var(--border)] bg-[var(--bg-panel)] flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-[var(--border)]">
+        <div className="flex items-start justify-between gap-3 mb-1">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold truncate">{algo.name}</h3>
+            <div className="text-[11px] text-[var(--text-secondary)] truncate">
+              on {dataSource.instrument} {dataSource.timeframe}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onStop}
+            disabled={status === "halted" || run.status === "installing"}
+            className="px-2.5 py-1 text-[11px] rounded-md font-medium bg-[var(--accent-red)] text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {run.status === "installing" ? "Installing…" : "Stop"}
+          </button>
+        </div>
+        <div className="flex items-center gap-2 text-[11px]">
+          <span
+            className={`text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded ${pillClass}`}
+          >
+            {pillLabel}
+          </span>
+          <span className="text-[var(--text-secondary)]">{run.account}</span>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-1.5 px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-secondary)]">
+        <button
+          type="button"
+          onClick={onOpenInEditor}
+          className="px-2.5 py-1 text-[11px] rounded-md font-medium bg-[var(--bg-panel)] border border-[var(--border)] text-[var(--text-primary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)] transition-colors"
+        >
+          λ Open in Editor
+        </button>
+        <button
+          type="button"
+          onClick={onViewTrades}
+          className="px-2.5 py-1 text-[11px] rounded-md font-medium bg-[var(--bg-panel)] border border-[var(--border)] text-[var(--text-primary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)] transition-colors"
+        >
+          ⇅ View trades
+        </button>
+        {onOpenAiTerminal && (
+          <button
+            type="button"
+            onClick={onOpenAiTerminal}
+            disabled={hasActiveAiTerminal}
+            className={`px-2.5 py-1 text-[11px] rounded-md font-medium border border-[var(--border)] transition-colors ${
+              hasActiveAiTerminal
+                ? "bg-[var(--bg-panel)] text-[var(--text-secondary)] cursor-not-allowed opacity-60"
+                : "bg-[var(--bg-panel)] text-[var(--text-primary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)]"
+            }`}
+          >
+            ◎ AI terminal
+          </button>
+        )}
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 px-4 py-3 border-b border-[var(--border)]">
+        <Stat label="P&L" value={formatPnl(pnl)} color={pnlColorClass(pnl)} />
+        <Stat
+          label="Win rate"
+          value={stats && stats.totalTrades > 0 ? `${stats.winRate}%` : "—"}
+        />
+        <Stat label="Sharpe" value={stats?.sharpe ?? "—"} />
+        <Stat label="Profit factor" value={stats?.profitFactor ?? "—"} />
+        <Stat
+          label="Avg win"
+          value={stats && stats.totalTrades > 0 ? formatPnl(stats.avgWin) : "—"}
+          color={stats && stats.totalTrades > 0 ? "text-[var(--accent-green)]" : undefined}
+        />
+        <Stat
+          label="Avg loss"
+          value={stats && stats.totalTrades > 0 ? formatPnl(stats.avgLoss) : "—"}
+          color={stats && stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+        />
+        <Stat
+          label="Max DD"
+          value={stats && stats.totalTrades > 0 ? formatPnl(-Math.abs(stats.maxDrawdown)) : "—"}
+          color={stats && stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined}
+        />
+        <Stat label="Trades" value={`${stats?.totalTrades ?? 0}`} />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-[var(--border)] px-2">
+        {(
+          [
+            { id: "logs", label: "Logs" },
+            { id: "errors", label: "Errors", count: errorCount + warnCount },
+            { id: "config", label: "Config" },
+          ] as { id: Tab; label: string; count?: number }[]
+        ).map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={`px-3 py-2 text-[11px] font-medium transition-colors border-b-2 ${
+              tab === t.id
+                ? "text-[var(--text-primary)] border-[var(--accent-blue)]"
+                : "text-[var(--text-secondary)] border-transparent hover:text-[var(--text-primary)]"
+            }`}
+          >
+            {t.label}
+            {typeof t.count === "number" && t.count > 0 && (
+              <span className="ml-1 text-[9px] px-1 py-0.5 rounded bg-[var(--accent-red)]/15 text-[var(--accent-red)]">
+                {t.count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab body */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {tab === "logs" && (
+          <LogPanel logs={logs} health={health} onClear={onClearLogs} />
+        )}
+        {tab === "errors" &&
+          (errors && errors.errors.length > 0 ? (
+            <div className="overflow-auto">
+              {errors.autoStopped && (
+                <div className="px-4 py-2 bg-[var(--accent-red)]/10 text-[var(--accent-red)] text-xs font-medium">
+                  Algo halted due to repeated errors
+                </div>
+              )}
+              {errors.errors.map((e) => (
+                <ErrorRow key={e.id} error={e} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex-1 flex items-center justify-center text-xs text-[var(--text-secondary)] py-8">
+              No errors recorded
+            </div>
+          ))}
+        {tab === "config" && (
+          <div className="flex-1 overflow-auto p-4">
+            {algo.config ? (
+              <pre className="text-[11px] font-mono whitespace-pre-wrap bg-[var(--bg-primary)] rounded-md p-3 border border-[var(--border)]">
+                {algo.config}
+              </pre>
+            ) : (
+              <div className="text-xs text-[var(--text-secondary)]">
+                No config defined. Edit in the Editor view.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/AlgoGroupHeader.tsx
+++ b/src/components/AlgoGroupHeader.tsx
@@ -1,0 +1,55 @@
+import type { GroupView } from "../lib/algoInstanceView";
+import { formatPnl, pnlColorClass } from "../lib/algoInstanceView";
+
+type AlgoGroupHeaderProps = {
+  group: GroupView;
+  onDeepLink: () => void;
+  onAddAlgo: () => void;
+};
+
+export const AlgoGroupHeader = ({ group, onDeepLink, onAddAlgo }: AlgoGroupHeaderProps) => {
+  if (group.groupBy === "none") return null;
+
+  const linkLabel = group.groupBy === "chart" ? "→ chart" : "→ editor";
+  const linkTitle =
+    group.groupBy === "chart"
+      ? "Open Trading view for this account"
+      : "Open this algo in Editor";
+
+  return (
+    <div className="group flex items-center gap-3 px-4 py-2 bg-[var(--bg-secondary)] border-b border-[var(--border)] sticky top-0 z-10">
+      <span className="text-[var(--text-secondary)] text-xs">▼</span>
+      <span className="text-xs font-semibold">{group.label}</span>
+      <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+        {group.meta}
+      </span>
+      <div className="ml-auto flex items-center gap-3 text-[11px]">
+        <span className={`font-mono tabular-nums ${pnlColorClass(group.aggregatePnl)}`}>
+          {formatPnl(group.aggregatePnl)}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAddAlgo();
+          }}
+          className="opacity-0 group-hover:opacity-100 text-[10px] px-2 py-0.5 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent-blue)] hover:text-[var(--accent-blue)] transition-all"
+          title="Run a new algo in this group"
+        >
+          + add
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeepLink();
+          }}
+          className="text-[10px] text-[var(--accent-blue)] hover:underline"
+          title={linkTitle}
+        >
+          {linkLabel}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/AlgoInstanceRow.tsx
+++ b/src/components/AlgoInstanceRow.tsx
@@ -8,6 +8,7 @@ import {
 type AlgoInstanceRowProps = {
   instance: InstanceView;
   isSelected: boolean;
+  hasActiveAiTerminal: boolean;
   onSelect: () => void;
   onClear: () => void;
 };
@@ -34,6 +35,7 @@ const SPARK_H = 18;
 export const AlgoInstanceRow = ({
   instance,
   isSelected,
+  hasActiveAiTerminal,
   onSelect,
   onClear,
 }: AlgoInstanceRowProps) => {
@@ -41,6 +43,7 @@ export const AlgoInstanceRow = ({
   const pnl = stats?.pnl ?? 0;
   const points = sparklinePoints(pnlHistory, SPARK_W, SPARK_H);
   const strokeColor = pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+  const isInstalling = run.status === "installing";
 
   const statusLabel =
     status === "halted"
@@ -49,7 +52,17 @@ export const AlgoInstanceRow = ({
         ? `${errors.warningCount} warn`
         : null;
 
-  const pillLabel = status === "halted" ? "Halted" : run.mode === "live" ? "Live" : "Shadow";
+  const pillLabel = isInstalling
+    ? "Installing"
+    : status === "halted"
+      ? "Halted"
+      : run.mode === "live"
+        ? "Live"
+        : "Shadow";
+
+  const pillTone = isInstalling
+    ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
+    : pillClass(status, run.mode);
 
   return (
     <div
@@ -66,6 +79,12 @@ export const AlgoInstanceRow = ({
       <div className="flex flex-col gap-0.5 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium truncate">{algo.name}</span>
+          {hasActiveAiTerminal && (
+            <span
+              className="w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse shrink-0"
+              title="AI terminal active"
+            />
+          )}
           {statusLabel && (
             <span
               className={`text-[10px] ${
@@ -86,11 +105,11 @@ export const AlgoInstanceRow = ({
       </div>
 
       <span
-        className={`text-[9px] uppercase tracking-wider px-2 py-0.5 rounded font-semibold text-center ${pillClass(
-          status,
-          run.mode,
-        )}`}
+        className={`text-[9px] uppercase tracking-wider px-2 py-0.5 rounded font-semibold text-center inline-flex items-center justify-center gap-1 ${pillTone}`}
       >
+        {isInstalling && (
+          <span className="w-2 h-2 border-2 border-[var(--accent-blue)] border-t-transparent rounded-full animate-spin" />
+        )}
         {pillLabel}
       </span>
 

--- a/src/components/AlgoInstanceRow.tsx
+++ b/src/components/AlgoInstanceRow.tsx
@@ -1,0 +1,140 @@
+import type { InstanceView } from "../lib/algoInstanceView";
+import {
+  formatPnl,
+  pnlColorClass,
+  sparklinePoints,
+} from "../lib/algoInstanceView";
+
+type AlgoInstanceRowProps = {
+  instance: InstanceView;
+  isSelected: boolean;
+  onSelect: () => void;
+  onClear: () => void;
+};
+
+const pillClass = (status: InstanceView["status"], mode: string): string => {
+  if (status === "halted") {
+    return "bg-[var(--accent-red)]/15 text-[var(--accent-red)]";
+  }
+  if (mode === "live") {
+    return "bg-[var(--accent-green)]/15 text-[var(--accent-green)]";
+  }
+  return "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+};
+
+const dotClass = (status: InstanceView["status"]): string => {
+  if (status === "halted") return "bg-[var(--accent-red)]";
+  if (status === "warning") return "bg-[var(--accent-yellow)]";
+  return "bg-[var(--accent-green)]";
+};
+
+const SPARK_W = 80;
+const SPARK_H = 18;
+
+export const AlgoInstanceRow = ({
+  instance,
+  isSelected,
+  onSelect,
+  onClear,
+}: AlgoInstanceRowProps) => {
+  const { run, algo, dataSource, stats, errors, status, pnlHistory } = instance;
+  const pnl = stats?.pnl ?? 0;
+  const points = sparklinePoints(pnlHistory, SPARK_W, SPARK_H);
+  const strokeColor = pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+
+  const statusLabel =
+    status === "halted"
+      ? "halted"
+      : errors && errors.warningCount > 0
+        ? `${errors.warningCount} warn`
+        : null;
+
+  const pillLabel = status === "halted" ? "Halted" : run.mode === "live" ? "Live" : "Shadow";
+
+  return (
+    <div
+      onClick={onSelect}
+      className={`group grid items-center gap-3 px-4 py-2.5 border-b border-[var(--border)] cursor-pointer transition-colors ${
+        isSelected
+          ? "bg-[var(--accent-blue)]/10 border-l-2 border-l-[var(--accent-blue)] pl-[14px]"
+          : "hover:bg-[var(--bg-secondary)]"
+      } ${status === "halted" ? "opacity-75" : ""}`}
+      style={{ gridTemplateColumns: "18px 1fr 76px 80px 110px 96px 28px" }}
+    >
+      <span className={`w-2 h-2 rounded-full ${dotClass(status)}`} />
+
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium truncate">{algo.name}</span>
+          {statusLabel && (
+            <span
+              className={`text-[10px] ${
+                status === "halted" ? "text-[var(--accent-red)]" : "text-[var(--accent-yellow)]"
+              }`}
+            >
+              {statusLabel}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-[10px] text-[var(--text-secondary)] truncate">
+          <span className="truncate">
+            {dataSource.instrument} {dataSource.timeframe}
+          </span>
+          <span>·</span>
+          <span className="truncate">{run.account}</span>
+        </div>
+      </div>
+
+      <span
+        className={`text-[9px] uppercase tracking-wider px-2 py-0.5 rounded font-semibold text-center ${pillClass(
+          status,
+          run.mode,
+        )}`}
+      >
+        {pillLabel}
+      </span>
+
+      <div className="flex items-center justify-center h-[18px]">
+        {points ? (
+          <svg
+            viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+            preserveAspectRatio="none"
+            width={SPARK_W}
+            height={SPARK_H}
+            aria-hidden
+          >
+            <polyline fill="none" stroke={strokeColor} strokeWidth="1.2" points={points} />
+          </svg>
+        ) : (
+          <span className="text-[var(--text-secondary)] text-xs">—</span>
+        )}
+      </div>
+
+      <span className={`text-sm font-mono tabular-nums text-right ${pnlColorClass(pnl)}`}>
+        {formatPnl(pnl)}
+      </span>
+
+      <span className="text-[11px] text-[var(--text-secondary)] text-right font-mono tabular-nums">
+        {stats && stats.totalTrades > 0
+          ? `${stats.totalTrades} · ${stats.winRate}%`
+          : "— · —"}
+      </span>
+
+      {status === "halted" ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClear();
+          }}
+          className="opacity-0 group-hover:opacity-100 text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent-red)] transition-all"
+          title="Clear this row from the list"
+        >
+          ✕
+        </button>
+      ) : (
+        <span />
+      )}
+    </div>
+  );
+};

--- a/src/components/AlgosCommandBar.tsx
+++ b/src/components/AlgosCommandBar.tsx
@@ -1,0 +1,54 @@
+import { formatPnl, pnlColorClass } from "../lib/algoInstanceView";
+
+type AlgosCommandBarProps = {
+  chartCount: number;
+  instanceCount: number;
+  runningCount: number;
+  haltedCount: number;
+  sessionPnl: number;
+  onRunNewAlgo: () => void;
+};
+
+export const AlgosCommandBar = ({
+  chartCount,
+  instanceCount,
+  runningCount,
+  haltedCount,
+  sessionPnl,
+  onRunNewAlgo,
+}: AlgosCommandBarProps) => {
+  const metaParts = [
+    `${chartCount} chart${chartCount === 1 ? "" : "s"}`,
+    `${instanceCount} instance${instanceCount === 1 ? "" : "s"}`,
+    `${runningCount} running`,
+  ];
+  if (haltedCount > 0) metaParts.push(`${haltedCount} halted`);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-3 bg-[var(--bg-panel)] border-b border-[var(--border)]">
+      <div className="flex items-baseline gap-3 min-w-0">
+        <h2 className="text-[15px] font-semibold tracking-tight">Algos</h2>
+        <span className="text-[11px] text-[var(--text-secondary)] truncate">
+          {metaParts.join(" · ")}
+        </span>
+      </div>
+      <div className="flex items-center gap-4">
+        <div className="flex items-baseline gap-2">
+          <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+            Session
+          </span>
+          <span className={`text-sm font-mono font-semibold tabular-nums ${pnlColorClass(sessionPnl)}`}>
+            {formatPnl(sessionPnl)}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onRunNewAlgo}
+          className="px-3.5 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90 transition-opacity"
+        >
+          + Run new algo
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/AlgosFilterBar.tsx
+++ b/src/components/AlgosFilterBar.tsx
@@ -1,0 +1,98 @@
+import type { GroupBy, ModeFilter, StatusFilter } from "../lib/algoInstanceView";
+
+type AlgosFilterBarProps = {
+  groupBy: GroupBy;
+  onGroupByChange: (v: GroupBy) => void;
+  modeFilter: ModeFilter;
+  onModeFilterChange: (v: ModeFilter) => void;
+  statusFilter: StatusFilter;
+  onStatusFilterChange: (v: StatusFilter) => void;
+  searchQuery: string;
+  onSearchQueryChange: (v: string) => void;
+};
+
+type SegItem<T extends string> = { value: T; label: string };
+
+const GROUP_BY_OPTIONS: SegItem<GroupBy>[] = [
+  { value: "chart", label: "Chart" },
+  { value: "algo", label: "Algo" },
+  { value: "none", label: "None" },
+];
+
+const MODE_OPTIONS: SegItem<ModeFilter>[] = [
+  { value: "all", label: "All" },
+  { value: "live", label: "Live" },
+  { value: "shadow", label: "Shadow" },
+];
+
+const STATUS_OPTIONS: SegItem<StatusFilter>[] = [
+  { value: "all", label: "All" },
+  { value: "running", label: "Running" },
+  { value: "warning", label: "Warning" },
+  { value: "halted", label: "Halted" },
+];
+
+const Segmented = <T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T;
+  options: SegItem<T>[];
+  onChange: (v: T) => void;
+}) => (
+  <div className="flex bg-[var(--bg-secondary)] border border-[var(--border)] rounded-md overflow-hidden">
+    {options.map((opt) => (
+      <button
+        key={opt.value}
+        type="button"
+        onClick={() => onChange(opt.value)}
+        className={`px-2.5 py-1 text-[11px] transition-colors ${
+          value === opt.value
+            ? "bg-[var(--bg-panel)] text-[var(--text-primary)]"
+            : "text-[var(--text-secondary)] hover:bg-[var(--bg-panel)]"
+        }`}
+      >
+        {opt.label}
+      </button>
+    ))}
+  </div>
+);
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">
+    {children}
+  </span>
+);
+
+export const AlgosFilterBar = ({
+  groupBy,
+  onGroupByChange,
+  modeFilter,
+  onModeFilterChange,
+  statusFilter,
+  onStatusFilterChange,
+  searchQuery,
+  onSearchQueryChange,
+}: AlgosFilterBarProps) => (
+  <div className="flex items-center gap-3 px-4 py-2 bg-[var(--bg-panel)] border-b border-[var(--border)]">
+    <Label>Group by</Label>
+    <Segmented value={groupBy} options={GROUP_BY_OPTIONS} onChange={onGroupByChange} />
+
+    <Label>Mode</Label>
+    <Segmented value={modeFilter} options={MODE_OPTIONS} onChange={onModeFilterChange} />
+
+    <Label>Status</Label>
+    <Segmented value={statusFilter} options={STATUS_OPTIONS} onChange={onStatusFilterChange} />
+
+    <div className="flex-1" />
+
+    <input
+      type="search"
+      value={searchQuery}
+      onChange={(e) => onSearchQueryChange(e.target.value)}
+      placeholder="Search algo, instrument, account…"
+      className="w-[220px] px-2.5 py-1 text-[11px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-blue)]"
+    />
+  </div>
+);

--- a/src/components/AlgosInstanceList.tsx
+++ b/src/components/AlgosInstanceList.tsx
@@ -7,6 +7,7 @@ type AlgosInstanceListProps = {
   hasAnyCharts: boolean;
   hasAnyInstances: boolean;
   selectedInstanceId: string | null;
+  aiTerminalAlgoIds?: Set<number>;
   onSelect: (instance: InstanceView) => void;
   onClear: (instance: InstanceView) => void;
   onGroupDeepLink: (group: GroupView) => void;
@@ -20,6 +21,7 @@ export const AlgosInstanceList = ({
   hasAnyCharts,
   hasAnyInstances,
   selectedInstanceId,
+  aiTerminalAlgoIds,
   onSelect,
   onClear,
   onGroupDeepLink,
@@ -87,6 +89,7 @@ export const AlgosInstanceList = ({
               key={inst.run.instance_id}
               instance={inst}
               isSelected={selectedInstanceId === inst.run.instance_id}
+              hasActiveAiTerminal={aiTerminalAlgoIds?.has(inst.algo.id) ?? false}
               onSelect={() => onSelect(inst)}
               onClear={() => onClear(inst)}
             />

--- a/src/components/AlgosInstanceList.tsx
+++ b/src/components/AlgosInstanceList.tsx
@@ -1,0 +1,98 @@
+import type { GroupView, InstanceView } from "../lib/algoInstanceView";
+import { AlgoGroupHeader } from "./AlgoGroupHeader";
+import { AlgoInstanceRow } from "./AlgoInstanceRow";
+
+type AlgosInstanceListProps = {
+  groups: GroupView[];
+  hasAnyCharts: boolean;
+  hasAnyInstances: boolean;
+  selectedInstanceId: string | null;
+  onSelect: (instance: InstanceView) => void;
+  onClear: (instance: InstanceView) => void;
+  onGroupDeepLink: (group: GroupView) => void;
+  onGroupAddAlgo: (group: GroupView) => void;
+  onClearFilters: () => void;
+  onRunNewAlgo: () => void;
+};
+
+export const AlgosInstanceList = ({
+  groups,
+  hasAnyCharts,
+  hasAnyInstances,
+  selectedInstanceId,
+  onSelect,
+  onClear,
+  onGroupDeepLink,
+  onGroupAddAlgo,
+  onClearFilters,
+  onRunNewAlgo,
+}: AlgosInstanceListProps) => {
+  if (!hasAnyCharts) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="max-w-[380px] text-center text-xs text-[var(--text-secondary)]">
+          No charts connected. Add the WolfDenBridge indicator to a NinjaTrader chart to get
+          started.
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasAnyInstances) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center">
+        <h3 className="text-sm font-medium">No algos running</h3>
+        <p className="text-xs text-[var(--text-secondary)] max-w-[320px]">
+          Charts are connected but no algos are running. Start one to see it here.
+        </p>
+        <button
+          type="button"
+          onClick={onRunNewAlgo}
+          className="mt-1 px-3 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90"
+        >
+          + Run new algo
+        </button>
+      </div>
+    );
+  }
+
+  if (groups.length === 0 || groups.every((g) => g.instances.length === 0)) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="text-xs text-[var(--text-secondary)] flex items-center gap-3">
+          <span>No instances match these filters</span>
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="text-[var(--accent-blue)] hover:underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      {groups.map((group) => (
+        <div key={group.key}>
+          <AlgoGroupHeader
+            group={group}
+            onDeepLink={() => onGroupDeepLink(group)}
+            onAddAlgo={() => onGroupAddAlgo(group)}
+          />
+          {group.instances.map((inst) => (
+            <AlgoInstanceRow
+              key={inst.run.instance_id}
+              instance={inst}
+              isSelected={selectedInstanceId === inst.run.instance_id}
+              onSelect={() => onSelect(inst)}
+              onClear={() => onClear(inst)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/RunAlgoSlideOver.tsx
+++ b/src/components/RunAlgoSlideOver.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react";
+import type { Algo, AlgoRun } from "../types";
+import type { DataSource } from "../hooks/useTradingSimulation";
+
+type Mode = "live" | "shadow";
+
+type RunAlgoSlideOverProps = {
+  open: boolean;
+  algos: Algo[];
+  dataSources: DataSource[];
+  activeRuns: AlgoRun[];
+  prefill: { algoId?: number; chartId?: string } | null;
+  onClose: () => void;
+  onStart: (algoId: number, mode: Mode, account: string, dataSourceId: string) => void;
+};
+
+export const RunAlgoSlideOver = ({
+  open,
+  algos,
+  dataSources,
+  activeRuns,
+  prefill,
+  onClose,
+  onStart,
+}: RunAlgoSlideOverProps) => {
+  const [algoId, setAlgoId] = useState<number | null>(null);
+  const [chartId, setChartId] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>("shadow");
+  const [accountOverride, setAccountOverride] = useState<string>("");
+
+  // Reset on open, respecting prefill.
+  useEffect(() => {
+    if (!open) return;
+    setAlgoId(prefill?.algoId ?? null);
+    setChartId(prefill?.chartId ?? null);
+    setMode("shadow");
+    setAccountOverride("");
+  }, [open, prefill]);
+
+  // Esc to close.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const chart = dataSources.find((d) => d.id === chartId) ?? null;
+  const algo = algos.find((a) => a.id === algoId) ?? null;
+  const effectiveAccount = accountOverride.trim() || chart?.account || "";
+  const duplicate =
+    algo &&
+    chart &&
+    activeRuns.some((r) => r.algo_id === algo.id && r.data_source_id === chart.id);
+
+  const canSubmit = !!algo && !!chart && !!effectiveAccount && !duplicate;
+
+  const handleSubmit = () => {
+    if (!canSubmit || !algo || !chart) return;
+    onStart(algo.id, mode, effectiveAccount, chart.id);
+    onClose();
+  };
+
+  return (
+    <>
+      {/* Scrim */}
+      <div
+        onClick={onClose}
+        className="absolute inset-0 bg-black/30 z-20"
+        aria-hidden
+      />
+
+      {/* Panel */}
+      <aside
+        className="absolute top-0 right-0 bottom-0 w-[380px] bg-[var(--bg-panel)] border-l border-[var(--border)] z-30 flex flex-col shadow-2xl"
+        role="dialog"
+        aria-label="Run a new algo"
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)]">
+          <h3 className="text-sm font-semibold">Run a new algo</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-sm leading-none"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4 flex flex-col gap-4">
+          <Field label="Algo">
+            <select
+              value={algoId ?? ""}
+              onChange={(e) => setAlgoId(e.target.value ? Number(e.target.value) : null)}
+              className="w-full px-2.5 py-1.5 text-[12px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-blue)]"
+            >
+              <option value="">Select an algo…</option>
+              {algos.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Chart">
+            <select
+              value={chartId ?? ""}
+              onChange={(e) => setChartId(e.target.value || null)}
+              className="w-full px-2.5 py-1.5 text-[12px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-blue)]"
+            >
+              <option value="">Select a chart…</option>
+              {dataSources.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.instrument} {d.timeframe} · {d.account}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Mode">
+            <div className="grid grid-cols-2 gap-2">
+              <ModeChip
+                tone="yellow"
+                selected={mode === "shadow"}
+                label="◐ Shadow"
+                onClick={() => setMode("shadow")}
+              />
+              <ModeChip
+                tone="green"
+                selected={mode === "live"}
+                label="● Live"
+                onClick={() => setMode("live")}
+              />
+            </div>
+          </Field>
+
+          <Field label="Account override (optional)">
+            <input
+              type="text"
+              value={accountOverride}
+              onChange={(e) => setAccountOverride(e.target.value)}
+              placeholder={chart ? `use chart's account · ${chart.account}` : "pick a chart first"}
+              className="w-full px-2.5 py-1.5 text-[12px] rounded-md bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-blue)]"
+            />
+          </Field>
+
+          {duplicate && (
+            <div className="text-[11px] text-[var(--accent-yellow)]">
+              This algo is already running on the selected chart.
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-3 border-t border-[var(--border)] bg-[var(--bg-secondary)]">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded-md text-[var(--text-secondary)] border border-[var(--border)] hover:text-[var(--text-primary)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="px-3.5 py-1.5 text-xs rounded-md font-medium bg-[var(--accent-blue)] text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Start
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex flex-col gap-1.5">
+    <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] font-medium">
+      {label}
+    </span>
+    {children}
+  </div>
+);
+
+const ModeChip = ({
+  tone,
+  selected,
+  label,
+  onClick,
+}: {
+  tone: "yellow" | "green";
+  selected: boolean;
+  label: string;
+  onClick: () => void;
+}) => {
+  const base = "px-3 py-1.5 text-xs rounded-md font-medium border transition-colors";
+  const toneClass =
+    tone === "green"
+      ? selected
+        ? "bg-[var(--accent-green)]/15 border-[var(--accent-green)] text-[var(--accent-green)]"
+        : "bg-transparent border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent-green)]"
+      : selected
+        ? "bg-[var(--accent-yellow)]/15 border-[var(--accent-yellow)] text-[var(--accent-yellow)]"
+        : "bg-transparent border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent-yellow)]";
+  return (
+    <button type="button" onClick={onClick} className={`${base} ${toneClass}`}>
+      {label}
+    </button>
+  );
+};

--- a/src/lib/algoInstanceView.ts
+++ b/src/lib/algoInstanceView.ts
@@ -1,0 +1,225 @@
+import type { Algo, AlgoRun } from "../types";
+import type { AlgoStats, DataSource } from "../hooks/useTradingSimulation";
+import type { InstanceErrors } from "../hooks/useAlgoErrors";
+
+export type GroupBy = "chart" | "algo" | "none";
+export type ModeFilter = "all" | "live" | "shadow";
+export type StatusFilter = "all" | "running" | "halted" | "warning";
+export type InstanceStatus = "running" | "halted" | "warning";
+
+export type ViewFilters = {
+  mode: ModeFilter;
+  status: StatusFilter;
+  search: string;
+};
+
+export type InstanceView = {
+  run: AlgoRun;
+  algo: Algo;
+  dataSource: DataSource;
+  stats: AlgoStats | undefined;
+  errors: InstanceErrors | undefined;
+  status: InstanceStatus;
+  pnlHistory: number[];
+};
+
+export type GroupView = {
+  key: string;
+  label: string;
+  meta: string;
+  aggregatePnl: number;
+  instances: InstanceView[];
+  groupBy: GroupBy;
+  // Deep-link payloads — populated per-pivot:
+  chartId?: string;
+  account?: string;
+  algoId?: number;
+};
+
+export const computeStatus = (errors: InstanceErrors | undefined): InstanceStatus => {
+  if (!errors) return "running";
+  if (errors.autoStopped) return "halted";
+  if (errors.warningCount > 0 || errors.errorCount > 0) return "warning";
+  return "running";
+};
+
+export const aggregatePnl = (instances: InstanceView[]): number =>
+  instances.reduce((sum, i) => sum + (i.stats?.pnl ?? 0), 0);
+
+export const sparklinePoints = (history: number[], width: number, height: number): string => {
+  if (history.length <= 1) return "";
+  const min = Math.min(...history);
+  const max = Math.max(...history);
+  const range = max - min || 1;
+  const stepX = width / (history.length - 1);
+  return history
+    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
+    .join(" ");
+};
+
+export const passesFilters = (inst: InstanceView, filters: ViewFilters): boolean => {
+  if (filters.mode !== "all" && inst.run.mode !== filters.mode) return false;
+  if (filters.status !== "all" && inst.status !== filters.status) return false;
+  if (filters.search.trim()) {
+    const q = filters.search.trim().toLowerCase();
+    const hay = [
+      inst.algo.name,
+      inst.dataSource.instrument,
+      inst.dataSource.timeframe,
+      inst.run.account,
+    ]
+      .join(" ")
+      .toLowerCase();
+    if (!hay.includes(q)) return false;
+  }
+  return true;
+};
+
+// Halted rows sort to the bottom of their group; running / warning in original order.
+const sortInstances = (instances: InstanceView[]): InstanceView[] => {
+  const rank = (s: InstanceStatus) => (s === "halted" ? 1 : 0);
+  return [...instances].sort((a, b) => rank(a.status) - rank(b.status));
+};
+
+type BuildArgs = {
+  activeRuns: AlgoRun[];
+  algos: Algo[];
+  dataSources: DataSource[];
+  algoStats: Record<string, AlgoStats>;
+  errorsByInstance: Record<string, InstanceErrors>;
+  runPnlHistories: Record<string, number[]>;
+  dismissedInstanceIds: Set<string>;
+  groupBy: GroupBy;
+  filters: ViewFilters;
+};
+
+export const buildInstanceViews = ({
+  activeRuns,
+  algos,
+  dataSources,
+  algoStats,
+  errorsByInstance,
+  runPnlHistories,
+  dismissedInstanceIds,
+}: Pick<
+  BuildArgs,
+  | "activeRuns"
+  | "algos"
+  | "dataSources"
+  | "algoStats"
+  | "errorsByInstance"
+  | "runPnlHistories"
+  | "dismissedInstanceIds"
+>): InstanceView[] => {
+  const views: InstanceView[] = [];
+  for (const run of activeRuns) {
+    if (dismissedInstanceIds.has(run.instance_id)) continue;
+    const algo = algos.find((a) => a.id === run.algo_id);
+    const dataSource = dataSources.find((d) => d.id === run.data_source_id);
+    if (!algo || !dataSource) continue;
+    const errors = errorsByInstance[run.instance_id];
+    views.push({
+      run,
+      algo,
+      dataSource,
+      stats: algoStats[run.instance_id],
+      errors,
+      status: computeStatus(errors),
+      pnlHistory: runPnlHistories[run.instance_id] ?? [],
+    });
+  }
+  return views;
+};
+
+export const buildGroups = (args: BuildArgs): GroupView[] => {
+  const allViews = buildInstanceViews(args);
+  const filtered = allViews.filter((v) => passesFilters(v, args.filters));
+
+  if (args.groupBy === "none") {
+    const sorted = sortInstances(filtered);
+    return [
+      {
+        key: "__all__",
+        label: "All instances",
+        meta: `${sorted.length} instance${sorted.length === 1 ? "" : "s"}`,
+        aggregatePnl: aggregatePnl(sorted),
+        instances: sorted,
+        groupBy: "none",
+      },
+    ];
+  }
+
+  if (args.groupBy === "chart") {
+    const groups: GroupView[] = [];
+    for (const ds of args.dataSources) {
+      const dsInstances = sortInstances(filtered.filter((v) => v.dataSource.id === ds.id));
+      if (dsInstances.length === 0) continue;
+      groups.push({
+        key: `chart:${ds.id}`,
+        label: `${ds.instrument} ${ds.timeframe}`,
+        meta: `${ds.account} · ${dsInstances.length} algo${dsInstances.length === 1 ? "" : "s"}`,
+        aggregatePnl: aggregatePnl(dsInstances),
+        instances: dsInstances,
+        groupBy: "chart",
+        chartId: ds.id,
+        account: ds.account,
+      });
+    }
+    return groups;
+  }
+
+  // group by algo
+  const byAlgo = new Map<number, InstanceView[]>();
+  for (const v of filtered) {
+    const existing = byAlgo.get(v.algo.id) ?? [];
+    existing.push(v);
+    byAlgo.set(v.algo.id, existing);
+  }
+  const groups: GroupView[] = [];
+  const algoNameOrder = [...byAlgo.keys()].sort((a, b) => {
+    const na = args.algos.find((x) => x.id === a)?.name ?? "";
+    const nb = args.algos.find((x) => x.id === b)?.name ?? "";
+    return na.localeCompare(nb);
+  });
+  for (const algoId of algoNameOrder) {
+    const algo = args.algos.find((x) => x.id === algoId);
+    if (!algo) continue;
+    const instances = sortInstances(byAlgo.get(algoId) ?? []);
+    groups.push({
+      key: `algo:${algoId}`,
+      label: algo.name,
+      meta: `${instances.length} instance${instances.length === 1 ? "" : "s"}`,
+      aggregatePnl: aggregatePnl(instances),
+      instances,
+      groupBy: "algo",
+      algoId,
+    });
+  }
+  return groups;
+};
+
+export const formatPnl = (value: number): string => {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}$${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+export const pnlColorClass = (value: number): string =>
+  value > 0
+    ? "text-[var(--accent-green)]"
+    : value < 0
+      ? "text-[var(--accent-red)]"
+      : "text-[var(--text-primary)]";
+
+export const formatDurationShort = (msElapsed: number): string => {
+  if (msElapsed < 0) return "0s";
+  const totalSeconds = Math.floor(msElapsed / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+};

--- a/src/lib/algoInstanceView.ts
+++ b/src/lib/algoInstanceView.ts
@@ -212,14 +212,3 @@ export const pnlColorClass = (value: number): string =>
     : value < 0
       ? "text-[var(--accent-red)]"
       : "text-[var(--text-primary)]";
-
-export const formatDurationShort = (msElapsed: number): string => {
-  if (msElapsed < 0) return "0s";
-  const totalSeconds = Math.floor(msElapsed / 1000);
-  const h = Math.floor(totalSeconds / 3600);
-  const m = Math.floor((totalSeconds % 3600) / 60);
-  const s = totalSeconds % 60;
-  if (h > 0) return `${h}h ${m}m`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-};

--- a/src/views/AlgosView.tsx
+++ b/src/views/AlgosView.tsx
@@ -1,16 +1,29 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Algo, AlgoRun, NavOptions, View } from "../types";
 import { type AlgoStats, type DataSource } from "../hooks/useTradingSimulation";
-import { type InstanceErrors, type AlgoError } from "../hooks/useAlgoErrors";
+import { type InstanceErrors } from "../hooks/useAlgoErrors";
 import { type LogEntry } from "../hooks/useAlgoLogs";
 import { type AlgoHealth } from "../hooks/useAlgoHealth";
-import { LogPanel } from "../components/LogPanel";
-import type { Algo, AlgoRun } from "../types";
+import {
+  buildGroups,
+  type GroupBy,
+  type GroupView,
+  type InstanceView,
+  type ModeFilter,
+  type StatusFilter,
+} from "../lib/algoInstanceView";
+import { AlgosCommandBar } from "../components/AlgosCommandBar";
+import { AlgosFilterBar } from "../components/AlgosFilterBar";
+import { AlgosInstanceList } from "../components/AlgosInstanceList";
+import { AlgoDetailPanel } from "../components/AlgoDetailPanel";
+import { RunAlgoSlideOver } from "../components/RunAlgoSlideOver";
 
 type AlgosViewProps = {
   algos: Algo[];
   dataSources: DataSource[];
   activeRuns: AlgoRun[];
   algoStats: Record<string, AlgoStats>;
+  runPnlHistories: Record<string, number[]>;
   errorsByInstance: Record<string, InstanceErrors>;
   logsByInstance: Record<string, LogEntry[]>;
   healthByInstance: Record<string, AlgoHealth>;
@@ -20,343 +33,8 @@ type AlgosViewProps = {
   onOpenAiTerminal?: (algoId: number) => void;
   aiTerminalAlgoIds?: Set<number>;
   initialInstanceId?: string | null;
-  /** Called after initialInstanceId is consumed (found or not). Not called when falling back to default auto-select. */
   onInstanceFocused?: () => void;
-};
-
-const formatDataSource = (ds: DataSource) => {
-  const symbol = ds.instrument.split(" ")[0];
-  return `${symbol} ${ds.timeframe}`;
-};
-
-const Stat = ({ label, value, color }: { label: string; value: string; color?: string }) => (
-  <div>
-    <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">{label}</div>
-    <div className={`text-sm font-medium ${color ?? ""}`}>{value}</div>
-  </div>
-);
-
-const PerformanceStats = ({ stats }: { stats: AlgoStats }) => {
-  const pnlColor = stats.pnl >= 0 ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
-
-  return (
-    <div>
-      {stats.label && (
-        <div className="px-6 pb-1">
-          <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-md bg-[var(--accent-blue)]/10 text-[var(--accent-blue)] font-medium">
-            {stats.label}
-          </span>
-        </div>
-      )}
-      <div className="grid grid-cols-4 gap-x-6 gap-y-3 px-6 pb-4 pt-2">
-      <Stat label="P&L" value={`${stats.pnl >= 0 ? "+" : ""}$${Math.abs(stats.pnl).toFixed(2)}`} color={pnlColor} />
-      <Stat label="Win Rate" value={stats.totalTrades > 0 ? `${stats.winRate}%` : "--"} />
-      <Stat label="Sharpe" value={stats.sharpe} />
-      <Stat label="Profit Factor" value={stats.profitFactor} />
-      <Stat label="Total Trades" value={`${stats.totalTrades}`} />
-      <Stat label="Avg Win" value={stats.totalTrades > 0 ? `+$${stats.avgWin.toFixed(2)}` : "--"} color={stats.totalTrades > 0 ? "text-[var(--accent-green)]" : undefined} />
-      <Stat label="Avg Loss" value={stats.totalTrades > 0 ? `-$${Math.abs(stats.avgLoss).toFixed(2)}` : "--"} color={stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined} />
-      <Stat label="Max Drawdown" value={stats.totalTrades > 0 ? `-$${Math.abs(stats.maxDrawdown).toFixed(2)}` : "--"} color={stats.totalTrades > 0 ? "text-[var(--accent-red)]" : undefined} />
-      </div>
-    </div>
-  );
-};
-
-const ErrorBadge = ({ errors }: { errors: InstanceErrors }) => {
-  if (errors.errorCount === 0 && errors.warningCount === 0) return null;
-
-  return (
-    <div className="flex items-center gap-1.5">
-      {errors.errorCount > 0 && (
-        <span className="text-[10px] px-2 py-0.5 rounded-md font-medium bg-[var(--accent-red)]/15 text-[var(--accent-red)]">
-          {errors.errorCount} error{errors.errorCount !== 1 ? "s" : ""}
-        </span>
-      )}
-      {errors.warningCount > 0 && (
-        <span className="text-[10px] px-2 py-0.5 rounded-md font-medium bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
-          {errors.warningCount} warning{errors.warningCount !== 1 ? "s" : ""}
-        </span>
-      )}
-      {errors.autoStopped && (
-        <span className="text-[10px] px-2 py-0.5 rounded-md font-medium bg-[var(--accent-red)]/15 text-[var(--accent-red)]">
-          halted
-        </span>
-      )}
-    </div>
-  );
-};
-
-const formatErrorTime = (ts: number) => {
-  const date = new Date(ts);
-  return date.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
-};
-
-const ErrorRow = ({ error }: { error: AlgoError }) => {
-  const [expanded, setExpanded] = useState(false);
-  const severityColor = error.severity === "warning"
-    ? "text-[var(--accent-yellow)]"
-    : "text-[var(--accent-red)]";
-
-  return (
-    <div className="border-b border-[var(--border)] last:border-b-0">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full text-left px-4 py-2 hover:bg-[var(--bg-secondary)] transition-colors"
-      >
-        <div className="flex items-center gap-3">
-          <span className="text-[10px] text-[var(--text-secondary)] font-mono shrink-0">
-            {formatErrorTime(error.timestamp)}
-          </span>
-          <span className={`text-[10px] uppercase font-medium shrink-0 ${severityColor}`}>
-            {error.severity}
-          </span>
-          <span className="text-xs text-[var(--text-primary)] truncate">{error.message}</span>
-          {error.handler && (
-            <span className="text-[10px] text-[var(--text-secondary)] shrink-0 font-mono">
-              {error.handler}
-            </span>
-          )}
-        </div>
-      </button>
-      {expanded && error.traceback && (
-        <div className="px-4 pb-3">
-          <pre className="text-[10px] text-[var(--text-secondary)] bg-[var(--bg-primary)] rounded-md p-3 overflow-x-auto font-mono whitespace-pre-wrap">
-            {error.traceback}
-          </pre>
-        </div>
-      )}
-    </div>
-  );
-};
-
-const ErrorList = ({ errors }: { errors: InstanceErrors }) => {
-  if (errors.errors.length === 0) return null;
-
-  return (
-    <div className="border-t border-[var(--border)] max-h-48 overflow-auto">
-      {errors.autoStopped && (
-        <div className="px-4 py-2 bg-[var(--accent-red)]/10 text-[var(--accent-red)] text-xs font-medium">
-          Algo halted due to repeated errors
-        </div>
-      )}
-      {errors.errors.map((error) => (
-        <ErrorRow key={error.id} error={error} />
-      ))}
-    </div>
-  );
-};
-
-const ChartCard = ({
-  ds,
-  isSelected,
-  runCount,
-  onClick,
-}: {
-  ds: DataSource;
-  isSelected: boolean;
-  runCount: number;
-  onClick: () => void;
-}) => {
-  return (
-    <button
-      onClick={onClick}
-      className={`w-full text-left p-4 rounded-lg border transition-colors ${
-        isSelected
-          ? "bg-[var(--accent-blue)]/10 border-[var(--accent-blue)]/30"
-          : "bg-[var(--bg-panel)] border-[var(--border)] hover:border-[var(--text-secondary)]/30"
-      }`}
-    >
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-[var(--accent-green)]" />
-          <span className="text-sm font-medium">{formatDataSource(ds)}</span>
-        </div>
-        {runCount > 0 && (
-          <span className="text-[10px] px-2 py-0.5 rounded-full bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]">
-            {runCount} algo{runCount > 1 ? "s" : ""}
-          </span>
-        )}
-      </div>
-      <div className="flex items-center gap-3 text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
-        <span>{ds.instrument}</span>
-        <span>{ds.timeframe}</span>
-        <span>{ds.account}</span>
-      </div>
-    </button>
-  );
-};
-
-const AddAlgoPanel = ({
-  algos,
-  chartRuns,
-  ds,
-  onStartAlgo,
-  onOpenAiTerminal,
-  aiTerminalAlgoIds,
-}: {
-  algos: Algo[];
-  chartRuns: AlgoRun[];
-  ds: DataSource;
-  onStartAlgo: (id: number, mode: "live" | "shadow", account: string, dataSourceId: string) => void;
-  onOpenAiTerminal?: (algoId: number) => void;
-  aiTerminalAlgoIds?: Set<number>;
-}) => {
-  const availableAlgos = algos.filter(
-    (a) => !chartRuns.some((r) => r.algo_id === a.id)
-  );
-
-  if (availableAlgos.length === 0) {
-    return (
-      <div className="px-6 py-4 text-xs text-[var(--text-secondary)]">
-        All algos are already running on this chart
-      </div>
-    );
-  }
-
-  return (
-    <div className="px-6 py-4 border-t border-[var(--border)]">
-      <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-3 font-semibold">
-        Add Algo
-      </div>
-      <div className="space-y-2">
-        {availableAlgos.map((algo) => {
-          const hasActiveTerminal = aiTerminalAlgoIds?.has(algo.id) ?? false;
-          return (
-            <div
-              key={algo.id}
-              className="flex items-center justify-between p-3 rounded-lg bg-[var(--bg-secondary)] border border-[var(--border)]"
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium">{algo.name}</span>
-                {hasActiveTerminal && (
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse" />
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                {onOpenAiTerminal && (
-                  <button
-                    onClick={() => onOpenAiTerminal(algo.id)}
-                    disabled={hasActiveTerminal}
-                    className={`px-3 py-1.5 text-[11px] rounded-md font-medium transition-colors ${
-                      hasActiveTerminal
-                        ? "bg-[var(--accent-blue)]/10 text-[var(--accent-blue)]/50 cursor-not-allowed"
-                        : "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/25"
-                    }`}
-                  >
-                    AI
-                  </button>
-                )}
-                <button
-                  onClick={() => onStartAlgo(algo.id, "shadow", ds.account, ds.id)}
-                  className="px-3 py-1.5 text-[11px] bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)] rounded-md hover:bg-[var(--accent-yellow)]/25 transition-colors font-medium"
-                >
-                  Shadow
-                </button>
-                <button
-                  onClick={() => onStartAlgo(algo.id, "live", ds.account, ds.id)}
-                  className="px-3 py-1.5 text-[11px] bg-[var(--accent-green)]/15 text-[var(--accent-green)] rounded-md hover:bg-[var(--accent-green)]/25 transition-colors font-medium"
-                >
-                  Live
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-};
-
-const RunningInstanceRow = ({
-  algo,
-  run,
-  stats,
-  instanceErrors,
-  isSelectedForLogs,
-  onSelectForLogs,
-  onStopAlgo,
-  onOpenAiTerminal,
-  hasActiveTerminal,
-}: {
-  algo: Algo;
-  run: AlgoRun;
-  stats: AlgoStats | undefined;
-  instanceErrors: InstanceErrors | undefined;
-  isSelectedForLogs: boolean;
-  onSelectForLogs: () => void;
-  onStopAlgo: (instanceId: string) => void;
-  onOpenAiTerminal?: (algoId: number) => void;
-  hasActiveTerminal: boolean;
-}) => {
-  const [showErrors, setShowErrors] = useState(false);
-  const hasErrors = instanceErrors && (instanceErrors.errorCount > 0 || instanceErrors.warningCount > 0);
-
-  return (
-    <div className={isSelectedForLogs ? "bg-[var(--accent-blue)]/5" : ""}>
-      <div className="flex items-center justify-between px-6 py-4 cursor-pointer" onClick={onSelectForLogs}>
-        <div className="flex items-center gap-4">
-          <div>
-            <div className="flex items-center gap-2">
-              <div className="text-sm font-medium">{algo.name}</div>
-              {run.status === "installing" ? (
-                <span className="text-[10px] uppercase px-2 py-0.5 rounded-md font-medium bg-[var(--accent-blue)]/15 text-[var(--accent-blue)] flex items-center gap-1.5">
-                  <span className="w-3 h-3 border-2 border-[var(--accent-blue)] border-t-transparent rounded-full animate-spin" />
-                  installing deps
-                </span>
-              ) : (
-                <span className={`text-[10px] uppercase px-2 py-0.5 rounded-md font-medium ${
-                  run.mode === "live"
-                    ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
-                    : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]"
-                }`}>
-                  {run.mode}
-                </span>
-              )}
-              {hasActiveTerminal && (
-                <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent-blue)] animate-pulse" title="AI terminal active" />
-              )}
-            </div>
-            <div className="flex items-center gap-3 mt-0.5">
-              <span className="text-xs text-[var(--text-secondary)]">{run.account}</span>
-              {hasErrors && (
-                <button onClick={() => setShowErrors(!showErrors)}>
-                  <ErrorBadge errors={instanceErrors} />
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          {onOpenAiTerminal && (
-            <button
-              onClick={() => onOpenAiTerminal(algo.id)}
-              disabled={hasActiveTerminal}
-              className={`px-3 py-1.5 text-[11px] rounded-md font-medium transition-colors ${
-                hasActiveTerminal
-                  ? "bg-[var(--accent-blue)]/10 text-[var(--accent-blue)]/50 cursor-not-allowed"
-                  : "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/25"
-              }`}
-            >
-              AI
-            </button>
-          )}
-          <button
-            onClick={() => onStopAlgo(run.instance_id)}
-            disabled={run.status === "installing"}
-            className={`px-4 py-2 text-xs rounded-md font-medium transition-opacity ${
-              run.status === "installing"
-                ? "bg-[var(--bg-secondary)] text-[var(--text-secondary)] cursor-not-allowed"
-                : "bg-[var(--accent-red)] text-white hover:opacity-90"
-            }`}
-          >
-            {run.status === "installing" ? "Installing..." : "Stop"}
-          </button>
-        </div>
-      </div>
-      {stats && <PerformanceStats stats={stats} />}
-      {showErrors && hasErrors && <ErrorList errors={instanceErrors} />}
-    </div>
-  );
+  onNavigate: (view: View, options?: NavOptions) => void;
 };
 
 export const AlgosView = ({
@@ -364,6 +42,7 @@ export const AlgosView = ({
   dataSources,
   activeRuns,
   algoStats,
+  runPnlHistories,
   errorsByInstance,
   logsByInstance,
   healthByInstance,
@@ -374,163 +53,214 @@ export const AlgosView = ({
   aiTerminalAlgoIds,
   initialInstanceId,
   onInstanceFocused,
+  onNavigate,
 }: AlgosViewProps) => {
-  const [selectedChartId, setSelectedChartId] = useState<string | null>(null);
+  const [groupBy, setGroupBy] = useState<GroupBy>("chart");
+  const [modeFilter, setModeFilter] = useState<ModeFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [searchQuery, setSearchQuery] = useState("");
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
   const [hasAutoSelected, setHasAutoSelected] = useState(false);
+  const [launcherOpen, setLauncherOpen] = useState(false);
+  const [launcherPrefill, setLauncherPrefill] = useState<{
+    algoId?: number;
+    chartId?: string;
+  } | null>(null);
+  const [dismissedInstanceIds, setDismissedInstanceIds] = useState<Set<string>>(() => new Set());
 
-  // Auto-select on mount: prefer navigation-provided instance,
-  // otherwise fall back to first running algo
+  // Auto-select on mount: navigation-provided instance, else first running.
   useEffect(() => {
     if (hasAutoSelected) return;
     if (initialInstanceId) {
       const run = activeRuns.find((r) => r.instance_id === initialInstanceId);
       if (run) {
-        setSelectedChartId(run.data_source_id);
         setSelectedInstanceId(run.instance_id);
       }
-      // mark consumed + notify App even if the instance wasn't found,
-      // so stale context doesn't leak into the next navigation
       setHasAutoSelected(true);
       onInstanceFocused?.();
       return;
     }
     const firstRunning = activeRuns.find((r) => r.status === "running");
     if (firstRunning) {
-      setSelectedChartId(firstRunning.data_source_id);
       setSelectedInstanceId(firstRunning.instance_id);
       setHasAutoSelected(true);
     }
   }, [activeRuns, hasAutoSelected, initialInstanceId, onInstanceFocused]);
 
-  const selectedDs = dataSources.find((ds) => ds.id === selectedChartId) ?? null;
-  const chartRuns = selectedChartId
-    ? activeRuns.filter((r) => r.data_source_id === selectedChartId)
-    : [];
+  const groups = useMemo(
+    () =>
+      buildGroups({
+        activeRuns,
+        algos,
+        dataSources,
+        algoStats,
+        errorsByInstance,
+        runPnlHistories,
+        dismissedInstanceIds,
+        groupBy,
+        filters: { mode: modeFilter, status: statusFilter, search: searchQuery },
+      }),
+    [
+      activeRuns,
+      algos,
+      dataSources,
+      algoStats,
+      errorsByInstance,
+      runPnlHistories,
+      dismissedInstanceIds,
+      groupBy,
+      modeFilter,
+      statusFilter,
+      searchQuery,
+    ],
+  );
 
-  const getRunCount = (dsId: string) => activeRuns.filter((r) => r.data_source_id === dsId).length;
+  const allInstances = useMemo(
+    () => groups.flatMap((g) => g.instances),
+    [groups],
+  );
+
+  const selectedInstance: InstanceView | null =
+    allInstances.find((i) => i.run.instance_id === selectedInstanceId) ?? null;
+
+  // Counts for the command bar — use activeRuns (not filtered) so headline numbers stay stable.
+  const runningCount = activeRuns.filter((r) => r.status === "running").length;
+  const haltedCount = activeRuns.filter(
+    (r) => errorsByInstance[r.instance_id]?.autoStopped,
+  ).length;
+  const sessionPnl = Object.values(algoStats).reduce((sum, s) => sum + s.pnl, 0);
+
+  const clearFilters = useCallback(() => {
+    setModeFilter("all");
+    setStatusFilter("all");
+    setSearchQuery("");
+  }, []);
+
+  const openLauncher = useCallback((prefill: { algoId?: number; chartId?: string } | null) => {
+    setLauncherPrefill(prefill);
+    setLauncherOpen(true);
+  }, []);
+
+  const handleGroupDeepLink = useCallback(
+    (group: GroupView) => {
+      if (group.groupBy === "chart" && group.account) {
+        onNavigate("trading", { accountFilter: group.account });
+      } else if (group.groupBy === "algo" && typeof group.algoId === "number") {
+        onNavigate("editor", { algoFilter: group.algoId });
+      }
+    },
+    [onNavigate],
+  );
+
+  const handleGroupAddAlgo = useCallback(
+    (group: GroupView) => {
+      if (group.groupBy === "chart" && group.chartId) {
+        openLauncher({ chartId: group.chartId });
+      } else if (group.groupBy === "algo" && typeof group.algoId === "number") {
+        openLauncher({ algoId: group.algoId });
+      } else {
+        openLauncher(null);
+      }
+    },
+    [openLauncher],
+  );
+
+  const handleStart = useCallback(
+    (algoId: number, mode: "live" | "shadow", account: string, dataSourceId: string) => {
+      onStartAlgo(algoId, mode, account, dataSourceId);
+    },
+    [onStartAlgo],
+  );
+
+  const clearInstance = useCallback((inst: InstanceView) => {
+    setDismissedInstanceIds((prev) => {
+      const next = new Set(prev);
+      next.add(inst.run.instance_id);
+      return next;
+    });
+    setSelectedInstanceId((sid) => (sid === inst.run.instance_id ? null : sid));
+  }, []);
 
   return (
-    <div className="flex-1 flex gap-4 p-4 overflow-hidden">
-      {/* Left: Charts Panel */}
-      <div className="w-72 flex flex-col gap-3 overflow-auto flex-shrink-0">
-        <div className="flex items-center justify-between px-1">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-            Charts
-          </h2>
-          <span className="text-xs text-[var(--text-secondary)]">
-            {dataSources.length} connected
-          </span>
-        </div>
+    <div className="flex-1 flex flex-col min-h-0 bg-[var(--bg-primary)] relative">
+      <AlgosCommandBar
+        chartCount={dataSources.length}
+        instanceCount={activeRuns.length}
+        runningCount={runningCount}
+        haltedCount={haltedCount}
+        sessionPnl={sessionPnl}
+        onRunNewAlgo={() => openLauncher(null)}
+      />
+      <AlgosFilterBar
+        groupBy={groupBy}
+        onGroupByChange={setGroupBy}
+        modeFilter={modeFilter}
+        onModeFilterChange={setModeFilter}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+      />
 
-        {dataSources.length === 0 ? (
-          <div className="p-4 rounded-lg bg-[var(--bg-panel)] border border-[var(--border)] text-xs text-[var(--text-secondary)]">
-            No charts connected. Add the WolfDenBridge indicator to a NinjaTrader chart to get started.
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {dataSources.map((ds) => (
-              <ChartCard
-                key={ds.id}
-                ds={ds}
-                isSelected={selectedChartId === ds.id}
-                runCount={getRunCount(ds.id)}
-                onClick={() => setSelectedChartId(ds.id === selectedChartId ? null : ds.id)}
-              />
-            ))}
-          </div>
-        )}
+      <div className="flex-1 flex min-h-0">
+        <AlgosInstanceList
+          groups={groups}
+          hasAnyCharts={dataSources.length > 0}
+          hasAnyInstances={activeRuns.length > 0}
+          selectedInstanceId={selectedInstanceId}
+          onSelect={(inst) => setSelectedInstanceId(inst.run.instance_id)}
+          onClear={clearInstance}
+          onGroupDeepLink={handleGroupDeepLink}
+          onGroupAddAlgo={handleGroupAddAlgo}
+          onClearFilters={clearFilters}
+          onRunNewAlgo={() => openLauncher(null)}
+        />
+
+        <AlgoDetailPanel
+          instance={selectedInstance}
+          logs={
+            selectedInstance ? logsByInstance[selectedInstance.run.instance_id] ?? [] : []
+          }
+          health={
+            selectedInstance ? healthByInstance[selectedInstance.run.instance_id] : undefined
+          }
+          onClearLogs={() => {
+            if (selectedInstance) onClearLogs(selectedInstance.run.instance_id);
+          }}
+          onStop={() => {
+            if (selectedInstance) onStopAlgo(selectedInstance.run.instance_id);
+          }}
+          onOpenInEditor={() => {
+            if (selectedInstance) onNavigate("editor", { algoFilter: selectedInstance.algo.id });
+          }}
+          onViewTrades={() => {
+            if (selectedInstance)
+              onNavigate("trading", {
+                accountFilter: selectedInstance.run.account,
+                scrollTo: "positions",
+              });
+          }}
+          onOpenAiTerminal={
+            onOpenAiTerminal && selectedInstance
+              ? () => onOpenAiTerminal(selectedInstance.algo.id)
+              : undefined
+          }
+          hasActiveAiTerminal={
+            !!(selectedInstance && aiTerminalAlgoIds?.has(selectedInstance.algo.id))
+          }
+          onRunNewAlgo={() => openLauncher(null)}
+        />
       </div>
 
-      {/* Right: Chart Detail / Instance Management */}
-      <div className="flex-1 flex flex-col gap-4 min-h-0">
-        {selectedDs ? (
-          <>
-            {/* Chart header */}
-            <div className="bg-[var(--bg-panel)] rounded-lg p-4 border border-[var(--border)]">
-              <div className="flex items-center gap-3 mb-1">
-                <div className="w-2.5 h-2.5 rounded-full bg-[var(--accent-green)]" />
-                <h2 className="text-base font-semibold">{formatDataSource(selectedDs)}</h2>
-              </div>
-              <div className="flex items-center gap-4 text-xs text-[var(--text-secondary)] ml-5">
-                <span>{selectedDs.instrument}</span>
-                <span>{selectedDs.timeframe}</span>
-                <span>{selectedDs.account}</span>
-              </div>
-            </div>
-
-            {/* Running instances on this chart */}
-            <div className="flex-1 bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
-              <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--border)] flex-shrink-0">
-                <div className="flex items-center gap-3">
-                  <span className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-                    Running Algos
-                  </span>
-                  <span className="text-xs text-[var(--text-secondary)]">{chartRuns.length}</span>
-                </div>
-                {chartRuns.length > 0 && (
-                  <button
-                    onClick={() => chartRuns.forEach((r) => onStopAlgo(r.instance_id))}
-                    className="px-3 py-1.5 text-[11px] bg-[var(--accent-red)]/15 text-[var(--accent-red)] rounded-md hover:bg-[var(--accent-red)]/25 transition-colors font-medium"
-                  >
-                    Stop All
-                  </button>
-                )}
-              </div>
-
-              <div className="flex-1 overflow-auto divide-y divide-[var(--border)]">
-                {chartRuns.length === 0 ? (
-                  <div className="px-6 py-6 text-xs text-[var(--text-secondary)] text-center">
-                    No algos running on this chart. Add one below.
-                  </div>
-                ) : (
-                  chartRuns.map((run) => {
-                    const algo = algos.find((a) => a.id === run.algo_id);
-                    if (!algo) return null;
-                    return (
-                      <RunningInstanceRow
-                        key={run.instance_id}
-                        algo={algo}
-                        run={run}
-                        stats={algoStats[run.instance_id]}
-                        instanceErrors={errorsByInstance[run.instance_id]}
-                        isSelectedForLogs={selectedInstanceId === run.instance_id}
-                        onSelectForLogs={() => setSelectedInstanceId(run.instance_id)}
-                        onStopAlgo={onStopAlgo}
-                        onOpenAiTerminal={onOpenAiTerminal}
-                        hasActiveTerminal={aiTerminalAlgoIds?.has(algo.id) ?? false}
-                      />
-                    );
-                  })
-                )}
-              </div>
-
-              {/* Add algo to this chart */}
-              <AddAlgoPanel
-                  algos={algos}
-                  chartRuns={chartRuns}
-                  ds={selectedDs}
-                  onStartAlgo={onStartAlgo}
-                  onOpenAiTerminal={onOpenAiTerminal}
-                  aiTerminalAlgoIds={aiTerminalAlgoIds}
-                />
-
-              {/* Log Panel */}
-              {selectedInstanceId && (
-                <LogPanel
-                  logs={logsByInstance[selectedInstanceId] ?? []}
-                  health={healthByInstance[selectedInstanceId]}
-                  onClear={() => onClearLogs(selectedInstanceId)}
-                />
-              )}
-            </div>
-          </>
-        ) : (
-          <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)]">
-            Select a chart to manage algos
-          </div>
-        )}
-      </div>
+      <RunAlgoSlideOver
+        open={launcherOpen}
+        algos={algos}
+        dataSources={dataSources}
+        activeRuns={activeRuns}
+        prefill={launcherPrefill}
+        onClose={() => setLauncherOpen(false)}
+        onStart={handleStart}
+      />
     </div>
   );
 };

--- a/src/views/AlgosView.tsx
+++ b/src/views/AlgosView.tsx
@@ -208,6 +208,7 @@ export const AlgosView = ({
           hasAnyCharts={dataSources.length > 0}
           hasAnyInstances={activeRuns.length > 0}
           selectedInstanceId={selectedInstanceId}
+          aiTerminalAlgoIds={aiTerminalAlgoIds}
           onSelect={(inst) => setSelectedInstanceId(inst.run.instance_id)}
           onClear={clearInstance}
           onGroupDeepLink={handleGroupDeepLink}


### PR DESCRIPTION
## Summary

- Rebuilds the Algos view around a **single grouped instance list + always-visible detail panel**. A segmented control toggles grouping between **Chart (default)**, **Algo**, and **None** — one layout serves both mental models.
- Adds a **slide-over launcher** for starting new runs (replaces the inline per-chart add panel). Supports prefill from chart/algo group `+ add`, duplicate-run guard, Esc / scrim / Cancel dismiss.
- Adds **deep-links out**: group headers → Trading (chart pivot) / Editor (algo pivot); detail panel → Editor, Trading (filtered + scrolled to positions), AI terminal.
- Preserves prior behaviors: nav-in via `initialInstanceId`, error drilldown with traceback, `LogPanel` wiring, stop-while-installing guard, AI-terminal active indicator, installing-deps pill.

Spec: `docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md`
Plan: `docs/superpowers/plans/2026-04-19-algos-view-redesign.md`

## Architecture

Pure helpers (`src/lib/algoInstanceView.ts`) own grouping / filtering / aggregation / sparkline math. `AlgosView.tsx` becomes a layout-only orchestrator composing seven new components:

- `AlgosCommandBar` — title, aggregate meta, session P&L, primary action
- `AlgosFilterBar` — group-by + mode + status segmented controls + search
- `AlgosInstanceList` — grouped list with empty states (no charts / no runs / no results)
- `AlgoGroupHeader` + `AlgoInstanceRow`
- `AlgoDetailPanel` — stats grid + tabs (Logs / Errors / Config)
- `RunAlgoSlideOver` — launcher dialog

`App.tsx` passes two new props (`runPnlHistories`, `onNavigate`). No backend, Tauri command, or schema changes.

## Test Plan

Project has no test runner; verification is `tsc --noEmit` + manual smoke. `npm run build` passes clean.

- [ ] `npm run dev` — open Algos view, confirm:
  - [ ] Groups render correctly in **Chart** (default), **Algo**, and **None** pivots
  - [ ] Mode / Status filters combine; search filters on algo name, instrument, account
  - [ ] Halted instances sink to bottom of their group with muted styling; hover `✕` clears them locally
  - [ ] Row pulses blue dot when algo has an active AI terminal
  - [ ] Installing runs show an "Installing" pill with spinner
  - [ ] Detail panel stats + Logs / Errors / Config tabs update on selection; Errors is the default tab when `errorCount > 0`, Logs otherwise
  - [ ] Stop button disables while installing and when halted
  - [ ] Deep-links: group header → Trading (chart acct) / Editor (algo); detail panel Editor / Trades (filtered + scrolled to positions) / AI terminal
- [ ] `+ Run new algo` launcher: opens empty; group-header `+ add` prefills Chart (chart pivot) or Algo (algo pivot); Esc / scrim / Cancel all dismiss; Start fires `onStartAlgo`; duplicate guard disables Start with a yellow inline notice
- [ ] Nav from Home: clicking an algo tape row auto-focuses that instance in the detail panel
- [ ] Empty states: no charts connected, no runs, no matches for filters, no selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Algos view with grouping options (by Chart, Algo, or None)
  * Always-visible side panel showing instance details with Logs, Errors, and Config tabs
  * New filtering capabilities by mode, status, and search
  * P&L sparkline visualizations for each instance
  * Slide-over launcher for configuring and running new algo instances
  * Enhanced instance status indicators (running/halted/warning)
  * Ability to locally dismiss halted instances

* **Documentation**
  * Added design specification for Algos view redesign

<!-- end of auto-generated comment: release notes by coderabbit.ai -->