### PR TITLE
feat: trading view redesign — unified dashboard (hero + filters + tabs + drill-down)

### DIFF
--- a/docs/superpowers/plans/2026-04-19-trading-view-redesign.md
+++ b/docs/superpowers/plans/2026-04-19-trading-view-redesign.md
@@ -1,0 +1,3184 @@
+# Trading View Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the Trading view as a unified dashboard — pinned hero (KPIs + equity + drawdown), global Chart/Account/Algo filters, and four tabs (Live / Performance / Analytics / Trades) with a right-side drill-down panel — per `docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md`.
+
+**Architecture:** Two pure helper modules (`src/lib/tradingView.ts`, `src/lib/roundtrips.ts`) own filtering, aggregation, bucketing, and MAE/MFE derivation. Three new sibling hooks (`useTradeHistory`, `useEquityTimeline`, `useRollingMetrics`) sit next to the existing `useTradingSimulation` (unchanged). `TradingView.tsx` becomes a layout-only orchestrator composing `TradingFilterBar`, `TradingHero` (with `EquityChart`), `TradingTabs`, and the four tab components (`LiveTab`, `PerformanceTab`, `AnalyticsTab`, `TradesTab`) that delegate to small, focused sub-components. `App.tsx` adds new props fed from the new hooks. No backend / Tauri-command / schema / event-payload changes.
+
+**Tech Stack:** React 19, TypeScript 6, Tailwind 4 + CSS vars (`src/styles.css`), `@tauri-apps/api/event.listen` for event subscriptions, Canvas 2D + SVG for charts, no new dependencies.
+
+---
+
+## Project has no test framework — adapted task template
+
+The standard `superpowers:writing-plans` template uses a TDD flow. This project has no vitest / jest setup (see `package.json`), and the spec's verification plan is `tsc` + manual smoke. Every task here replaces the "write failing test → run → implement → pass" cycle with:
+
+1. **Implement** — write the code.
+2. **Type-check** — run `npx tsc --noEmit` from the repo root; expect zero TypeScript errors. (`npm run build` also valid but slower.)
+3. **Smoke** — a targeted manual walk-through described per task. For pure-helper tasks, smoke = just type-check.
+4. **Commit** — Conventional Commits.
+
+Do not introduce a test framework in this plan. It's out of scope.
+
+---
+
+## Task dependency map
+
+Tasks 1–4 (helpers + hooks) produce self-contained new files with no UI dependencies. Tasks 5–9 produce UI components — each depends on the helpers/hooks but not on each other (any can be done in parallel once 1–4 land). Task 10 is the coordinated rewire of `TradingView.tsx` and `App.tsx`. Task 11 is the end-to-end smoke.
+
+```
+1 (pure helpers) ──┐
+                   ├──▶ 2 (useTradeHistory) ──┬──▶ 3 (useEquityTimeline) ──┐
+                   │                          ├──▶ 4 (useRollingMetrics) ──┤
+                   │                          │                            │
+                   └───────────────────────────────────────────────────────┤
+                                              │                            │
+                                      5 (chrome: chart/filter/tabs/hero) ──┤
+                                      6 (LiveTab)                          ├──▶ 10 (rewire) ──▶ 11 (smoke)
+                                      7 (PerformanceTab)                   │
+                                      8 (AnalyticsTab)                     │
+                                      9 (TradesTab)                        │
+                                                                           ┘
+```
+
+Tasks 5, 6, 7, 8, 9 can be done in parallel by a subagent runner once tasks 1–4 are done.
+
+---
+
+### Task 1: Create pure helpers — `src/lib/roundtrips.ts` + `src/lib/tradingView.ts`
+
+**Files:**
+- Create: `src/lib/roundtrips.ts`
+- Create: `src/lib/tradingView.ts`
+
+- [ ] **Step 1: Write `src/lib/roundtrips.ts`**
+
+Create with this exact content:
+
+```ts
+// Pure helpers for roundtrip-level derivations. No React imports.
+
+export type MaeMfeSample = { t: number; pnl: number };
+
+export const deriveMaeMfe = (samples: MaeMfeSample[]): { mae: number; mfe: number } => {
+  if (samples.length === 0) return { mae: 0, mfe: 0 };
+  let mae = 0;
+  let mfe = 0;
+  for (const s of samples) {
+    if (s.pnl < mae) mae = s.pnl;
+    if (s.pnl > mfe) mfe = s.pnl;
+  }
+  return { mae, mfe };
+};
+
+export const computeRMultiple = (pnl: number, mae: number): number | null => {
+  if (mae >= 0) return null;
+  return Math.round((pnl / Math.abs(mae)) * 100) / 100;
+};
+
+// Decimate samples to a target count, preserving temporal ordering.
+// We always keep the first and last sample; intermediate samples are evenly spaced.
+export const decimateSamples = (samples: MaeMfeSample[], target: number): MaeMfeSample[] => {
+  if (samples.length <= target) return samples;
+  if (target <= 2) return [samples[0], samples[samples.length - 1]];
+  const step = (samples.length - 1) / (target - 1);
+  const out: MaeMfeSample[] = [];
+  for (let i = 0; i < target; i++) {
+    out.push(samples[Math.round(i * step)]);
+  }
+  return out;
+};
+```
+
+- [ ] **Step 2: Write `src/lib/tradingView.ts`**
+
+Create with this exact content:
+
+```ts
+// Pure helpers for the Trading view. No React imports.
+
+import type { MaeMfeSample } from "./roundtrips";
+
+// ----- Shared types -----
+
+export type Roundtrip = {
+  id: string;
+  symbol: string;
+  side: "Long" | "Short";
+  qty: number;
+  entryPrice: number;
+  exitPrice: number;
+  openTimestamp: number;
+  closeTimestamp: number;
+  pnl: number;
+  mae: number;
+  mfe: number;
+  rMultiple: number | null;
+  algo: string;
+  algoId: number;
+  account: string;
+  dataSourceId: string;
+  instanceId: string;
+  isShadow: boolean;
+  maeMfeSamples: MaeMfeSample[];
+};
+
+export type EquityPoint = { t: number; pnl: number };
+export type DrawdownPoint = { t: number; peak: number; pnl: number; underwater: number };
+
+export type Filters = {
+  chart: string | null;
+  account: string | null;
+  algo: number | null;
+};
+
+export const EMPTY_FILTERS: Filters = { chart: null, account: null, algo: null };
+
+export type Filterable = {
+  dataSourceId: string;
+  account: string;
+  algoId: number;
+};
+
+export const matchesFilters = (item: Filterable, f: Filters): boolean => {
+  if (f.chart !== null && item.dataSourceId !== f.chart) return false;
+  if (f.account !== null && item.account !== f.account) return false;
+  if (f.algo !== null && item.algoId !== f.algo) return false;
+  return true;
+};
+
+export const applyFilters = <T extends Filterable>(items: T[], f: Filters): T[] =>
+  items.filter((i) => matchesFilters(i, f));
+
+export const isFilterActive = (f: Filters): boolean =>
+  f.chart !== null || f.account !== null || f.algo !== null;
+
+// ----- Formatting helpers (shared by components) -----
+
+export const formatPnl = (v: number): string => {
+  const sign = v >= 0 ? "+" : "-";
+  return `${sign}$${Math.abs(v).toFixed(2)}`;
+};
+
+export const pnlColorClass = (v: number): string =>
+  v > 0
+    ? "text-[var(--accent-green)]"
+    : v < 0
+      ? "text-[var(--accent-red)]"
+      : "text-[var(--text-primary)]";
+
+export const formatChartLabel = (dsId: string): string => {
+  const [instrument, tf] = dsId.split(":");
+  if (!instrument || !tf) return dsId;
+  return `${instrument.split(" ")[0]} ${tf}`;
+};
+
+export const formatDuration = (fromTs: number, toTs: number): string => {
+  const ms = toTs - fromTs;
+  if (ms < 60_000) return `${Math.max(0, Math.round(ms / 1000))}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+};
+
+export const sparklinePoints = (history: number[], width: number, height: number): string => {
+  if (history.length <= 1) return "";
+  const min = Math.min(...history);
+  const max = Math.max(...history);
+  const range = max - min || 1;
+  const stepX = width / (history.length - 1);
+  return history
+    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
+    .join(" ");
+};
+
+// ----- Breakdown aggregation -----
+
+export type BreakdownKey = "algo" | "symbol" | "account";
+
+export type BreakdownRow = {
+  key: string;
+  label: string;
+  trades: number;
+  pnl: number;
+  winRate: number;
+  sharpe: string;
+  profitFactor: string;
+  avgWin: number;
+  avgLoss: number;
+  sparkline: number[];
+};
+
+const keyOf = (r: Roundtrip, by: BreakdownKey): { key: string; label: string } => {
+  switch (by) {
+    case "algo":
+      return { key: String(r.algoId), label: r.algo || `algo ${r.algoId}` };
+    case "symbol":
+      return { key: r.symbol, label: r.symbol };
+    case "account":
+      return { key: r.account, label: r.account };
+  }
+};
+
+const sharpeString = (pnls: number[]): string => {
+  if (pnls.length < 2) return "--";
+  const mean = pnls.reduce((a, b) => a + b, 0) / pnls.length;
+  const variance = pnls.reduce((s, v) => s + (v - mean) ** 2, 0) / pnls.length;
+  const std = Math.sqrt(variance);
+  return std > 0 ? (mean / std).toFixed(2) : "--";
+};
+
+export const aggregateByKey = (roundtrips: Roundtrip[], by: BreakdownKey): BreakdownRow[] => {
+  const groups = new Map<string, { label: string; trips: Roundtrip[] }>();
+  for (const r of roundtrips) {
+    const { key, label } = keyOf(r, by);
+    const g = groups.get(key) ?? { label, trips: [] };
+    g.trips.push(r);
+    groups.set(key, g);
+  }
+  const rows: BreakdownRow[] = [];
+  for (const [key, { label, trips }] of groups) {
+    const wins = trips.filter((t) => t.pnl > 0);
+    const losses = trips.filter((t) => t.pnl < 0);
+    const totalPnl = trips.reduce((s, t) => s + t.pnl, 0);
+    const totalWin = wins.reduce((s, t) => s + t.pnl, 0);
+    const totalLoss = Math.abs(losses.reduce((s, t) => s + t.pnl, 0));
+    const winRate = trips.length > 0 ? Math.round((wins.length / trips.length) * 100) : 0;
+    const avgWin = wins.length > 0 ? totalWin / wins.length : 0;
+    const avgLoss = losses.length > 0 ? losses.reduce((s, t) => s + t.pnl, 0) / losses.length : 0;
+    const profitFactor =
+      totalLoss > 0 ? (totalWin / totalLoss).toFixed(2) : wins.length > 0 ? "∞" : "--";
+    const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+    const sparkline: number[] = [];
+    let cum = 0;
+    for (const r of sorted) {
+      cum += r.pnl;
+      sparkline.push(Math.round(cum * 100) / 100);
+    }
+    rows.push({
+      key,
+      label,
+      trades: trips.length,
+      pnl: Math.round(totalPnl * 100) / 100,
+      winRate,
+      sharpe: sharpeString(trips.map((t) => t.pnl)),
+      profitFactor,
+      avgWin: Math.round(avgWin * 100) / 100,
+      avgLoss: Math.round(avgLoss * 100) / 100,
+      sparkline,
+    });
+  }
+  return rows.sort((a, b) => b.pnl - a.pnl);
+};
+
+// ----- Live vs. shadow pairing -----
+
+export type LiveShadowPair = {
+  algoId: number;
+  algoName: string;
+  live: BreakdownRow | null;
+  shadow: BreakdownRow | null;
+  delta: number;
+  slippagePerTrade: number;
+};
+
+export const pairLiveShadow = (roundtrips: Roundtrip[]): LiveShadowPair[] => {
+  const liveByAlgo = new Map<number, Roundtrip[]>();
+  const shadowByAlgo = new Map<number, Roundtrip[]>();
+  for (const r of roundtrips) {
+    const bucket = r.isShadow ? shadowByAlgo : liveByAlgo;
+    const cur = bucket.get(r.algoId) ?? [];
+    cur.push(r);
+    bucket.set(r.algoId, cur);
+  }
+  const allAlgoIds = new Set<number>([...liveByAlgo.keys(), ...shadowByAlgo.keys()]);
+  const result: LiveShadowPair[] = [];
+  for (const algoId of allAlgoIds) {
+    const liveTrips = liveByAlgo.get(algoId) ?? [];
+    const shadowTrips = shadowByAlgo.get(algoId) ?? [];
+    const liveRow = liveTrips.length ? aggregateByKey(liveTrips, "algo")[0] : null;
+    const shadowRow = shadowTrips.length ? aggregateByKey(shadowTrips, "algo")[0] : null;
+    const algoName = liveRow?.label ?? shadowRow?.label ?? `algo ${algoId}`;
+    const delta = Math.round(((liveRow?.pnl ?? 0) - (shadowRow?.pnl ?? 0)) * 100) / 100;
+    const liveAvg = liveRow && liveRow.trades > 0 ? liveRow.pnl / liveRow.trades : 0;
+    const shadowAvg = shadowRow && shadowRow.trades > 0 ? shadowRow.pnl / shadowRow.trades : 0;
+    const slippagePerTrade = Math.round((liveAvg - shadowAvg) * 100) / 100;
+    result.push({ algoId, algoName, live: liveRow, shadow: shadowRow, delta, slippagePerTrade });
+  }
+  return result.sort((a, b) => a.algoName.localeCompare(b.algoName));
+};
+
+// ----- Distribution -----
+
+export type DistributionBucket = { lo: number; hi: number; count: number };
+
+export const buildDistribution = (
+  roundtrips: Roundtrip[],
+  bucketCount: number = 12,
+): DistributionBucket[] => {
+  if (roundtrips.length === 0) return [];
+  const pnls = roundtrips.map((r) => r.pnl);
+  const min = Math.min(...pnls);
+  const max = Math.max(...pnls);
+  const range = max - min || 1;
+  const step = range / bucketCount;
+  const buckets: DistributionBucket[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    const lo = min + i * step;
+    const hi = i === bucketCount - 1 ? max + 0.0001 : lo + step;
+    const count = pnls.filter((p) => p >= lo && p < hi).length;
+    buckets.push({ lo: Math.round(lo * 100) / 100, hi: Math.round(hi * 100) / 100, count });
+  }
+  return buckets;
+};
+
+// ----- Heatmap (day × hour) -----
+
+export type HeatCell = { trades: number; pnl: number; winRate: number };
+
+export const buildHeatmap = (roundtrips: Roundtrip[]): HeatCell[][] => {
+  // [day][hour] where day 0 = Sunday, hour 0–23
+  const grid: HeatCell[][] = Array.from({ length: 7 }, () =>
+    Array.from({ length: 24 }, () => ({ trades: 0, pnl: 0, winRate: 0 })),
+  );
+  const wins = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0));
+  for (const r of roundtrips) {
+    const d = new Date(r.closeTimestamp);
+    const day = d.getDay();
+    const hour = d.getHours();
+    grid[day][hour].trades += 1;
+    grid[day][hour].pnl += r.pnl;
+    if (r.pnl > 0) wins[day][hour] += 1;
+  }
+  for (let d = 0; d < 7; d++) {
+    for (let h = 0; h < 24; h++) {
+      const cell = grid[d][h];
+      cell.pnl = Math.round(cell.pnl * 100) / 100;
+      cell.winRate = cell.trades > 0 ? Math.round((wins[d][h] / cell.trades) * 100) : 0;
+    }
+  }
+  return grid;
+};
+
+// ----- Hero KPI derivation -----
+
+export type HeroKpis = {
+  realizedPnl: number;
+  unrealizedPnl: number;
+  totalPnl: number;
+  winRate: number;
+  trades: number;
+  sharpe: string;
+  maxDrawdown: number;
+};
+
+export const deriveHeroKpis = (
+  filteredRoundtrips: Roundtrip[],
+  filteredOpenPositions: { pnl: number }[],
+  drawdown: DrawdownPoint[],
+): HeroKpis => {
+  const realized = filteredRoundtrips.reduce((s, r) => s + r.pnl, 0);
+  const unrealized = filteredOpenPositions.reduce((s, p) => s + p.pnl, 0);
+  const wins = filteredRoundtrips.filter((r) => r.pnl > 0).length;
+  const winRate =
+    filteredRoundtrips.length > 0 ? Math.round((wins / filteredRoundtrips.length) * 100) : 0;
+  const sharpe = sharpeString(filteredRoundtrips.map((r) => r.pnl));
+  const maxDrawdown = drawdown.reduce((max, d) => Math.max(max, d.underwater), 0);
+  return {
+    realizedPnl: Math.round(realized * 100) / 100,
+    unrealizedPnl: Math.round(unrealized * 100) / 100,
+    totalPnl: Math.round((realized + unrealized) * 100) / 100,
+    winRate,
+    trades: filteredRoundtrips.length,
+    sharpe,
+    maxDrawdown: Math.round(maxDrawdown * 100) / 100,
+  };
+};
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/roundtrips.ts src/lib/tradingView.ts
+git commit -m "feat(trading): add pure helpers for roundtrips and trading view derivations"
+```
+
+---
+
+### Task 2: Create `useTradeHistory` hook
+
+**Files:**
+- Create: `src/hooks/useTradeHistory.ts`
+
+This hook subscribes to the same NinjaTrader events `useTradingSimulation` listens to (`nt-position`, `nt-order-update`, `nt-chart-removed`), independently tracks open positions, samples unrealized P&L while positions are open for MAE/MFE, and on flat emits a full `Roundtrip` record. Aggregates are derived from the roundtrip list via `useMemo`.
+
+- [ ] **Step 1: Write the hook file**
+
+Create `src/hooks/useTradeHistory.ts` with this exact content:
+
+```ts
+import { useState, useEffect, useRef, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { Algo, AlgoRun } from "../types";
+import {
+  type Roundtrip,
+  type BreakdownRow,
+  type LiveShadowPair,
+  type DistributionBucket,
+  type HeatCell,
+  aggregateByKey,
+  pairLiveShadow,
+  buildDistribution,
+  buildHeatmap,
+} from "../lib/tradingView";
+import {
+  type MaeMfeSample,
+  deriveMaeMfe,
+  computeRMultiple,
+  decimateSamples,
+} from "../lib/roundtrips";
+
+type PositionEvent = {
+  source_id: string;
+  account: string;
+  symbol: string;
+  direction: string;
+  qty: number;
+  avg_price: number;
+  unrealized_pnl: number;
+};
+
+type OrderEvent = {
+  source_id: string;
+  account: string;
+  instance_id: string;
+  order_id: string;
+  state: string;
+  symbol: string;
+  side: string | null;
+  filled_qty: number | null;
+  avg_fill_price: number | null;
+  fill_price: number | null;
+  remaining: number | null;
+  error: string | null;
+  timestamp: number | null;
+};
+
+type OpenPosition = {
+  posKey: string;
+  dataSourceId: string;
+  symbol: string;
+  account: string;
+  side: "Long" | "Short";
+  qty: number;
+  entryPrice: number;
+  openTimestamp: number;
+  lastPnl: number;
+  samples: MaeMfeSample[];
+  lastExitPrice: number | null;
+};
+
+export type TradeHistory = {
+  roundtrips: Roundtrip[];
+  byAlgo: BreakdownRow[];
+  bySymbol: BreakdownRow[];
+  byAccount: BreakdownRow[];
+  liveVsShadow: LiveShadowPair[];
+  distribution: DistributionBucket[];
+  heatmap: HeatCell[][];
+};
+
+const MAX_ROUNDTRIPS = 1000;
+const MAX_SAMPLES_PER_TRIP = 200;
+const SAMPLE_INTERVAL_MS = 250;
+
+const posKeyOf = (sourceId: string, symbol: string, account: string): string =>
+  `${sourceId}:${symbol}:${account}`;
+
+export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHistory => {
+  const [roundtrips, setRoundtrips] = useState<Roundtrip[]>([]);
+  const openPositions = useRef<Map<string, OpenPosition>>(new Map());
+  const algosRef = useRef(algos);
+  const activeRunsRef = useRef(activeRuns);
+
+  useEffect(() => {
+    algosRef.current = algos;
+  }, [algos]);
+  useEffect(() => {
+    activeRunsRef.current = activeRuns;
+  }, [activeRuns]);
+
+  // Resolve algo + instance attribution from the current live run table.
+  // If the instance has already stopped by the time the trip closes, we
+  // fall back to the best-effort values (algoId = 0, empty names).
+  const resolveAttribution = (dataSourceId: string, account: string) => {
+    const run = activeRunsRef.current.find(
+      (r) => r.data_source_id === dataSourceId && r.account === account,
+    );
+    if (!run) {
+      return { algoId: 0, algoName: "", instanceId: "" };
+    }
+    const algo = algosRef.current.find((a) => a.id === run.algo_id);
+    return {
+      algoId: run.algo_id,
+      algoName: algo?.name ?? `algo ${run.algo_id}`,
+      instanceId: run.instance_id,
+    };
+  };
+
+  // Position events — pairing, sampling, close-to-roundtrip construction.
+  useEffect(() => {
+    const unlisten = listen<PositionEvent>("nt-position", (event) => {
+      const p = event.payload;
+      const posKey = posKeyOf(p.source_id, p.symbol, p.account);
+      const now = Date.now();
+
+      if (p.direction === "Flat" || p.qty === 0) {
+        const open = openPositions.current.get(posKey);
+        if (!open) return;
+        const { algoId, algoName, instanceId } = resolveAttribution(
+          open.dataSourceId,
+          open.account,
+        );
+        const { mae, mfe } = deriveMaeMfe(open.samples);
+        const exitPrice = open.lastExitPrice ?? p.avg_price ?? open.entryPrice;
+        const trip: Roundtrip = {
+          id: `${posKey}-${open.openTimestamp}`,
+          symbol: open.symbol,
+          side: open.side,
+          qty: open.qty,
+          entryPrice: open.entryPrice,
+          exitPrice,
+          openTimestamp: open.openTimestamp,
+          closeTimestamp: now,
+          pnl: Math.round(open.lastPnl * 100) / 100,
+          mae: Math.round(mae * 100) / 100,
+          mfe: Math.round(mfe * 100) / 100,
+          rMultiple: computeRMultiple(open.lastPnl, mae),
+          algo: algoName,
+          algoId,
+          account: open.account,
+          dataSourceId: open.dataSourceId,
+          instanceId,
+          isShadow: open.account === "shadow",
+          maeMfeSamples: decimateSamples(open.samples, MAX_SAMPLES_PER_TRIP),
+        };
+        openPositions.current.delete(posKey);
+        setRoundtrips((prev) => {
+          const next = [...prev, trip];
+          return next.length > MAX_ROUNDTRIPS ? next.slice(-MAX_ROUNDTRIPS) : next;
+        });
+        return;
+      }
+
+      const side: "Long" | "Short" = p.direction === "Long" ? "Long" : "Short";
+      const existing = openPositions.current.get(posKey);
+      if (existing) {
+        existing.lastPnl = p.unrealized_pnl;
+        existing.qty = Math.abs(p.qty);
+        // Throttle samples: only append if SAMPLE_INTERVAL_MS has passed since the last.
+        const lastSample = existing.samples[existing.samples.length - 1];
+        if (!lastSample || now - lastSample.t >= SAMPLE_INTERVAL_MS) {
+          existing.samples.push({ t: now, pnl: p.unrealized_pnl });
+        }
+      } else {
+        openPositions.current.set(posKey, {
+          posKey,
+          dataSourceId: p.source_id,
+          symbol: p.symbol,
+          account: p.account,
+          side,
+          qty: Math.abs(p.qty),
+          entryPrice: p.avg_price,
+          openTimestamp: now,
+          lastPnl: p.unrealized_pnl,
+          samples: [{ t: now, pnl: p.unrealized_pnl }],
+          lastExitPrice: null,
+        });
+      }
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Order events — track the most recent fill price so we can record it as exitPrice on close.
+  useEffect(() => {
+    const unlisten = listen<OrderEvent>("nt-order-update", (event) => {
+      const o = event.payload;
+      if (o.state !== "filled" && o.state !== "partial") return;
+      const price = o.fill_price ?? o.avg_fill_price;
+      if (price == null) return;
+      const posKey = posKeyOf(o.source_id, o.symbol, o.account);
+      const open = openPositions.current.get(posKey);
+      if (open) open.lastExitPrice = price;
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Chart removal — drop any dangling open positions for that chart. Already-closed
+  // roundtrips stay in history.
+  useEffect(() => {
+    const unlisten = listen<string>("nt-chart-removed", (event) => {
+      const removedId = event.payload;
+      for (const [key, val] of openPositions.current) {
+        if (val.dataSourceId === removedId) {
+          openPositions.current.delete(key);
+        }
+      }
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  const byAlgo = useMemo(() => aggregateByKey(roundtrips, "algo"), [roundtrips]);
+  const bySymbol = useMemo(() => aggregateByKey(roundtrips, "symbol"), [roundtrips]);
+  const byAccount = useMemo(() => aggregateByKey(roundtrips, "account"), [roundtrips]);
+  const liveVsShadow = useMemo(() => pairLiveShadow(roundtrips), [roundtrips]);
+  const distribution = useMemo(() => buildDistribution(roundtrips), [roundtrips]);
+  const heatmap = useMemo(() => buildHeatmap(roundtrips), [roundtrips]);
+
+  return { roundtrips, byAlgo, bySymbol, byAccount, liveVsShadow, distribution, heatmap };
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Smoke — manual (hook alone, not wired yet)**
+
+The hook is not yet wired into any view. Smoke is purely type-check. Functional smoke happens in Task 10 after the rewire.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useTradeHistory.ts
+git commit -m "feat(trading): add useTradeHistory hook for roundtrip pairing and aggregates"
+```
+
+---
+
+### Task 3: Create `useEquityTimeline` hook
+
+**Files:**
+- Create: `src/hooks/useEquityTimeline.ts`
+
+Owns the timestamped equity series (live + shadow) and derives the drawdown series from each. Live equity is driven by `nt-account` realized P&L updates (NinjaTrader only emits account snapshots for real accounts — shadow has no account). Shadow equity is derived from cumulative closed shadow roundtrips from `useTradeHistory`.
+
+- [ ] **Step 1: Write the hook file**
+
+Create `src/hooks/useEquityTimeline.ts` with this exact content:
+
+```ts
+import { useState, useEffect, useRef, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { Roundtrip, EquityPoint, DrawdownPoint } from "../lib/tradingView";
+
+type AccountSnapshot = {
+  name: string;
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+const MAX_POINTS = 500;
+
+const pushCapped = (arr: EquityPoint[], point: EquityPoint): EquityPoint[] => {
+  const next = [...arr, point];
+  return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+};
+
+const deriveDrawdown = (series: EquityPoint[]): DrawdownPoint[] => {
+  let peak = 0;
+  const out: DrawdownPoint[] = [];
+  for (const p of series) {
+    if (p.pnl > peak) peak = p.pnl;
+    out.push({ t: p.t, peak, pnl: p.pnl, underwater: peak - p.pnl });
+  }
+  return out;
+};
+
+export type EquityTimeline = {
+  live: EquityPoint[];
+  shadow: EquityPoint[];
+  liveDrawdown: DrawdownPoint[];
+  shadowDrawdown: DrawdownPoint[];
+};
+
+const INITIAL: EquityPoint[] = [{ t: Date.now(), pnl: 0 }];
+
+export const useEquityTimeline = (roundtrips: Roundtrip[]): EquityTimeline => {
+  const [live, setLive] = useState<EquityPoint[]>(INITIAL);
+  const [shadow, setShadow] = useState<EquityPoint[]>(INITIAL);
+  const lastLiveRealizedRef = useRef<number | null>(null);
+  const lastShadowCumulativeRef = useRef(0);
+  const lastShadowCloseRef = useRef(0);
+
+  // Live realized P&L comes from the nt-account stream (non-shadow accounts).
+  // Emit a new point whenever realized_pnl changes for any live account.
+  useEffect(() => {
+    const unlisten = listen<AccountSnapshot>("nt-account", (event) => {
+      const a = event.payload;
+      if (a.name === "shadow") return;
+      if (lastLiveRealizedRef.current === a.realized_pnl) return;
+      lastLiveRealizedRef.current = a.realized_pnl;
+      setLive((prev) => pushCapped(prev, { t: Date.now(), pnl: a.realized_pnl }));
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Shadow equity is derived from cumulative closed shadow roundtrips. Only append
+  // when a newly-closed shadow trip arrives after our last recorded shadow close.
+  useEffect(() => {
+    const shadowTrips = roundtrips.filter((r) => r.isShadow);
+    if (shadowTrips.length === 0) return;
+    const latestClose = shadowTrips.reduce((m, r) => Math.max(m, r.closeTimestamp), 0);
+    if (latestClose <= lastShadowCloseRef.current) return;
+    lastShadowCloseRef.current = latestClose;
+    const cum = shadowTrips.reduce((s, r) => s + r.pnl, 0);
+    const rounded = Math.round(cum * 100) / 100;
+    if (rounded === lastShadowCumulativeRef.current) return;
+    lastShadowCumulativeRef.current = rounded;
+    setShadow((prev) => pushCapped(prev, { t: latestClose, pnl: rounded }));
+  }, [roundtrips]);
+
+  const liveDrawdown = useMemo(() => deriveDrawdown(live), [live]);
+  const shadowDrawdown = useMemo(() => deriveDrawdown(shadow), [shadow]);
+
+  return { live, shadow, liveDrawdown, shadowDrawdown };
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useEquityTimeline.ts
+git commit -m "feat(trading): add useEquityTimeline hook for timestamped equity + drawdown"
+```
+
+---
+
+### Task 4: Create `useRollingMetrics` hook
+
+**Files:**
+- Create: `src/hooks/useRollingMetrics.ts`
+
+Windowed Sharpe / win rate / expectancy over the trailing N roundtrips. Pure derivation from the roundtrip list — no event subscriptions; just `useMemo`.
+
+- [ ] **Step 1: Write the hook file**
+
+Create `src/hooks/useRollingMetrics.ts` with this exact content:
+
+```ts
+import { useMemo } from "react";
+import type { Roundtrip } from "../lib/tradingView";
+
+export type RollingMetric = "sharpe" | "winRate" | "expectancy";
+
+export type RollingPoint = { t: number; value: number; windowSize: number };
+
+export type RollingMetrics = {
+  sharpe: RollingPoint[];
+  winRate: RollingPoint[];
+  expectancy: RollingPoint[];
+};
+
+const computeSharpe = (pnls: number[]): number | null => {
+  if (pnls.length < 2) return null;
+  const mean = pnls.reduce((a, b) => a + b, 0) / pnls.length;
+  const variance = pnls.reduce((s, v) => s + (v - mean) ** 2, 0) / pnls.length;
+  const std = Math.sqrt(variance);
+  return std > 0 ? Math.round((mean / std) * 100) / 100 : null;
+};
+
+const computeWinRate = (pnls: number[]): number => {
+  if (pnls.length === 0) return 0;
+  const wins = pnls.filter((p) => p > 0).length;
+  return Math.round((wins / pnls.length) * 100);
+};
+
+const computeExpectancy = (pnls: number[]): number => {
+  if (pnls.length === 0) return 0;
+  return Math.round((pnls.reduce((a, b) => a + b, 0) / pnls.length) * 100) / 100;
+};
+
+export const useRollingMetrics = (
+  roundtrips: Roundtrip[],
+  windowSize: number = 20,
+): RollingMetrics => {
+  return useMemo(() => {
+    const sorted = [...roundtrips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+    const sharpe: RollingPoint[] = [];
+    const winRate: RollingPoint[] = [];
+    const expectancy: RollingPoint[] = [];
+    for (let i = 0; i < sorted.length; i++) {
+      const start = Math.max(0, i - windowSize + 1);
+      const window = sorted.slice(start, i + 1);
+      const pnls = window.map((r) => r.pnl);
+      const t = sorted[i].closeTimestamp;
+      const ws = window.length;
+      const s = computeSharpe(pnls);
+      if (s !== null) sharpe.push({ t, value: s, windowSize: ws });
+      winRate.push({ t, value: computeWinRate(pnls), windowSize: ws });
+      expectancy.push({ t, value: computeExpectancy(pnls), windowSize: ws });
+    }
+    return { sharpe, winRate, expectancy };
+  }, [roundtrips, windowSize]);
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useRollingMetrics.ts
+git commit -m "feat(trading): add useRollingMetrics hook for windowed trade metrics"
+```
+
+---
+
+### Task 5: Shared chrome — `EquityChart` + `TradingFilterBar` + `TradingTabs` + `TradingHero`
+
+**Files:**
+- Create: `src/components/EquityChart.tsx`
+- Create: `src/components/TradingFilterBar.tsx`
+- Create: `src/components/TradingTabs.tsx`
+- Create: `src/components/TradingHero.tsx`
+
+These four components form the always-visible chrome: hero (KPIs + equity chart), filter bar, tab bar. They have no cross-dependencies on the tab components — only on the helpers and hooks.
+
+- [ ] **Step 1: Write `src/components/EquityChart.tsx`**
+
+Canvas-based chart replacing the inline `PnlChart` from today's `TradingView`. Renders live as a solid step-line (green above zero, red below), shadow as a dashed line on the same axis, and underwater drawdown as a muted-red band beneath the live line.
+
+Create with this exact content:
+
+```tsx
+import { useEffect, useRef } from "react";
+import type { EquityPoint, DrawdownPoint } from "../lib/tradingView";
+
+type EquityChartProps = {
+  live: EquityPoint[];
+  shadow: EquityPoint[];
+  drawdown: DrawdownPoint[];
+};
+
+const GREEN = "#00d68f";
+const RED = "#ff4d6a";
+const DD_FILL = "rgba(255, 77, 106, 0.10)";
+const GRID = "rgba(136, 136, 160, 0.2)";
+const SHADOW_COLOR = "rgba(255, 193, 7, 0.8)";
+const TOOLTIP_BG = "rgba(26, 26, 40, 0.92)";
+const TOOLTIP_BORDER = "rgba(42, 42, 58, 0.8)";
+
+type DrawData = {
+  t: number;
+  pnl: number;
+};
+
+const formatValue = (v: number) => `${v >= 0 ? "+" : "-"}$${Math.abs(v).toFixed(2)}`;
+
+export const EquityChart = ({ live, shadow, drawdown }: EquityChartProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+  const mouseRef = useRef<{ x: number; y: number } | null>(null);
+  const liveRef = useRef(live);
+  const shadowRef = useRef(shadow);
+  const ddRef = useRef(drawdown);
+
+  useEffect(() => {
+    liveRef.current = live;
+  }, [live]);
+  useEffect(() => {
+    shadowRef.current = shadow;
+  }, [shadow]);
+  useEffect(() => {
+    ddRef.current = drawdown;
+  }, [drawdown]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const move = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouseRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    };
+    const leave = () => {
+      mouseRef.current = null;
+    };
+    canvas.addEventListener("mousemove", move);
+    canvas.addEventListener("mouseleave", leave);
+    return () => {
+      canvas.removeEventListener("mousemove", move);
+      canvas.removeEventListener("mouseleave", leave);
+    };
+  }, []);
+
+  useEffect(() => {
+    const draw = () => {
+      const canvas = canvasRef.current;
+      const container = containerRef.current;
+      if (!canvas || !container) {
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      if (
+        canvas.width !== Math.round(rect.width * dpr) ||
+        canvas.height !== Math.round(rect.height * dpr)
+      ) {
+        canvas.width = Math.round(rect.width * dpr);
+        canvas.height = Math.round(rect.height * dpr);
+        canvas.style.width = `${rect.width}px`;
+        canvas.style.height = `${rect.height}px`;
+      }
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const w = rect.width;
+      const h = rect.height;
+      ctx.clearRect(0, 0, w, h);
+
+      const liveSeries = liveRef.current;
+      const shadowSeries = shadowRef.current;
+      const dd = ddRef.current;
+
+      const all: DrawData[] = [...liveSeries, ...shadowSeries];
+      if (all.length < 2) {
+        ctx.fillStyle = "rgba(136, 136, 160, 0.5)";
+        ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText("No equity data yet", w / 2, h / 2);
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+
+      // Domain: time min/max across both series; value min/max anchored at 0.
+      const tMin = Math.min(...all.map((p) => p.t));
+      const tMax = Math.max(...all.map((p) => p.t));
+      const tRange = Math.max(tMax - tMin, 1);
+      const vMin = Math.min(0, ...all.map((p) => p.pnl));
+      const vMax = Math.max(0, ...all.map((p) => p.pnl));
+      const vRange = vMax - vMin || 1;
+      const pad = vRange * 0.1;
+      const toX = (t: number) => ((t - tMin) / tRange) * w;
+      const toY = (v: number) => h - ((v - vMin + pad) / (vRange + pad * 2)) * h;
+
+      // Zero line
+      const zeroY = toY(0);
+      ctx.strokeStyle = GRID;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(0, zeroY);
+      ctx.lineTo(w, zeroY);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Drawdown band (underwater area beneath live series)
+      if (dd.length >= 2) {
+        ctx.beginPath();
+        ctx.moveTo(toX(dd[0].t), toY(dd[0].peak));
+        for (let i = 1; i < dd.length; i++) {
+          ctx.lineTo(toX(dd[i].t), toY(dd[i].peak));
+        }
+        for (let i = dd.length - 1; i >= 0; i--) {
+          ctx.lineTo(toX(dd[i].t), toY(dd[i].pnl));
+        }
+        ctx.closePath();
+        ctx.fillStyle = DD_FILL;
+        ctx.fill();
+      }
+
+      const traceStep = (series: DrawData[]) => {
+        if (series.length === 0) return;
+        ctx.moveTo(toX(series[0].t), toY(series[0].pnl));
+        for (let i = 1; i < series.length; i++) {
+          ctx.lineTo(toX(series[i].t), toY(series[i - 1].pnl));
+          ctx.lineTo(toX(series[i].t), toY(series[i].pnl));
+        }
+      };
+
+      // Live series — split by sign for green/red coloring via clip regions.
+      if (liveSeries.length >= 2) {
+        const regions = [
+          { yStart: 0, yEnd: zeroY, color: GREEN, grad: ["rgba(0,214,143,0.2)", "rgba(0,214,143,0)"] },
+          { yStart: zeroY, yEnd: h, color: RED, grad: ["rgba(255,77,106,0)", "rgba(255,77,106,0.2)"] },
+        ];
+        for (const r of regions) {
+          if (r.yEnd - r.yStart <= 0) continue;
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(0, r.yStart, w, r.yEnd - r.yStart);
+          ctx.clip();
+          const g = ctx.createLinearGradient(0, r.yStart, 0, r.yEnd);
+          g.addColorStop(0, r.grad[0]);
+          g.addColorStop(1, r.grad[1]);
+          ctx.beginPath();
+          ctx.moveTo(toX(liveSeries[0].t), zeroY);
+          traceStep(liveSeries);
+          ctx.lineTo(toX(liveSeries[liveSeries.length - 1].t), zeroY);
+          ctx.closePath();
+          ctx.fillStyle = g;
+          ctx.fill();
+          ctx.beginPath();
+          traceStep(liveSeries);
+          ctx.strokeStyle = r.color;
+          ctx.lineWidth = 2;
+          ctx.stroke();
+          ctx.restore();
+        }
+      }
+
+      // Shadow series — dashed overlay
+      if (shadowSeries.length >= 2) {
+        ctx.save();
+        ctx.setLineDash([4, 3]);
+        ctx.strokeStyle = SHADOW_COLOR;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        traceStep(shadowSeries);
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      // Crosshair + tooltip for the live series
+      const mouse = mouseRef.current;
+      if (mouse && liveSeries.length >= 2) {
+        // Nearest point by x
+        let nearestIdx = 0;
+        let nearestDx = Infinity;
+        for (let i = 0; i < liveSeries.length; i++) {
+          const dx = Math.abs(toX(liveSeries[i].t) - mouse.x);
+          if (dx < nearestDx) {
+            nearestDx = dx;
+            nearestIdx = i;
+          }
+        }
+        const point = liveSeries[nearestIdx];
+        const px = toX(point.t);
+        const py = toY(point.pnl);
+        const color = point.pnl >= 0 ? GREEN : RED;
+
+        ctx.strokeStyle = "rgba(136, 136, 160, 0.3)";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([3, 3]);
+        ctx.beginPath();
+        ctx.moveTo(px, 0);
+        ctx.lineTo(px, h);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        ctx.beginPath();
+        ctx.arc(px, py, 5, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.fill();
+        ctx.strokeStyle = "#1a1a28";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+
+        const label = formatValue(point.pnl);
+        ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+        const metrics = ctx.measureText(label);
+        const tw = metrics.width + 16;
+        const th = 24;
+        const pad2 = 10;
+        let tx = px + pad2;
+        if (tx + tw > w) tx = px - tw - pad2;
+        let ty = py - th - pad2;
+        if (ty < 0) ty = py + pad2;
+        ctx.fillStyle = TOOLTIP_BG;
+        ctx.beginPath();
+        ctx.roundRect(tx, ty, tw, th, 4);
+        ctx.fill();
+        ctx.strokeStyle = TOOLTIP_BORDER;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.fillStyle = color;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(label, tx + tw / 2, ty + th / 2);
+      }
+
+      rafRef.current = requestAnimationFrame(draw);
+    };
+    rafRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex-1 min-h-0">
+      <canvas ref={canvasRef} className="w-full h-full" style={{ cursor: "crosshair" }} />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `src/components/TradingFilterBar.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { ReactNode } from "react";
+import type { Filters, Roundtrip } from "../lib/tradingView";
+import { formatChartLabel } from "../lib/tradingView";
+import type { Algo, AlgoRun } from "../types";
+import type { DataSource, Position, SimOrder } from "../hooks/useTradingSimulation";
+
+type TradingFilterBarProps = {
+  filters: Filters;
+  onFiltersChange: (next: Filters) => void;
+  algos: Algo[];
+  activeRuns: AlgoRun[];
+  dataSources: DataSource[];
+  positions: Position[];
+  orders: SimOrder[];
+  roundtrips: Roundtrip[];
+};
+
+// Build the union of every chart / account / algo that has appeared this session:
+//   connected charts + accounts seen on positions/orders/roundtrips + algos seen on runs/roundtrips.
+const deriveFilterPools = (
+  algos: Algo[],
+  activeRuns: AlgoRun[],
+  dataSources: DataSource[],
+  positions: Position[],
+  orders: SimOrder[],
+  roundtrips: Roundtrip[],
+): { charts: string[]; accounts: string[]; algos: { id: number; name: string }[] } => {
+  const chartIds = new Set<string>();
+  for (const ds of dataSources) chartIds.add(ds.id);
+  for (const p of positions) chartIds.add(p.dataSourceId);
+  for (const o of orders) chartIds.add(o.dataSourceId);
+  for (const r of roundtrips) chartIds.add(r.dataSourceId);
+
+  const accountSet = new Set<string>();
+  for (const p of positions) accountSet.add(p.account);
+  for (const o of orders) accountSet.add(o.account);
+  for (const r of roundtrips) accountSet.add(r.account);
+  for (const run of activeRuns) accountSet.add(run.account);
+
+  const algoMap = new Map<number, string>();
+  for (const run of activeRuns) {
+    const a = algos.find((x) => x.id === run.algo_id);
+    algoMap.set(run.algo_id, a?.name ?? `algo ${run.algo_id}`);
+  }
+  for (const r of roundtrips) {
+    if (r.algoId !== 0) algoMap.set(r.algoId, r.algo || `algo ${r.algoId}`);
+  }
+
+  return {
+    charts: [...chartIds].sort(),
+    accounts: [...accountSet].sort(),
+    algos: [...algoMap.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  };
+};
+
+type ChipProps = { active: boolean; onClick: () => void; children: ReactNode };
+
+const Chip = ({ active, onClick, children }: ChipProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`px-3 py-1 text-[11px] rounded-md transition-colors ${
+      active
+        ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
+        : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
+    }`}
+  >
+    {children}
+  </button>
+);
+
+export const TradingFilterBar = ({
+  filters,
+  onFiltersChange,
+  algos,
+  activeRuns,
+  dataSources,
+  positions,
+  orders,
+  roundtrips,
+}: TradingFilterBarProps) => {
+  const { charts, accounts, algos: algoPool } = deriveFilterPools(
+    algos,
+    activeRuns,
+    dataSources,
+    positions,
+    orders,
+    roundtrips,
+  );
+
+  if (charts.length === 0 && accounts.length === 0 && algoPool.length === 0) {
+    return null;
+  }
+
+  const setChart = (v: string | null) => onFiltersChange({ ...filters, chart: v });
+  const setAccount = (v: string | null) => onFiltersChange({ ...filters, account: v });
+  const setAlgo = (v: number | null) => onFiltersChange({ ...filters, algo: v });
+
+  return (
+    <div className="flex items-center gap-4 px-2 flex-wrap">
+      {charts.length > 0 && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">
+            Chart
+          </span>
+          <Chip active={filters.chart === null} onClick={() => setChart(null)}>
+            All
+          </Chip>
+          {charts.map((id) => (
+            <Chip
+              key={id}
+              active={filters.chart === id}
+              onClick={() => setChart(filters.chart === id ? null : id)}
+            >
+              {formatChartLabel(id)}
+            </Chip>
+          ))}
+        </div>
+      )}
+
+      {accounts.length > 0 && (
+        <>
+          <div className="w-px h-5 bg-[var(--border)]" />
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">
+              Account
+            </span>
+            <Chip active={filters.account === null} onClick={() => setAccount(null)}>
+              All
+            </Chip>
+            {accounts.map((acc) => (
+              <Chip
+                key={acc}
+                active={filters.account === acc}
+                onClick={() => setAccount(filters.account === acc ? null : acc)}
+              >
+                {acc === "shadow" ? "shadow" : acc}
+              </Chip>
+            ))}
+          </div>
+        </>
+      )}
+
+      {algoPool.length > 0 && (
+        <>
+          <div className="w-px h-5 bg-[var(--border)]" />
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">
+              Algo
+            </span>
+            <Chip active={filters.algo === null} onClick={() => setAlgo(null)}>
+              All
+            </Chip>
+            {algoPool.map((a) => (
+              <Chip
+                key={a.id}
+                active={filters.algo === a.id}
+                onClick={() => setAlgo(filters.algo === a.id ? null : a.id)}
+              >
+                {a.name}
+              </Chip>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Write `src/components/TradingTabs.tsx`**
+
+Create with this exact content:
+
+```tsx
+export type TradingTab = "live" | "performance" | "analytics" | "trades";
+
+type TradingTabsProps = {
+  activeTab: TradingTab;
+  onChange: (tab: TradingTab) => void;
+};
+
+const TABS: { id: TradingTab; label: string }[] = [
+  { id: "live", label: "Live" },
+  { id: "performance", label: "Performance" },
+  { id: "analytics", label: "Analytics" },
+  { id: "trades", label: "Trades" },
+];
+
+export const TradingTabs = ({ activeTab, onChange }: TradingTabsProps) => (
+  <div className="flex gap-1 border-b border-[var(--border)] px-2">
+    {TABS.map((tab) => (
+      <button
+        key={tab.id}
+        type="button"
+        onClick={() => onChange(tab.id)}
+        className={`px-4 py-2 text-sm transition-colors border-b-2 -mb-px ${
+          activeTab === tab.id
+            ? "border-[var(--accent-blue)] text-[var(--accent-blue)]"
+            : "border-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        }`}
+      >
+        {tab.label}
+      </button>
+    ))}
+  </div>
+);
+```
+
+- [ ] **Step 4: Write `src/components/TradingHero.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { HeroKpis, EquityPoint, DrawdownPoint } from "../lib/tradingView";
+import { pnlColorClass } from "../lib/tradingView";
+import { EquityChart } from "./EquityChart";
+
+type TradingHeroProps = {
+  kpis: HeroKpis;
+  equityLive: EquityPoint[];
+  equityShadow: EquityPoint[];
+  drawdown: DrawdownPoint[];
+};
+
+const Kpi = ({ label, value, tone }: { label: string; value: string; tone?: string }) => (
+  <div className="flex-1 min-w-0">
+    <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+      {label}
+    </div>
+    <div className={`text-lg font-semibold font-mono tabular-nums truncate ${tone ?? ""}`}>
+      {value}
+    </div>
+  </div>
+);
+
+const formatDollars = (v: number): string => `${v >= 0 ? "+" : "-"}$${Math.abs(v).toFixed(2)}`;
+
+export const TradingHero = ({ kpis, equityLive, equityShadow, drawdown }: TradingHeroProps) => {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-7 gap-4 p-4 bg-[var(--bg-panel)] rounded-lg">
+        <Kpi label="Realized" value={formatDollars(kpis.realizedPnl)} tone={pnlColorClass(kpis.realizedPnl)} />
+        <Kpi label="Unrealized" value={formatDollars(kpis.unrealizedPnl)} tone={pnlColorClass(kpis.unrealizedPnl)} />
+        <Kpi label="Total" value={formatDollars(kpis.totalPnl)} tone={pnlColorClass(kpis.totalPnl)} />
+        <Kpi label="Win Rate" value={kpis.trades > 0 ? `${kpis.winRate}%` : "--"} />
+        <Kpi label="Trades" value={`${kpis.trades}`} />
+        <Kpi label="Sharpe" value={kpis.sharpe} />
+        <Kpi
+          label="Max DD"
+          value={kpis.maxDrawdown > 0 ? `-$${kpis.maxDrawdown.toFixed(2)}` : "--"}
+          tone={kpis.maxDrawdown > 0 ? "text-[var(--accent-red)]" : ""}
+        />
+      </div>
+
+      <div className="bg-[var(--bg-panel)] rounded-lg p-4 flex flex-col h-[220px]">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Equity
+            <span className="ml-2 font-normal normal-case tracking-normal text-[var(--text-muted)]">
+              · with drawdown overlay
+            </span>
+          </h2>
+          <div className="flex items-center gap-3 text-[10px] text-[var(--text-secondary)]">
+            <span className="flex items-center gap-1.5">
+              <span className="w-3 h-[2px] bg-[var(--accent-green)]" />
+              Live
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span
+                className="w-3 h-[2px]"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(90deg, var(--accent-yellow) 50%, transparent 50%)",
+                  backgroundSize: "4px 2px",
+                }}
+              />
+              Shadow
+            </span>
+          </div>
+        </div>
+        <EquityChart live={equityLive} shadow={equityShadow} drawdown={drawdown} />
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/EquityChart.tsx src/components/TradingFilterBar.tsx src/components/TradingTabs.tsx src/components/TradingHero.tsx
+git commit -m "feat(trading): add hero, filter bar, tabs, and equity chart components"
+```
+
+---
+
+### Task 6: Live tab — `PositionCard` + `RiskSummary` + `OrderTape` + `LiveTab`
+
+**Files:**
+- Create: `src/components/PositionCard.tsx`
+- Create: `src/components/RiskSummary.tsx`
+- Create: `src/components/OrderTape.tsx`
+- Create: `src/components/LiveTab.tsx`
+
+- [ ] **Step 1: Write `src/components/PositionCard.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { Position } from "../hooks/useTradingSimulation";
+import { formatPrice } from "../hooks/useTradingSimulation";
+import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
+
+type PositionCardProps = {
+  position: Position;
+  openSinceTs: number | null;
+};
+
+export const PositionCard = ({ position, openSinceTs }: PositionCardProps) => {
+  const isShadow = position.account === "shadow";
+  const sideColor = position.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
+  const now = Date.now();
+  const held = openSinceTs ? formatDuration(openSinceTs, now) : "--";
+
+  return (
+    <div className="flex-1 min-w-[240px] bg-[var(--bg-elevated)] border border-[var(--border)] rounded-lg p-3">
+      <div className="flex items-center justify-between mb-1">
+        <div className="text-sm font-semibold">{position.symbol}</div>
+        <span
+          className={`text-[9px] uppercase tracking-wider px-2 py-0.5 rounded font-semibold ${
+            isShadow
+              ? "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]"
+              : "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
+          }`}
+        >
+          {isShadow ? "Shadow" : "Live"}
+        </span>
+      </div>
+      <div className="text-[10px] text-[var(--text-secondary)] mb-2 truncate">
+        {position.algo || "—"} · {position.account}
+      </div>
+      <div className="flex items-center justify-between mb-1">
+        <span className={`text-sm font-medium ${sideColor}`}>
+          {position.side} {position.qty}
+        </span>
+        <span className={`text-sm font-semibold font-mono tabular-nums ${pnlColorClass(position.pnl)}`}>
+          {formatPnl(position.pnl)}
+        </span>
+      </div>
+      <div className="text-[10px] text-[var(--text-secondary)] font-mono">
+        entry {formatPrice(position.symbol, position.avgPrice)} · held {held}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `src/components/RiskSummary.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { Position } from "../hooks/useTradingSimulation";
+
+type AccountSummary = {
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+type RiskSummaryProps = {
+  positions: Position[];
+  accounts: Record<string, AccountSummary>;
+};
+
+const Cell = ({ label, value, tone }: { label: string; value: string; tone?: string }) => (
+  <div className="flex-1 min-w-0">
+    <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+      {label}
+    </div>
+    <div className={`text-base font-semibold font-mono tabular-nums ${tone ?? ""}`}>{value}</div>
+  </div>
+);
+
+const formatDollars = (v: number): string => `$${Math.abs(v).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+
+export const RiskSummary = ({ positions, accounts }: RiskSummaryProps) => {
+  const liveAccounts = Object.entries(accounts).filter(([name]) => name !== "shadow");
+  const totalBuyingPower = liveAccounts.reduce((s, [, a]) => s + a.buying_power, 0);
+
+  // Open risk = sum of negative unrealized P&Ls across open positions (how much we could still lose
+  // if every position adversely hit zero at current prices). A crude but useful gauge.
+  const openRisk = positions.reduce((s, p) => s + (p.pnl < 0 ? Math.abs(p.pnl) : 0), 0);
+  const openPositions = positions.length;
+  const portfolioHeat =
+    totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(2) : "--";
+  const marginUsed = totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(0) : "--";
+
+  return (
+    <div className="grid grid-cols-5 gap-4 p-3 bg-[var(--bg-panel)] rounded-lg">
+      <Cell
+        label="Open Risk"
+        value={openRisk > 0 ? `-${formatDollars(openRisk)}` : "$0"}
+        tone={openRisk > 0 ? "text-[var(--accent-yellow)]" : ""}
+      />
+      <Cell
+        label="Portfolio Heat"
+        value={portfolioHeat === "--" ? "--" : `${portfolioHeat}%`}
+      />
+      <Cell
+        label="Buying Power"
+        value={totalBuyingPower > 0 ? formatDollars(totalBuyingPower) : "--"}
+      />
+      <Cell label="Margin Used" value={marginUsed === "--" ? "--" : `${marginUsed}%`} />
+      <Cell label="Open Positions" value={`${openPositions}`} />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Write `src/components/OrderTape.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { SimOrder } from "../hooks/useTradingSimulation";
+
+type OrderTapeProps = {
+  orders: SimOrder[];
+};
+
+const statusTone = (status: SimOrder["status"]): string => {
+  switch (status) {
+    case "Filled":
+      return "bg-[var(--accent-green)]/15 text-[var(--accent-green)]";
+    case "Working":
+      return "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+    case "Cancelled":
+      return "bg-[var(--accent-red)]/15 text-[var(--accent-red)]";
+  }
+};
+
+export const OrderTape = ({ orders }: OrderTapeProps) => {
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Order Tape
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">
+          {orders.length > 0 ? `${orders.length} recent` : "live-updating"}
+        </span>
+      </div>
+      <div className="flex-1 overflow-auto max-h-[260px]">
+        {orders.length === 0 ? (
+          <div className="px-4 py-5 text-center text-sm text-[var(--text-secondary)]">
+            No orders yet
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+                <th className="text-left px-4 py-2 font-medium">Time</th>
+                <th className="text-left px-4 py-2 font-medium">Symbol</th>
+                <th className="text-left px-4 py-2 font-medium">Side</th>
+                <th className="text-right px-4 py-2 font-medium">Qty</th>
+                <th className="text-right px-4 py-2 font-medium">Price</th>
+                <th className="text-left px-4 py-2 font-medium">Status</th>
+                <th className="text-left px-4 py-2 font-medium">Algo</th>
+                <th className="text-left px-4 py-2 font-medium">Account</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((o) => (
+                <tr key={o.id} className="border-b border-[var(--border)] last:border-0">
+                  <td className="px-4 py-2 text-[var(--text-secondary)] font-mono text-[11px]">
+                    {o.time}
+                  </td>
+                  <td className="px-4 py-2 font-medium">{o.symbol}</td>
+                  <td
+                    className={`px-4 py-2 ${
+                      o.side === "Buy" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"
+                    }`}
+                  >
+                    {o.side}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{o.qty}</td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{o.price}</td>
+                  <td className="px-4 py-2">
+                    <span className={`text-[10px] px-2 py-0.5 rounded ${statusTone(o.status)}`}>
+                      {o.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-[var(--text-secondary)]">{o.algo || "—"}</td>
+                  <td className="px-4 py-2 text-[var(--text-secondary)]">
+                    {o.account === "shadow" ? (
+                      <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
+                        shadow
+                      </span>
+                    ) : (
+                      o.account
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Write `src/components/LiveTab.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { Position, SimOrder } from "../hooks/useTradingSimulation";
+import { RiskSummary } from "./RiskSummary";
+import { PositionCard } from "./PositionCard";
+import { OrderTape } from "./OrderTape";
+
+type AccountSummary = {
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+type LiveTabProps = {
+  positions: Position[];
+  orders: SimOrder[];
+  accounts: Record<string, AccountSummary>;
+  // Map posKey ("dataSourceId:symbol:account") → open-since timestamp; provided by useTradeHistory
+  // so position cards can render "held Xm" consistently. If a card has no entry in the map,
+  // fallback to "--" via null.
+  openSinceByPosKey: Map<string, number>;
+};
+
+export const LiveTab = ({ positions, orders, accounts, openSinceByPosKey }: LiveTabProps) => {
+  const hasAnything = positions.length > 0 || orders.length > 0;
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <RiskSummary positions={positions} accounts={accounts} />
+
+      <div className="bg-[var(--bg-panel)] rounded-lg p-3">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Open Positions
+          </h2>
+          <span className="text-[10px] text-[var(--text-muted)]">{positions.length}</span>
+        </div>
+        {positions.length === 0 ? (
+          <div className="text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)] rounded-lg p-6 text-center">
+            {hasAnything ? "No matching open positions" : "No open positions"}
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {positions.map((p) => {
+              const posKey = `${p.dataSourceId}:${p.symbol}:${p.account}`;
+              return (
+                <PositionCard
+                  key={posKey}
+                  position={p}
+                  openSinceTs={openSinceByPosKey.get(posKey) ?? null}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <OrderTape orders={orders} />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/PositionCard.tsx src/components/RiskSummary.tsx src/components/OrderTape.tsx src/components/LiveTab.tsx
+git commit -m "feat(trading): add Live tab components (position cards, risk summary, order tape)"
+```
+
+---
+
+### Task 7: Performance tab — `BreakdownTable` + `LiveShadowDelta` + `PerformanceTab`
+
+**Files:**
+- Create: `src/components/BreakdownTable.tsx`
+- Create: `src/components/LiveShadowDelta.tsx`
+- Create: `src/components/PerformanceTab.tsx`
+
+- [ ] **Step 1: Write `src/components/BreakdownTable.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { BreakdownRow } from "../lib/tradingView";
+import { formatPnl, pnlColorClass, sparklinePoints } from "../lib/tradingView";
+
+type BreakdownTableProps = {
+  title: string;
+  rows: BreakdownRow[];
+  labelHeader: string;
+  emptyMessage?: string;
+  onRowDeepLink?: (row: BreakdownRow) => void;
+  deepLinkLabel?: string;
+};
+
+const SPARK_W = 80;
+const SPARK_H = 20;
+
+export const BreakdownTable = ({
+  title,
+  rows,
+  labelHeader,
+  emptyMessage,
+  onRowDeepLink,
+  deepLinkLabel,
+}: BreakdownTableProps) => {
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[var(--border)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          {title}
+        </h2>
+      </div>
+      {rows.length === 0 ? (
+        <div className="px-4 py-6 text-center text-sm text-[var(--text-secondary)]">
+          {emptyMessage ?? "No data yet"}
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+              <th className="text-left px-4 py-2 font-medium">{labelHeader}</th>
+              <th className="text-right px-4 py-2 font-medium">Trades</th>
+              <th className="text-right px-4 py-2 font-medium">Win %</th>
+              <th className="text-right px-4 py-2 font-medium">P&L</th>
+              <th className="text-right px-4 py-2 font-medium">Sharpe</th>
+              <th className="text-right px-4 py-2 font-medium">Avg Win</th>
+              <th className="text-right px-4 py-2 font-medium">Avg Loss</th>
+              <th className="text-right px-4 py-2 font-medium">Profit Factor</th>
+              <th className="text-right px-4 py-2 font-medium">Trend</th>
+              {onRowDeepLink && <th className="text-right px-4 py-2 font-medium" />}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const strokeColor = row.pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+              const points = sparklinePoints(row.sparkline, SPARK_W, SPARK_H);
+              return (
+                <tr key={row.key} className="border-b border-[var(--border)] last:border-0">
+                  <td className="px-4 py-2 font-medium">
+                    {row.label === "shadow" ? (
+                      <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
+                        shadow
+                      </span>
+                    ) : (
+                      row.label
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.trades}</td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.winRate}%</td>
+                  <td className={`px-4 py-2 text-right font-mono tabular-nums font-medium ${pnlColorClass(row.pnl)}`}>
+                    {formatPnl(row.pnl)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.sharpe}</td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums text-[var(--accent-green)]">
+                    {formatPnl(row.avgWin)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums text-[var(--accent-red)]">
+                    {formatPnl(row.avgLoss)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.profitFactor}</td>
+                  <td className="px-4 py-2 text-right">
+                    {points ? (
+                      <svg
+                        className="inline-block"
+                        viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+                        preserveAspectRatio="none"
+                        width={SPARK_W}
+                        height={SPARK_H}
+                        aria-hidden
+                      >
+                        <polyline fill="none" stroke={strokeColor} strokeWidth="1.2" points={points} />
+                      </svg>
+                    ) : (
+                      <span className="text-[var(--text-muted)]">—</span>
+                    )}
+                  </td>
+                  {onRowDeepLink && (
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => onRowDeepLink(row)}
+                        className="text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent-blue)] transition-colors"
+                        title={deepLinkLabel}
+                      >
+                        →
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `src/components/LiveShadowDelta.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { LiveShadowPair } from "../lib/tradingView";
+import { formatPnl, pnlColorClass } from "../lib/tradingView";
+
+type LiveShadowDeltaProps = {
+  pairs: LiveShadowPair[];
+};
+
+export const LiveShadowDelta = ({ pairs }: LiveShadowDeltaProps) => {
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[var(--border)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Live vs. Shadow
+        </h2>
+      </div>
+      {pairs.length === 0 ? (
+        <div className="px-4 py-6 text-center text-sm text-[var(--text-secondary)]">
+          No paired trades yet · run the same algo live and shadow to compare
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+              <th className="text-left px-4 py-2 font-medium">Algo</th>
+              <th className="text-right px-4 py-2 font-medium">Live P&L</th>
+              <th className="text-right px-4 py-2 font-medium">Shadow P&L</th>
+              <th className="text-right px-4 py-2 font-medium">Δ</th>
+              <th className="text-right px-4 py-2 font-medium">Live Win %</th>
+              <th className="text-right px-4 py-2 font-medium">Shadow Win %</th>
+              <th className="text-right px-4 py-2 font-medium">Slippage est.</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pairs.map((p) => (
+              <tr key={p.algoId} className="border-b border-[var(--border)] last:border-0">
+                <td className="px-4 py-2 font-medium">{p.algoName}</td>
+                <td className={`px-4 py-2 text-right font-mono tabular-nums ${pnlColorClass(p.live?.pnl ?? 0)}`}>
+                  {p.live ? formatPnl(p.live.pnl) : "—"}
+                </td>
+                <td className={`px-4 py-2 text-right font-mono tabular-nums ${pnlColorClass(p.shadow?.pnl ?? 0)}`}>
+                  {p.shadow ? formatPnl(p.shadow.pnl) : "—"}
+                </td>
+                <td className={`px-4 py-2 text-right font-mono tabular-nums font-semibold ${pnlColorClass(p.delta)}`}>
+                  {formatPnl(p.delta)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono tabular-nums">
+                  {p.live ? `${p.live.winRate}%` : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono tabular-nums">
+                  {p.shadow ? `${p.shadow.winRate}%` : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono tabular-nums text-[var(--text-secondary)]">
+                  {p.live && p.shadow ? `${formatPnl(p.slippagePerTrade)}/trade` : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Write `src/components/PerformanceTab.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { BreakdownRow, LiveShadowPair } from "../lib/tradingView";
+import { BreakdownTable } from "./BreakdownTable";
+import { LiveShadowDelta } from "./LiveShadowDelta";
+
+type PerformanceTabProps = {
+  byAlgo: BreakdownRow[];
+  bySymbol: BreakdownRow[];
+  byAccount: BreakdownRow[];
+  liveVsShadow: LiveShadowPair[];
+  onOpenAlgoInEditor: (algoId: number) => void;
+  onViewAccountInAlgos: (account: string) => void;
+};
+
+export const PerformanceTab = ({
+  byAlgo,
+  bySymbol,
+  byAccount,
+  liveVsShadow,
+  onOpenAlgoInEditor,
+  onViewAccountInAlgos,
+}: PerformanceTabProps) => {
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <BreakdownTable
+        title="By Algo"
+        labelHeader="Algo"
+        rows={byAlgo}
+        emptyMessage="No completed trades yet — breakdowns appear after your first roundtrip"
+        onRowDeepLink={(row) => {
+          const id = Number(row.key);
+          if (Number.isFinite(id) && id > 0) onOpenAlgoInEditor(id);
+        }}
+        deepLinkLabel="Open in Editor"
+      />
+
+      <div className="grid grid-cols-2 gap-3">
+        <BreakdownTable
+          title="By Symbol"
+          labelHeader="Symbol"
+          rows={bySymbol}
+          emptyMessage="No completed trades yet"
+        />
+        <BreakdownTable
+          title="By Account"
+          labelHeader="Account"
+          rows={byAccount}
+          emptyMessage="No completed trades yet"
+          onRowDeepLink={(row) => onViewAccountInAlgos(row.key)}
+          deepLinkLabel="View algos for this account"
+        />
+      </div>
+
+      <LiveShadowDelta pairs={liveVsShadow} />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/BreakdownTable.tsx src/components/LiveShadowDelta.tsx src/components/PerformanceTab.tsx
+git commit -m "feat(trading): add Performance tab components (breakdowns, live-vs-shadow)"
+```
+
+---
+
+### Task 8: Analytics tab — `TradeDistribution` + `SessionHeatmap` + `RollingMetricsChart` + `AnalyticsTab`
+
+**Files:**
+- Create: `src/components/TradeDistribution.tsx`
+- Create: `src/components/SessionHeatmap.tsx`
+- Create: `src/components/RollingMetricsChart.tsx`
+- Create: `src/components/AnalyticsTab.tsx`
+
+- [ ] **Step 1: Write `src/components/TradeDistribution.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { DistributionBucket } from "../lib/tradingView";
+
+type TradeDistributionProps = {
+  buckets: DistributionBucket[];
+  totalTrades: number;
+};
+
+export const TradeDistribution = ({ buckets, totalTrades }: TradeDistributionProps) => {
+  if (buckets.length === 0 || totalTrades === 0) {
+    return (
+      <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+        <div className="px-4 py-2.5 border-b border-[var(--border)]">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Trade P&L Distribution
+          </h2>
+        </div>
+        <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)]">
+          No completed trades yet
+        </div>
+      </div>
+    );
+  }
+
+  const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Trade P&L Distribution
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">{totalTrades} trades</span>
+      </div>
+      <div className="flex-1 px-4 py-3 flex flex-col">
+        <div className="flex-1 flex items-end gap-[2px]">
+          {buckets.map((b, i) => {
+            const height = `${(b.count / maxCount) * 100}%`;
+            const isNegative = b.hi <= 0;
+            const color = isNegative
+              ? "bg-[var(--accent-red)]"
+              : b.lo >= 0
+                ? "bg-[var(--accent-green)]"
+                : "bg-[var(--text-muted)]";
+            return (
+              <div
+                key={i}
+                className={`flex-1 rounded-t ${color}`}
+                style={{ height, minHeight: b.count > 0 ? "2px" : "0" }}
+                title={`${b.count} trades · ${b.lo.toFixed(2)} to ${b.hi.toFixed(2)}`}
+              />
+            );
+          })}
+        </div>
+        <div className="flex justify-between text-[10px] text-[var(--text-muted)] mt-2 font-mono">
+          <span>{buckets[0].lo.toFixed(0)}</span>
+          <span>0</span>
+          <span>+{buckets[buckets.length - 1].hi.toFixed(0)}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `src/components/SessionHeatmap.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { HeatCell } from "../lib/tradingView";
+
+type SessionHeatmapProps = {
+  grid: HeatCell[][];
+};
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const cellColor = (cell: HeatCell, absMax: number): string => {
+  if (cell.trades === 0) return "var(--bg-elevated)";
+  const intensity = Math.min(1, Math.abs(cell.pnl) / (absMax || 1));
+  const alpha = 0.15 + intensity * 0.75;
+  return cell.pnl >= 0
+    ? `rgba(0, 214, 143, ${alpha.toFixed(2)})`
+    : `rgba(255, 77, 106, ${alpha.toFixed(2)})`;
+};
+
+export const SessionHeatmap = ({ grid }: SessionHeatmapProps) => {
+  const totalTrades = grid.reduce((s, row) => s + row.reduce((a, c) => a + c.trades, 0), 0);
+  const absMax = Math.max(
+    1,
+    ...grid.flatMap((row) => row.map((c) => Math.abs(c.pnl))),
+  );
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Hour × Day Heatmap <span className="font-normal normal-case tracking-normal text-[var(--text-muted)]">· P&L</span>
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">{totalTrades} trades</span>
+      </div>
+      <div className="flex-1 px-4 py-3 overflow-auto">
+        {totalTrades === 0 ? (
+          <div className="h-full flex items-center justify-center text-sm text-[var(--text-secondary)]">
+            No completed trades yet
+          </div>
+        ) : (
+          <div className="flex flex-col gap-[2px]">
+            <div className="flex gap-[2px] pl-[40px] text-[9px] text-[var(--text-muted)] font-mono">
+              {Array.from({ length: 24 }, (_, h) => (
+                <div key={h} className="flex-1 text-center">
+                  {h % 3 === 0 ? h : ""}
+                </div>
+              ))}
+            </div>
+            {grid.map((row, d) => (
+              <div key={d} className="flex gap-[2px] items-center">
+                <div className="w-[36px] text-[10px] text-[var(--text-secondary)] font-mono">
+                  {DAY_LABELS[d]}
+                </div>
+                {row.map((cell, h) => (
+                  <div
+                    key={h}
+                    className="flex-1 h-[16px] rounded-sm"
+                    style={{ backgroundColor: cellColor(cell, absMax) }}
+                    title={
+                      cell.trades === 0
+                        ? "No trades"
+                        : `${cell.trades} trades · ${cell.winRate}% win · ${cell.pnl >= 0 ? "+" : "-"}$${Math.abs(cell.pnl).toFixed(2)}`
+                    }
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Write `src/components/RollingMetricsChart.tsx`**
+
+Create with this exact content:
+
+```tsx
+import { useState, useEffect, useRef } from "react";
+import type { RollingMetric, RollingPoint } from "../hooks/useRollingMetrics";
+
+type RollingMetricsChartProps = {
+  sharpe: RollingPoint[];
+  winRate: RollingPoint[];
+  expectancy: RollingPoint[];
+};
+
+const PICKERS: { id: RollingMetric; label: string }[] = [
+  { id: "sharpe", label: "Sharpe" },
+  { id: "winRate", label: "Win %" },
+  { id: "expectancy", label: "Expectancy" },
+];
+
+export const RollingMetricsChart = ({ sharpe, winRate, expectancy }: RollingMetricsChartProps) => {
+  const [metric, setMetric] = useState<RollingMetric>("sharpe");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const series = metric === "sharpe" ? sharpe : metric === "winRate" ? winRate : expectancy;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+    const rect = container.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const w = rect.width;
+    const h = rect.height;
+    ctx.clearRect(0, 0, w, h);
+
+    if (series.length < 2) {
+      ctx.fillStyle = "rgba(136, 136, 160, 0.5)";
+      ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      const msg =
+        series.length === 0
+          ? "No rolling data yet"
+          : `Partial window · ${series[0].windowSize}/20 trades`;
+      ctx.fillText(msg, w / 2, h / 2);
+      return;
+    }
+
+    const values = series.map((p) => p.value);
+    const vMin = Math.min(0, ...values);
+    const vMax = Math.max(0, ...values);
+    const vRange = vMax - vMin || 1;
+    const pad = vRange * 0.1;
+    const toX = (i: number) => (i / Math.max(series.length - 1, 1)) * w;
+    const toY = (v: number) => h - ((v - vMin + pad) / (vRange + pad * 2)) * h;
+
+    // Zero line
+    const zeroY = toY(0);
+    ctx.strokeStyle = "rgba(136, 136, 160, 0.2)";
+    ctx.setLineDash([4, 4]);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, zeroY);
+    ctx.lineTo(w, zeroY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Line
+    const lastVal = values[values.length - 1];
+    ctx.strokeStyle = lastVal >= 0 ? "#00d68f" : "#ff4d6a";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    series.forEach((p, i) => {
+      const x = toX(i);
+      const y = toY(p.value);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // Last point dot
+    const lx = toX(series.length - 1);
+    const ly = toY(lastVal);
+    ctx.beginPath();
+    ctx.arc(lx, ly, 3, 0, Math.PI * 2);
+    ctx.fillStyle = lastVal >= 0 ? "#00d68f" : "#ff4d6a";
+    ctx.fill();
+  }, [series]);
+
+  const partialWindowNotice =
+    series.length > 0 && series[0].windowSize < 20
+      ? ` · partial ${series[0].windowSize}/20`
+      : "";
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Rolling Metrics
+          <span className="font-normal normal-case tracking-normal text-[var(--text-muted)]">
+            {" "}
+            · 20-trade window{partialWindowNotice}
+          </span>
+        </h2>
+        <div className="flex gap-1">
+          {PICKERS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setMetric(p.id)}
+              className={`text-[10px] px-2 py-1 rounded transition-colors ${
+                metric === p.id
+                  ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div ref={containerRef} className="flex-1 min-h-0 px-4 py-3">
+        <canvas ref={canvasRef} className="w-full h-full" />
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Write `src/components/AnalyticsTab.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { DistributionBucket, HeatCell } from "../lib/tradingView";
+import type { RollingMetrics } from "../hooks/useRollingMetrics";
+import { TradeDistribution } from "./TradeDistribution";
+import { SessionHeatmap } from "./SessionHeatmap";
+import { RollingMetricsChart } from "./RollingMetricsChart";
+
+type AnalyticsTabProps = {
+  distribution: DistributionBucket[];
+  heatmap: HeatCell[][];
+  rolling: RollingMetrics;
+  totalTrades: number;
+};
+
+export const AnalyticsTab = ({
+  distribution,
+  heatmap,
+  rolling,
+  totalTrades,
+}: AnalyticsTabProps) => {
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <TradeDistribution buckets={distribution} totalTrades={totalTrades} />
+      <div className="grid grid-cols-2 gap-3">
+        <SessionHeatmap grid={heatmap} />
+        <RollingMetricsChart
+          sharpe={rolling.sharpe}
+          winRate={rolling.winRate}
+          expectancy={rolling.expectancy}
+        />
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/TradeDistribution.tsx src/components/SessionHeatmap.tsx src/components/RollingMetricsChart.tsx src/components/AnalyticsTab.tsx
+git commit -m "feat(trading): add Analytics tab components (distribution, heatmap, rolling metrics)"
+```
+
+---
+
+### Task 9: Trades tab — `RoundtripsTable` + `TradeDetailPanel` + `TradesTab`
+
+**Files:**
+- Create: `src/components/RoundtripsTable.tsx`
+- Create: `src/components/TradeDetailPanel.tsx`
+- Create: `src/components/TradesTab.tsx`
+
+- [ ] **Step 1: Write `src/components/RoundtripsTable.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { Roundtrip } from "../lib/tradingView";
+import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
+
+type RoundtripsTableProps = {
+  roundtrips: Roundtrip[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+const formatHm = (ts: number): string => {
+  const d = new Date(ts);
+  return d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" });
+};
+
+export const RoundtripsTable = ({
+  roundtrips,
+  selectedId,
+  onSelect,
+}: RoundtripsTableProps) => {
+  const sorted = [...roundtrips].sort((a, b) => b.closeTimestamp - a.closeTimestamp);
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Roundtrips
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">{sorted.length}</span>
+      </div>
+      {sorted.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)] px-4 py-6">
+          No completed trades yet
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-[var(--bg-panel)] z-10">
+              <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+                <th className="text-left px-3 py-2 font-medium">Opened</th>
+                <th className="text-left px-3 py-2 font-medium">Closed</th>
+                <th className="text-left px-3 py-2 font-medium">Symbol</th>
+                <th className="text-left px-3 py-2 font-medium">Side</th>
+                <th className="text-right px-3 py-2 font-medium">Qty</th>
+                <th className="text-right px-3 py-2 font-medium">Dur</th>
+                <th className="text-right px-3 py-2 font-medium">R</th>
+                <th className="text-right px-3 py-2 font-medium">P&L</th>
+                <th className="text-left px-3 py-2 font-medium">Algo</th>
+                <th className="text-left px-3 py-2 font-medium">Account</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((r) => {
+                const isSelected = selectedId === r.id;
+                return (
+                  <tr
+                    key={r.id}
+                    onClick={() => onSelect(r.id)}
+                    className={`border-b border-[var(--border)] last:border-0 cursor-pointer transition-colors ${
+                      isSelected
+                        ? "bg-[var(--accent-blue)]/10 border-l-2 border-l-[var(--accent-blue)]"
+                        : "hover:bg-[var(--bg-secondary)]"
+                    }`}
+                  >
+                    <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">
+                      {formatHm(r.openTimestamp)}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">
+                      {formatHm(r.closeTimestamp)}
+                    </td>
+                    <td className="px-3 py-2 font-medium">{r.symbol}</td>
+                    <td
+                      className={`px-3 py-2 ${
+                        r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"
+                      }`}
+                    >
+                      {r.side}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums">{r.qty}</td>
+                    <td className="px-3 py-2 text-right text-[var(--text-secondary)] font-mono tabular-nums">
+                      {formatDuration(r.openTimestamp, r.closeTimestamp)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums">
+                      {r.rMultiple !== null ? r.rMultiple.toFixed(1) : "—"}
+                    </td>
+                    <td className={`px-3 py-2 text-right font-mono tabular-nums font-medium ${pnlColorClass(r.pnl)}`}>
+                      {formatPnl(r.pnl)}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] truncate max-w-[120px]">
+                      {r.algo || "—"}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">
+                      {r.isShadow ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
+                          shadow
+                        </span>
+                      ) : (
+                        r.account
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Write `src/components/TradeDetailPanel.tsx`**
+
+Create with this exact content:
+
+```tsx
+import { useEffect } from "react";
+import type { Roundtrip } from "../lib/tradingView";
+import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
+import { formatPrice } from "../hooks/useTradingSimulation";
+
+type TradeDetailPanelProps = {
+  roundtrip: Roundtrip | null;
+  onClose: () => void;
+};
+
+const formatFullTime = (ts: number): string => {
+  const d = new Date(ts);
+  return d.toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+};
+
+const CHART_W = 320;
+const CHART_H = 80;
+
+const samplePoints = (
+  samples: { t: number; pnl: number }[],
+  width: number,
+  height: number,
+): { zeroY: number; path: string } => {
+  if (samples.length < 2) return { zeroY: height / 2, path: "" };
+  const tMin = samples[0].t;
+  const tMax = samples[samples.length - 1].t;
+  const tRange = Math.max(tMax - tMin, 1);
+  const pnls = samples.map((s) => s.pnl);
+  const vMin = Math.min(0, ...pnls);
+  const vMax = Math.max(0, ...pnls);
+  const vRange = vMax - vMin || 1;
+  const pad = vRange * 0.1;
+  const toX = (t: number) => ((t - tMin) / tRange) * width;
+  const toY = (v: number) => height - ((v - vMin + pad) / (vRange + pad * 2)) * height;
+  const path = samples
+    .map((s, i) => `${i === 0 ? "M" : "L"}${toX(s.t).toFixed(1)},${toY(s.pnl).toFixed(1)}`)
+    .join(" ");
+  return { zeroY: toY(0), path };
+};
+
+export const TradeDetailPanel = ({ roundtrip, onClose }: TradeDetailPanelProps) => {
+  useEffect(() => {
+    if (!roundtrip) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [roundtrip, onClose]);
+
+  if (!roundtrip) {
+    return (
+      <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)]">
+        Click a roundtrip to see execution detail
+      </div>
+    );
+  }
+
+  const r = roundtrip;
+  const sideColor = r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
+  const { zeroY, path } = samplePoints(r.maeMfeSamples, CHART_W, CHART_H);
+  const strokeColor = r.pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <h2 className="text-sm font-semibold truncate">{r.symbol}</h2>
+            <span className={`text-xs font-medium ${sideColor}`}>{r.side}</span>
+            {r.isShadow && (
+              <span className="text-[9px] uppercase tracking-wider px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)] font-semibold">
+                Shadow
+              </span>
+            )}
+          </div>
+          <div className="text-[11px] text-[var(--text-secondary)] font-mono">
+            {formatFullTime(r.openTimestamp)} → {formatFullTime(r.closeTimestamp)} · {r.algo || "—"} ·{" "}
+            {r.account}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-lg leading-none"
+          title="Close (Esc)"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="overflow-auto p-3 flex flex-col gap-3">
+        <div className="grid grid-cols-3 gap-3">
+          <div className="bg-[var(--bg-elevated)] rounded-md p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-0.5">
+              P&L
+            </div>
+            <div className={`text-base font-semibold font-mono tabular-nums ${pnlColorClass(r.pnl)}`}>
+              {formatPnl(r.pnl)}
+            </div>
+          </div>
+          <div className="bg-[var(--bg-elevated)] rounded-md p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-0.5">
+              R
+            </div>
+            <div className="text-base font-semibold font-mono tabular-nums">
+              {r.rMultiple !== null ? r.rMultiple.toFixed(2) : "—"}
+            </div>
+          </div>
+          <div className="bg-[var(--bg-elevated)] rounded-md p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-0.5">
+              Dur
+            </div>
+            <div className="text-base font-semibold font-mono tabular-nums">
+              {formatDuration(r.openTimestamp, r.closeTimestamp)}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+            Execution
+          </div>
+          <div className="text-sm space-y-1 font-mono">
+            <div>
+              <span className={r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"}>
+                {r.side === "Long" ? "Buy" : "Sell"} {r.qty} @ {formatPrice(r.symbol, r.entryPrice)}
+              </span>{" "}
+              <span className="text-[var(--text-muted)]">· {formatFullTime(r.openTimestamp)}</span>
+            </div>
+            <div>
+              <span className={r.side === "Long" ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"}>
+                {r.side === "Long" ? "Sell" : "Buy"} {r.qty} @ {formatPrice(r.symbol, r.exitPrice)}
+              </span>{" "}
+              <span className="text-[var(--text-muted)]">· {formatFullTime(r.closeTimestamp)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+            Excursion
+          </div>
+          <div className="text-sm space-y-1 font-mono">
+            <div>
+              <span className="text-[var(--text-secondary)]">MAE:</span>{" "}
+              <span className="text-[var(--accent-red)]">
+                {r.mae >= 0 ? "$0.00" : formatPnl(r.mae)}
+              </span>
+            </div>
+            <div>
+              <span className="text-[var(--text-secondary)]">MFE:</span>{" "}
+              <span className="text-[var(--accent-green)]">
+                {r.mfe <= 0 ? "$0.00" : formatPnl(r.mfe)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+            Unrealized P&L over hold
+          </div>
+          {path ? (
+            <svg
+              viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+              preserveAspectRatio="none"
+              width="100%"
+              height={CHART_H}
+              className="bg-[var(--bg-elevated)] rounded"
+            >
+              <line
+                x1={0}
+                y1={zeroY}
+                x2={CHART_W}
+                y2={zeroY}
+                stroke="rgba(136,136,160,0.3)"
+                strokeWidth={1}
+                strokeDasharray="4 4"
+              />
+              <path d={path} fill="none" stroke={strokeColor} strokeWidth={1.5} />
+            </svg>
+          ) : (
+            <div className="text-[var(--text-muted)] text-xs">Not enough samples</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Write `src/components/TradesTab.tsx`**
+
+Create with this exact content:
+
+```tsx
+import type { Roundtrip } from "../lib/tradingView";
+import { RoundtripsTable } from "./RoundtripsTable";
+import { TradeDetailPanel } from "./TradeDetailPanel";
+
+type TradesTabProps = {
+  roundtrips: Roundtrip[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+};
+
+export const TradesTab = ({ roundtrips, selectedId, onSelect }: TradesTabProps) => {
+  const selected = selectedId ? roundtrips.find((r) => r.id === selectedId) ?? null : null;
+
+  return (
+    <div className="flex gap-3 p-3 h-full min-h-0">
+      <div className={`flex-1 min-h-0 ${selected ? "basis-3/5" : ""}`}>
+        <RoundtripsTable
+          roundtrips={roundtrips}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      </div>
+      {selected && (
+        <div className="basis-2/5 min-h-0">
+          <TradeDetailPanel roundtrip={selected} onClose={() => onSelect(null)} />
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/RoundtripsTable.tsx src/components/TradeDetailPanel.tsx src/components/TradesTab.tsx
+git commit -m "feat(trading): add Trades tab components (roundtrips table, drill-down panel)"
+```
+
+---
+
+### Task 10: Coordinated rewire — rewrite `TradingView.tsx` + wire new hooks in `App.tsx`
+
+**Files:**
+- Rewrite: `src/views/TradingView.tsx` (delete existing contents, replace)
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Rewrite `src/views/TradingView.tsx`**
+
+Replace the entire file with this exact content:
+
+```tsx
+import { useState, useEffect, useMemo } from "react";
+import type { Algo, AlgoRun, NavContext, View, NavOptions } from "../types";
+import type {
+  TradingSimulation,
+  DataSource,
+  Position,
+} from "../hooks/useTradingSimulation";
+import type { TradeHistory } from "../hooks/useTradeHistory";
+import type { EquityTimeline } from "../hooks/useEquityTimeline";
+import type { RollingMetrics } from "../hooks/useRollingMetrics";
+import {
+  type Filters,
+  type Roundtrip,
+  type DrawdownPoint,
+  EMPTY_FILTERS,
+  applyFilters,
+  aggregateByKey,
+  pairLiveShadow,
+  buildDistribution,
+  buildHeatmap,
+  deriveHeroKpis,
+} from "../lib/tradingView";
+import { TradingFilterBar } from "../components/TradingFilterBar";
+import { TradingHero } from "../components/TradingHero";
+import { TradingTabs, type TradingTab } from "../components/TradingTabs";
+import { LiveTab } from "../components/LiveTab";
+import { PerformanceTab } from "../components/PerformanceTab";
+import { AnalyticsTab } from "../components/AnalyticsTab";
+import { TradesTab } from "../components/TradesTab";
+
+type AccountSummary = {
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+type TradingViewProps = {
+  simulation: TradingSimulation;
+  tradeHistory: TradeHistory;
+  equity: EquityTimeline;
+  rolling: RollingMetrics;
+  algos: Algo[];
+  activeRuns: AlgoRun[];
+  dataSources: DataSource[];
+  accounts: Record<string, AccountSummary>;
+  initialContext?: NavContext | null;
+  onContextConsumed?: () => void;
+  onNavigate: (view: View, options?: NavOptions) => void;
+};
+
+// Build a drawdown series from the currently-filtered roundtrips (used when a filter
+// is active; the hook's `equity.liveDrawdown` follows nt-account realized P&L across
+// all accounts and can't be narrowed after the fact).
+const drawdownFromRoundtrips = (trips: Roundtrip[]): DrawdownPoint[] => {
+  const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+  let peak = 0;
+  let cum = 0;
+  const out: DrawdownPoint[] = [];
+  for (const r of sorted) {
+    cum += r.pnl;
+    if (cum > peak) peak = cum;
+    out.push({ t: r.closeTimestamp, peak, pnl: cum, underwater: peak - cum });
+  }
+  return out;
+};
+
+// Position cards need "open since" timestamps — we track them here (not in the hook)
+// because the hook only keeps MAE/MFE samples, not the open time as a separate datum
+// that's available synchronously at render. We rebuild the map from the current positions.
+const useOpenSinceMap = (positions: Position[]): Map<string, number> => {
+  const [map] = useState(() => new Map<string, number>());
+  useEffect(() => {
+    const seen = new Set<string>();
+    const now = Date.now();
+    for (const p of positions) {
+      const key = `${p.dataSourceId}:${p.symbol}:${p.account}`;
+      seen.add(key);
+      if (!map.has(key)) map.set(key, now);
+    }
+    for (const key of Array.from(map.keys())) {
+      if (!seen.has(key)) map.delete(key);
+    }
+  }, [positions, map]);
+  return map;
+};
+
+export const TradingView = ({
+  simulation,
+  tradeHistory,
+  equity,
+  rolling,
+  algos,
+  activeRuns,
+  dataSources,
+  accounts,
+  initialContext,
+  onContextConsumed,
+  onNavigate,
+}: TradingViewProps) => {
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [activeTab, setActiveTab] = useState<TradingTab>("live");
+  const [selectedRoundtripId, setSelectedRoundtripId] = useState<string | null>(null);
+
+  // Honor inbound nav context (from Algos view etc.)
+  useEffect(() => {
+    if (!initialContext || initialContext.targetView !== "trading") return;
+
+    const next: Partial<Filters> = {};
+    if (initialContext.accountFilter !== undefined) next.account = initialContext.accountFilter;
+    if (initialContext.algoFilter !== undefined) next.algo = initialContext.algoFilter;
+    if (Object.keys(next).length > 0) {
+      setFilters((f) => ({ ...f, ...next }));
+    }
+
+    if (initialContext.scrollTo) {
+      const target = initialContext.scrollTo;
+      if (target === "positions") setActiveTab("live");
+      else if (target === "orders") setActiveTab("live");
+      else if (target === "history") setActiveTab("trades");
+      // "stats" stays on whatever tab we're on — hero is always visible.
+    }
+
+    onContextConsumed?.();
+  }, [initialContext, onContextConsumed]);
+
+  const filteredPositions = useMemo(
+    () => applyFilters(simulation.positions, filters),
+    [simulation.positions, filters],
+  );
+  const filteredOrders = useMemo(
+    () => applyFilters(simulation.orders, filters),
+    [simulation.orders, filters],
+  );
+  const filteredRoundtrips = useMemo(
+    () => applyFilters(tradeHistory.roundtrips, filters),
+    [tradeHistory.roundtrips, filters],
+  );
+  const isFilterOn =
+    filters.chart !== null || filters.account !== null || filters.algo !== null;
+
+  const filteredByAlgo = useMemo(
+    () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "algo") : tradeHistory.byAlgo),
+    [tradeHistory.byAlgo, filteredRoundtrips, isFilterOn],
+  );
+  const filteredBySymbol = useMemo(
+    () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "symbol") : tradeHistory.bySymbol),
+    [tradeHistory.bySymbol, filteredRoundtrips, isFilterOn],
+  );
+  const filteredByAccount = useMemo(
+    () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "account") : tradeHistory.byAccount),
+    [tradeHistory.byAccount, filteredRoundtrips, isFilterOn],
+  );
+  const filteredLiveVsShadow = useMemo(
+    () => (isFilterOn ? pairLiveShadow(filteredRoundtrips) : tradeHistory.liveVsShadow),
+    [tradeHistory.liveVsShadow, filteredRoundtrips, isFilterOn],
+  );
+  const filteredDistribution = useMemo(
+    () => (isFilterOn ? buildDistribution(filteredRoundtrips) : tradeHistory.distribution),
+    [tradeHistory.distribution, filteredRoundtrips, isFilterOn],
+  );
+  const filteredHeatmap = useMemo(
+    () => (isFilterOn ? buildHeatmap(filteredRoundtrips) : tradeHistory.heatmap),
+    [tradeHistory.heatmap, filteredRoundtrips, isFilterOn],
+  );
+
+  // Drawdown follows the filtered roundtrips when a filter is set; otherwise use the
+  // hook's raw live drawdown series (which tracks the nt-account realized P&L).
+  const filteredDrawdown = useMemo(
+    () => (isFilterOn ? drawdownFromRoundtrips(filteredRoundtrips) : equity.liveDrawdown),
+    [equity.liveDrawdown, filteredRoundtrips, isFilterOn],
+  );
+
+  const heroKpis = useMemo(
+    () => deriveHeroKpis(filteredRoundtrips, filteredPositions, filteredDrawdown),
+    [filteredRoundtrips, filteredPositions, filteredDrawdown],
+  );
+
+  const openSinceByPosKey = useOpenSinceMap(simulation.positions);
+
+  const hasCharts = dataSources.length > 0;
+
+  return (
+    <div className="flex-1 flex flex-col gap-3 p-4 overflow-hidden min-h-0">
+      <TradingFilterBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        algos={algos}
+        activeRuns={activeRuns}
+        dataSources={dataSources}
+        positions={simulation.positions}
+        orders={simulation.orders}
+        roundtrips={tradeHistory.roundtrips}
+      />
+
+      <TradingHero
+        kpis={heroKpis}
+        equityLive={equity.live}
+        equityShadow={equity.shadow}
+        drawdown={filteredDrawdown}
+      />
+
+      <TradingTabs activeTab={activeTab} onChange={setActiveTab} />
+
+      {!hasCharts ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)] rounded-lg">
+          Connect a NinjaTrader chart to see trading activity
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto min-h-0">
+          {activeTab === "live" && (
+            <LiveTab
+              positions={filteredPositions}
+              orders={filteredOrders}
+              accounts={accounts}
+              openSinceByPosKey={openSinceByPosKey}
+            />
+          )}
+          {activeTab === "performance" && (
+            <PerformanceTab
+              byAlgo={filteredByAlgo}
+              bySymbol={filteredBySymbol}
+              byAccount={filteredByAccount}
+              liveVsShadow={filteredLiveVsShadow}
+              onOpenAlgoInEditor={(algoId) => onNavigate("editor", { algoFilter: algoId })}
+              onViewAccountInAlgos={(account) => onNavigate("algos", { accountFilter: account })}
+            />
+          )}
+          {activeTab === "analytics" && (
+            <AnalyticsTab
+              distribution={filteredDistribution}
+              heatmap={filteredHeatmap}
+              rolling={rolling}
+              totalTrades={filteredRoundtrips.length}
+            />
+          )}
+          {activeTab === "trades" && (
+            <TradesTab
+              roundtrips={filteredRoundtrips}
+              selectedId={selectedRoundtripId}
+              onSelect={setSelectedRoundtripId}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+```
+
+- [ ] **Step 2: Update `src/App.tsx`**
+
+Open `src/App.tsx`. Perform the following edits in order:
+
+**Edit 1: Add imports** — add these import lines after the existing `useTradingSimulation` import (around line 15):
+
+```tsx
+import { useTradeHistory } from "./hooks/useTradeHistory";
+import { useEquityTimeline } from "./hooks/useEquityTimeline";
+import { useRollingMetrics } from "./hooks/useRollingMetrics";
+```
+
+**Edit 2: Compose the new hooks** — just after the line `const simulation = useTradingSimulation(algos, activeRuns, dataSources);` (around line 52 today), add:
+
+```tsx
+const tradeHistory = useTradeHistory(algos, activeRuns);
+const equity = useEquityTimeline(tradeHistory.roundtrips);
+const rolling = useRollingMetrics(tradeHistory.roundtrips);
+```
+
+**Edit 3: Pass the new props to `TradingView`** — replace the current `{activeView === "trading" && (...)}` block with:
+
+```tsx
+{activeView === "trading" && (
+  <TradingView
+    simulation={simulation}
+    tradeHistory={tradeHistory}
+    equity={equity}
+    rolling={rolling}
+    algos={algos}
+    activeRuns={activeRuns}
+    dataSources={dataSources}
+    accounts={accounts}
+    initialContext={pendingNavContext}
+    onContextConsumed={clearPendingNavContext}
+    onNavigate={handleNavigate}
+  />
+)}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors. If TypeScript reports errors about the removed props on `TradingView` (e.g. `algos`, `activeRuns`), re-check Edit 3 above — the new prop shape should match.
+
+- [ ] **Step 4: Smoke — launch the dev app and walk through the view**
+
+Run: `npm run dev`
+In the app, navigate to the Trading view. Verify:
+
+- **No charts connected:** "Connect a NinjaTrader chart…" message shows below the hero.
+- **Connect a chart, start a live algo:** filter bar appears with Chart / Account / Algo chips. Hero KPIs show zeros initially. Equity chart is a flat zero line.
+- **First position opens:** Live tab — position card appears with Live pill, `held Xs` counts up; order tape shows the entry order. Hero's Unrealized updates.
+- **Position closes:** a roundtrip appears in the Trades tab. Performance tab: By Algo / By Symbol / By Account each gain a row. Analytics tab: distribution histogram gains a bar; heatmap cell gains color; rolling-metrics chart appears (starting with a "partial window" notice).
+- **Start a shadow algo:** second position card with Shadow pill; equity chart gains a dashed yellow series.
+- **Click a roundtrip row:** detail panel opens to the right (60/40 split). Shows execution, MAE/MFE, and the per-tick unrealized P&L SVG. Press Esc or click × to close.
+- **Filter bar:** click a Chart chip — every tab narrows; clearing returns to aggregate.
+- **Deep-link out:** on the Performance tab, click the `→` on an algo row. The app navigates to the Editor with that algo in view.
+- **Deep-link in:** on the Algos view, click "View trades" (or the existing Trading deep-link in Algos view detail panel). The Trading view opens with the account filter applied and scrolls/activates the Live tab.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/TradingView.tsx src/App.tsx
+git commit -m "feat(trading): unified dashboard — hero, filters, tabs, detail drill-down"
+```
+
+---
+
+### Task 11: Final smoke walk-through and polish
+
+**Files:**
+- Modify only if issues surface during smoke.
+
+- [ ] **Step 1: Type-check + build**
+
+Run: `npm run build`
+Expected: zero TypeScript errors, Vite bundle succeeds.
+
+- [ ] **Step 2: Smoke — full walk-through**
+
+Launch `npm run dev`. With NinjaTrader running and at least one chart connected, walk through every user flow from the spec. Focus areas:
+
+- **Pinned hero always visible.** Scroll within any tab — hero + filter bar + tab bar should not scroll off.
+- **Filter bar union.** After several algos have started + stopped, the Algo filter should include stopped algos that still have roundtrips in history (not only currently-running ones). Chart and Account filters similarly.
+- **Live + Shadow on equity chart.** Run the same algo live and shadow simultaneously. Equity chart shows a solid line (live) and a dashed yellow line (shadow). Legend labels match.
+- **Drawdown overlay.** Go briefly into drawdown (a losing trade). The underwater band appears beneath the live line in muted red and the hero's "Max DD" updates.
+- **Performance tab filter consistency.** Apply the Algo filter to a specific algo — all three breakdown tables narrow to that algo's rows. The Live-vs-Shadow panel narrows accordingly.
+- **Analytics tab.** With 20+ completed trades, verify Sharpe / Win% / Expectancy toggle in the rolling chart; switching does not reset filters. Heatmap highlights the hours/days where you traded most.
+- **Trades tab drill-down.** Click several roundtrips in succession — detail panel updates in place. Scroll the roundtrips table while a detail is open; panel stays put.
+- **Empty-state copy is correct** per the spec's empty-state table.
+- **Nav in/out:**
+  - From Algos view, `onNavigate("trading", { accountFilter: "<account>" })` lands with filter applied.
+  - From Trading's Performance tab, clicking `→` on an algo row opens the Editor with that algo.
+  - From Trading's Performance tab, clicking `→` on an account row opens the Algos view filtered to that account.
+- **No regressions in Home / Editor / Algos views.** Visit each briefly — their data comes from `useTradingSimulation` which is unchanged.
+
+- [ ] **Step 3: Visual polish pass**
+
+Open each tab and check for:
+- Table row padding consistent across Performance tab's three breakdown tables.
+- Card / panel gaps uniform at 12px (`gap-3`).
+- Pill casing consistent (Live / Shadow / filled / cancelled / working).
+- Equity chart legend not overflowing on narrow viewports.
+- Position card "held Xm" counter doesn't flicker (it only updates on React re-renders, not per-frame — this is intentional; verify it updates when a new `nt-position` event arrives).
+
+If anything looks off, fix inline in the relevant component file. Type-check after each fix.
+
+- [ ] **Step 4: Commit any polish fixes**
+
+Only if Step 3 surfaced changes:
+
+```bash
+git add -u
+git commit -m "style(trading): post-smoke polish"
+```
+
+- [ ] **Step 5: Push branch and open PR**
+
+Run:
+
+```bash
+git push -u origin feat/trading-view-redesign
+```
+
+Then open a pull request targeting `main` with:
+
+**Title:** `feat: trading view redesign — unified dashboard (hero + filters + tabs + drill-down)`
+
+**Body** (use the following template, adapting as needed):
+
+```markdown
+## Summary
+Rebuilds the Trading view as a unified dashboard per `docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md`:
+
+- Pinned hero (7 KPIs + equity curve with drawdown overlay)
+- Global Chart / Account / Algo filter bar
+- Four tabs: Live, Performance, Analytics, Trades
+- Right-side drill-down panel for per-roundtrip execution + MAE/MFE
+
+Adds three sibling hooks (`useTradeHistory`, `useEquityTimeline`, `useRollingMetrics`) alongside the existing `useTradingSimulation` (unchanged). No backend / Tauri / event-payload changes.
+
+## Test plan
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm run build` succeeds
+- [ ] Smoke per `docs/superpowers/plans/2026-04-19-trading-view-redesign.md` Task 11 Step 2
+- [ ] Home / Editor / Algos views unchanged visually and functionally
+```
+
+---
+
+## Spec coverage check
+
+| Spec section | Task(s) |
+|---|---|
+| Pure helpers (`tradingView.ts`, `roundtrips.ts`) | Task 1 |
+| `useTradeHistory` hook (roundtrip pairing, aggregates) | Task 2 |
+| `useEquityTimeline` hook | Task 3 |
+| `useRollingMetrics` hook | Task 4 |
+| Pinned hero (KPIs + equity + drawdown overlay) | Tasks 5, 10 |
+| Global Chart/Account/Algo filter bar | Tasks 5, 10 |
+| Tabs (Live / Performance / Analytics / Trades) | Tasks 5, 10 |
+| Live tab (position cards, risk summary, order tape) | Task 6 |
+| Performance tab (by-algo/symbol/account, live-vs-shadow) | Task 7 |
+| Analytics tab (distribution, heatmap, rolling metrics) | Task 8 |
+| Trades tab + drill-down panel (MAE/MFE chart) | Task 9 |
+| `App.tsx` wiring | Task 10 |
+| Shadow data inline (pills, dashed equity series) | Tasks 5, 6, 7, 8, 9 |
+| No mode toggle | Task 10 (filter set has no mode key) |
+| Deep-link contract (algo → editor, account → algos) | Task 7 + Task 10 (`onNavigate` wiring) |
+| Empty states for: no charts / no runs / filter excludes all / no trade selected | Task 10 (view) + Tasks 6–9 (per tab) |
+| In-memory only (no persistence across restarts) | Task 10 (local `useState` only) |
+| No backend / Rust / Tauri / event-schema changes | All tasks |
+| Smoke verification | Task 10 Step 4, Task 11 Step 2 |
+
+All spec requirements map to at least one task.

--- a/docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md
@@ -8,7 +8,7 @@
 
 Replace today's single-surface TradingView (mode toggle + chart/account/algo filters, P&L hero, one equity chart, positions table, orders table) with a unified dashboard designed to serve both the "live monitor" and "performance analytics" mental models without a mode switch. A pinned hero (KPIs + equity curve with drawdown overlay) and a global Chart/Account/Algo filter bar remain visible at all times. Four tabs below group the rest: **Live** (open position cards, risk/exposure summary, order tape), **Performance** (per-algo, per-symbol, per-account breakdowns, live-vs-shadow delta), **Analytics** (trade P&L distribution, hour×day heatmap, rolling metrics), and **Trades** (roundtrips table with a right-side drill-down panel showing execution and MAE/MFE). The live/shadow mode toggle is removed; shadow data renders inline tagged with a `Shadow` pill, and the dedicated live-vs-shadow delta module in Performance makes the comparison direct.
 
-The work extends the simulation layer: the existing `useTradingSimulation` shrinks to live positions + orders, and new sibling hooks (`useTradeHistory`, `useEquityTimeline`, `useRollingMetrics`) own roundtrip pairing, timestamped equity series, and windowed metrics. MAE/MFE are derived by sampling `position.unrealized_pnl` while a position is open. All data flows from events today's hook already listens to — no backend, Rust, or Tauri-command changes.
+The work extends the simulation layer additively. `useTradingSimulation` keeps its existing outputs intact (`HomeView` and `AlgosView` depend on them). Three new sibling hooks sit alongside it: `useTradeHistory` (roundtrip pairing + per-{algo,symbol,account} aggregates + distribution + heatmap buckets), `useEquityTimeline` (timestamped equity + drawdown derivation), and `useRollingMetrics` (windowed Sharpe / win% / expectancy). Only `TradingView` consumes the new hooks. MAE/MFE are derived by sampling `position.unrealized_pnl` while a position is open. All data flows from events today's hook already listens to — no backend, Rust, or Tauri-command changes.
 
 ## Goals
 
@@ -38,8 +38,7 @@ The work extends the simulation layer: the existing `useTradingSimulation` shrin
 
 - Rewrite of `src/views/TradingView.tsx` into an orchestrator (filter bar + hero + tabs + detail panel).
 - New view-layer components (listed below under Architecture).
-- Hook restructuring:
-  - `src/hooks/useTradingSimulation.ts` reduces to live positions + orders + account + live session equity (current behavior minus completed-trade and shadow-history concerns).
+- Hook additions (additive only — `useTradingSimulation` output contract is unchanged):
   - `src/hooks/useTradeHistory.ts` — new, owns roundtrip pairing and aggregate breakdowns.
   - `src/hooks/useEquityTimeline.ts` — new, owns timestamped equity series and drawdown derivation.
   - `src/hooks/useRollingMetrics.ts` — new, owns windowed metric series.
@@ -65,7 +64,7 @@ The work extends the simulation layer: the existing `useTradingSimulation` shrin
 ```
 src/
   hooks/
-    useTradingSimulation.ts     [reduce]  — positions + orders + live account state
+    useTradingSimulation.ts     [unchanged] — HomeView / AlgosView continue to consume it as-is
     useTradeHistory.ts          [new]     — roundtrips + per-{algo,symbol,account} aggregates + distribution + heatmap buckets
     useEquityTimeline.ts        [new]     — timestamped equity (live + shadow) + drawdown series
     useRollingMetrics.ts        [new]     — windowed Sharpe / win% / expectancy
@@ -101,16 +100,18 @@ src/
 
 | Hook | Subscribes to | Owns | Emits |
 |---|---|---|---|
-| `useTradingSimulation` | `nt-position`, `nt-order-update`, `nt-account`, `nt-chart-removed` | Live positions, orders (last 200), live-session equity (points only, retained for backwards compatibility during the transition), accounts | `positions`, `orders`, `accounts`, `liveStats` |
+| `useTradingSimulation` | unchanged | Live positions, orders, untimestamped `pnlHistory` / `runPnlHistories`, `algoStats`, `stats`, `shadowStats` — as today | unchanged — consumed by HomeView / AlgosView as-is, and by TradingView for live positions / orders / accounts |
 | `useTradeHistory` | `nt-position` (for pairing + unrealized-P&L sampling), `nt-order-update` (for fill prices / times), `nt-chart-removed` | `Roundtrip[]` (cap 1000), per-algo/symbol/account aggregates, distribution buckets, hour×day buckets | `roundtrips`, `byAlgo`, `bySymbol`, `byAccount`, `liveVsShadow`, `distribution`, `heatmap` |
 | `useEquityTimeline` | `nt-account`, roundtrip closes from `useTradeHistory` | Timestamped equity per series (`live`, `shadow`), running peak + underwater series | `{ live: EquityPoint[], shadow: EquityPoint[], drawdown: DrawdownPoint[] }` |
 | `useRollingMetrics` | `roundtrips` (from `useTradeHistory`) | Windowed derivation (default window = 20 trades) | `{ sharpe: number[], winRate: number[], expectancy: number[] }` + the roundtrip-close timestamps for x-axis labelling |
 
-`useTradeHistory` sources `algo` and `instanceId` by joining `algoId` / `instance_id` against the `algos` and `activeRuns` the view receives — same join the existing hook performs inside `computeStats` today.
+Both `useTradingSimulation` and `useTradeHistory` subscribe to the same `nt-position` / `nt-order-update` event stream; they maintain independent state, which is fine — React event listeners are cheap, and keeping state independent preserves the hook's focused responsibility.
+
+`useTradeHistory` sources `algo` and `instanceId` by joining `algoId` / `instance_id` against the `algos` and `activeRuns` the view receives — the same join `useTradingSimulation` performs inside `computeStats` today.
 
 ### Raw data → enriched roundtrip
 
-`useTradingSimulation` today already tracks an unrealized-P&L per `posKey` via `positionPnlRef` and records a `{ pnl }` entry into `completedTrades` on position flat. The new `useTradeHistory` subsumes and extends this:
+`useTradingSimulation` today tracks per-position unrealized P&L via `positionPnlRef` and records a `{ pnl }` entry into its internal `completedTrades` on position flat. `useTradeHistory` runs the same pattern independently with a richer record — the two do not share state:
 
 - On the first `nt-position` for a `posKey` with a non-zero qty, record `openTimestamp` (now), `entryPrice` (`p.avg_price`), `side`, `qty`, `symbol`, `account`, `dataSourceId`, and the matching algo/instance from `activeRuns`.
 - While the position is open, maintain `mae` (most-negative unrealized P&L seen) and `mfe` (most-positive). Sample via a ~250ms RAF tick bound to the position being open; reset on flat.
@@ -279,7 +280,7 @@ Pure helpers in `src/lib/tradingView.ts` and `src/lib/roundtrips.ts` are designe
 
 ## Implementation notes
 
-- `App.tsx` composes the new hooks the same way it composes the existing ones. The hook outputs fan out as props into `TradingView`.
+- `App.tsx` composes the new hooks the same way it composes the existing ones and fans their outputs into `TradingView` as new props. The existing `simulation` prop to `TradingView`, `HomeView`, and `AlgosView` is unchanged.
 - Reuse `useEquityTimeline` in the hero's `EquityChart` — the drawdown overlay reads from the same series; no secondary computation in the chart component.
 - `useTradeHistory` and `useTradingSimulation` must not race: the roundtrip-close-triggered equity update and the `nt-account` realized-P&L update can arrive in either order. `useEquityTimeline` resolves by keying on timestamp and using the most-recent account snapshot when one arrives.
 - MAE/MFE sampling uses a single shared `requestAnimationFrame` loop inside `useTradeHistory`, throttled by a ~250ms accumulator — only one RAF is alive regardless of how many positions are open.
@@ -295,7 +296,8 @@ Pure helpers in `src/lib/tradingView.ts` and `src/lib/roundtrips.ts` are designe
 - **Shadow slippage estimate.** `liveAvg − shadowAvg` is crude; anything more requires paired trade IDs the bridge does not expose. Ship the crude estimate and label it clearly ("est.").
 - **Rolling metrics window with sparse trades.** Early in a session the window is smaller than the target size. Show partial-window values with an indicator ("n/20 trades") rather than hiding.
 - **Drawdown overlay visual clarity.** Overlaid on the same axis as equity, the DD band can muddy the line at small scales. Implementation plan to validate this during layout and add a subtle separator / secondary axis if needed.
-- **`useTradingSimulation` reduction may affect HomeView / AlgosView.** Both consume the hook today. The reduction keeps all fields currently consumed by those views; anything removed from the hook must be verified against their usages before the PR lands.
+- **`useTradingSimulation` output contract is unchanged, by choice.** HomeView and AlgosView consume its `pnlHistory` / `runPnlHistories` / `algoStats` / `stats` today. Keeping the hook's outputs stable avoids cascading changes into those views. The tradeoff is two hooks subscribing to the same `nt-position` / `nt-order-update` streams (each maintaining independent state) — acceptable. A future cleanup pass can consolidate once `useEquityTimeline` is the preferred equity source across all views.
+- **Duplicated event subscriptions.** `useTradingSimulation` and `useTradeHistory` both listen to `nt-position` / `nt-order-update`. Both must remain internally consistent with each other — e.g. when a position flips flat, both hooks should reach the same conclusion about the trade's final P&L. The risk is isolated to bugs in either hook; the event stream is the same.
 
 ## References
 

--- a/docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md
@@ -1,0 +1,305 @@
+# Trading View Redesign — Design
+
+**Date:** 2026-04-19
+**Direction:** Unified dashboard — pinned hero + filter bar, four scrollable tabs (Live / Performance / Analytics / Trades), drill-down panel for per-trade detail
+**Brainstorm artifacts:** `.superpowers/brainstorm/` (wireframes generated during brainstorming; not committed)
+
+## Summary
+
+Replace today's single-surface TradingView (mode toggle + chart/account/algo filters, P&L hero, one equity chart, positions table, orders table) with a unified dashboard designed to serve both the "live monitor" and "performance analytics" mental models without a mode switch. A pinned hero (KPIs + equity curve with drawdown overlay) and a global Chart/Account/Algo filter bar remain visible at all times. Four tabs below group the rest: **Live** (open position cards, risk/exposure summary, order tape), **Performance** (per-algo, per-symbol, per-account breakdowns, live-vs-shadow delta), **Analytics** (trade P&L distribution, hour×day heatmap, rolling metrics), and **Trades** (roundtrips table with a right-side drill-down panel showing execution and MAE/MFE). The live/shadow mode toggle is removed; shadow data renders inline tagged with a `Shadow` pill, and the dedicated live-vs-shadow delta module in Performance makes the comparison direct.
+
+The work extends the simulation layer: the existing `useTradingSimulation` shrinks to live positions + orders, and new sibling hooks (`useTradeHistory`, `useEquityTimeline`, `useRollingMetrics`) own roundtrip pairing, timestamped equity series, and windowed metrics. MAE/MFE are derived by sampling `position.unrealized_pnl` while a position is open. All data flows from events today's hook already listens to — no backend, Rust, or Tauri-command changes.
+
+## Goals
+
+- One surface, two jobs — live monitoring and performance analytics coexist without a mode switch.
+- Pinned hero — KPIs + equity + drawdown are always visible while the rest scrolls or switches tabs.
+- Depth per module — each of 13 modules renders real per-trade data (not derived from a `{pnl}`-only stub).
+- Drill-through — click any roundtrip for execution and excursion detail without leaving the tab.
+- Consistent filters — Chart / Account / Algo apply globally; every panel agrees.
+- Incremental composition — new sibling hooks follow the `useAlgoErrors` / `useAlgoLogs` / `useAlgoHealth` pattern; no new cross-cutting abstractions.
+- Surgical refactor — no backend / Rust / Tauri-command / event-schema changes; PRable as one unit.
+
+## Non-Goals
+
+- Instrument price chart with execution overlay (module N from brainstorm) — deferred.
+- Journal / annotations (module O) — deferred.
+- Persisting tab, filters, or window selections across app restarts — in-memory only, matching Algos view precedent.
+- Keyboard shortcuts / command palette — deferred to an app-wide project.
+- Multi-select or bulk row actions — deferred.
+- Mobile / narrow-viewport responsiveness — Tauri desktop app, assume ≥1100px width.
+- Changes to `NavOptions` or cross-view navigation contract — reuse `onNavigate` as-is.
+- Changes to the NinjaTrader bridge, Rust side, Tauri commands, or event payload shapes.
+- Historical import of completed trades on app start — the new hooks build history from events received this session. Hot-reload during development is the only scenario that loses history; a cold start has none either way.
+
+## Scope
+
+### In scope
+
+- Rewrite of `src/views/TradingView.tsx` into an orchestrator (filter bar + hero + tabs + detail panel).
+- New view-layer components (listed below under Architecture).
+- Hook restructuring:
+  - `src/hooks/useTradingSimulation.ts` reduces to live positions + orders + account + live session equity (current behavior minus completed-trade and shadow-history concerns).
+  - `src/hooks/useTradeHistory.ts` — new, owns roundtrip pairing and aggregate breakdowns.
+  - `src/hooks/useEquityTimeline.ts` — new, owns timestamped equity series and drawdown derivation.
+  - `src/hooks/useRollingMetrics.ts` — new, owns windowed metric series.
+- New pure helpers:
+  - `src/lib/tradingView.ts` — filter/aggregate/bucketing helpers.
+  - `src/lib/roundtrips.ts` — fill-to-roundtrip pairing and MAE/MFE derivation.
+- Replacement of the inline `PnlChart` canvas inside `TradingView.tsx` with an extracted `EquityChart` component that also draws the drawdown overlay.
+- Deletion of the mode-toggle state, `tradingMode`, and all branches keyed on it.
+- `App.tsx` wiring: compose the new hooks and hand their outputs into `TradingView` alongside the existing simulation surface.
+
+### Out of scope
+
+- Other views (Home, Editor, Algos, Guide) — untouched.
+- `AiTerminalPanel`, `LogPanel`, `Sidebar`, `TitleBar` — untouched.
+- `useAlgoErrors`, `useAlgoLogs`, `useAlgoHealth` — untouched.
+- NinjaTrader bridge / Rust / Tauri commands — untouched.
+- Event payload contracts (`nt-position`, `nt-order-update`, `nt-account`, `nt-chart`, `nt-chart-removed`) — untouched.
+
+## Architecture
+
+### File layout
+
+```
+src/
+  hooks/
+    useTradingSimulation.ts     [reduce]  — positions + orders + live account state
+    useTradeHistory.ts          [new]     — roundtrips + per-{algo,symbol,account} aggregates + distribution + heatmap buckets
+    useEquityTimeline.ts        [new]     — timestamped equity (live + shadow) + drawdown series
+    useRollingMetrics.ts        [new]     — windowed Sharpe / win% / expectancy
+  lib/
+    tradingView.ts              [new]     — filter/aggregate helpers
+    roundtrips.ts               [new]     — fill pairing + MAE/MFE derivation
+  components/
+    TradingFilterBar.tsx        [new]
+    TradingHero.tsx             [new]     — KPIs + EquityChart
+    TradingTabs.tsx             [new]     — tab bar
+    EquityChart.tsx             [new]     — replaces inline PnlChart; adds DD overlay
+    LiveTab.tsx                 [new]
+    RiskSummary.tsx             [new]
+    PositionCard.tsx            [new]
+    OrderTape.tsx               [new]
+    PerformanceTab.tsx          [new]
+    BreakdownTable.tsx          [new]     — shared for by-algo / by-symbol / by-account
+    LiveShadowDelta.tsx         [new]
+    AnalyticsTab.tsx            [new]
+    TradeDistribution.tsx       [new]
+    SessionHeatmap.tsx          [new]
+    RollingMetricsChart.tsx     [new]
+    TradesTab.tsx               [new]
+    RoundtripsTable.tsx         [new]
+    TradeDetailPanel.tsx        [new]     — right-side drill-down
+  views/
+    TradingView.tsx             [rewrite] — orchestrator + local UI state
+```
+
+`App.tsx` composes the new hooks alongside `useTradingSimulation` and passes their outputs into `TradingView`. The view's props expand but remain explicit (no shared context).
+
+### Hook responsibilities
+
+| Hook | Subscribes to | Owns | Emits |
+|---|---|---|---|
+| `useTradingSimulation` | `nt-position`, `nt-order-update`, `nt-account`, `nt-chart-removed` | Live positions, orders (last 200), live-session equity (points only, retained for backwards compatibility during the transition), accounts | `positions`, `orders`, `accounts`, `liveStats` |
+| `useTradeHistory` | `nt-position` (for pairing + unrealized-P&L sampling), `nt-order-update` (for fill prices / times), `nt-chart-removed` | `Roundtrip[]` (cap 1000), per-algo/symbol/account aggregates, distribution buckets, hour×day buckets | `roundtrips`, `byAlgo`, `bySymbol`, `byAccount`, `liveVsShadow`, `distribution`, `heatmap` |
+| `useEquityTimeline` | `nt-account`, roundtrip closes from `useTradeHistory` | Timestamped equity per series (`live`, `shadow`), running peak + underwater series | `{ live: EquityPoint[], shadow: EquityPoint[], drawdown: DrawdownPoint[] }` |
+| `useRollingMetrics` | `roundtrips` (from `useTradeHistory`) | Windowed derivation (default window = 20 trades) | `{ sharpe: number[], winRate: number[], expectancy: number[] }` + the roundtrip-close timestamps for x-axis labelling |
+
+`useTradeHistory` sources `algo` and `instanceId` by joining `algoId` / `instance_id` against the `algos` and `activeRuns` the view receives — same join the existing hook performs inside `computeStats` today.
+
+### Raw data → enriched roundtrip
+
+`useTradingSimulation` today already tracks an unrealized-P&L per `posKey` via `positionPnlRef` and records a `{ pnl }` entry into `completedTrades` on position flat. The new `useTradeHistory` subsumes and extends this:
+
+- On the first `nt-position` for a `posKey` with a non-zero qty, record `openTimestamp` (now), `entryPrice` (`p.avg_price`), `side`, `qty`, `symbol`, `account`, `dataSourceId`, and the matching algo/instance from `activeRuns`.
+- While the position is open, maintain `mae` (most-negative unrealized P&L seen) and `mfe` (most-positive). Sample via a ~250ms RAF tick bound to the position being open; reset on flat.
+- On position flat, record `closeTimestamp`, `exitPrice` (last known `avg_price` before flat, or last fill from `nt-order-update`), `pnl` (the final `unrealized_pnl` observed just before the flat event), and close out the MAE/MFE sampling.
+- Push a `Roundtrip` record into the history (cap 1000). Emit the same downstream aggregates the tab panels consume.
+
+`Roundtrip` shape:
+
+```ts
+type Roundtrip = {
+  id: string;                 // generated — "<posKey>-<openTs>"
+  symbol: string;
+  side: "Long" | "Short";
+  qty: number;
+  entryPrice: number;
+  exitPrice: number;
+  openTimestamp: number;      // ms epoch
+  closeTimestamp: number;     // ms epoch
+  pnl: number;
+  mae: number;                // worst unrealized P&L during hold
+  mfe: number;                // best unrealized P&L during hold
+  rMultiple: number | null;   // (pnl / |mae|) when mae !== 0, else null
+  algo: string;
+  algoId: number;
+  account: string;
+  dataSourceId: string;
+  instanceId: string;
+  isShadow: boolean;          // account === "shadow"
+  maeMfeSamples: { t: number; pnl: number }[]; // for drill-down chart (capped per roundtrip to 200 samples)
+};
+```
+
+### Pure helpers
+
+**`src/lib/tradingView.ts`**
+
+- `applyFilters(items, { chart, account, algo })` — narrows any keyed collection (`{ dataSourceId, account, algoId }`) to the active filters. Used by hero aggregates, tab panels, and the drill-down panel.
+- `aggregateByKey<Key>(roundtrips, keyOf)` — groups and aggregates to `{ key, count, pnl, winRate, avgWin, avgLoss, sharpe, profitFactor, sparkline }`. Used by BreakdownTable for algo / symbol / account variants.
+- `pairLiveShadow(byAlgo)` — pairs a live algo's aggregate with its matching shadow aggregate (same algo name across the live and shadow account); returns `{ live, shadow, delta, slippageEstimate }` per algo.
+- `buildDistribution(roundtrips, bucketCount)` — histogram buckets keyed by P&L bins; fixed bucketCount default 12.
+- `buildHeatmap(roundtrips)` — 7×24 grid of `{ trades, pnl, winRate }`, using close timestamp.
+- `deriveHeroKpis(filteredRoundtrips, accounts, positions)` — Realized / Unrealized / Total / WinRate / Trades / Sharpe / MaxDD in one pass.
+
+**`src/lib/roundtrips.ts`**
+
+- `pairFillsToRoundtrip(fills, positionEvents)` — exported for use by `useTradeHistory` and unit-testable independently. Pairs fills between consecutive flat events.
+- `deriveMaeMfe(samples)` — pure reducer over `{ t, pnl }` samples to produce `{ mae, mfe }`.
+
+All helpers are pure, independently testable, and free of React.
+
+### `TradingView.tsx` responsibilities
+
+Local `useState`:
+
+- `filters: { chart: string | null; account: string | null; algo: number | null }` — default all `null`.
+- `activeTab: "live" | "performance" | "analytics" | "trades"` — default `"live"`.
+- `selectedRoundtripId: string | null` — drives the drill-down panel.
+- `rollingWindow: { size: number; metric: "sharpe" | "winRate" | "expectancy" }` — default `{ size: 20, metric: "sharpe" }`.
+
+`useMemo`-backed derived state (keyed on filters + hook outputs):
+
+- `filteredRoundtrips`, `filteredPositions`, `filteredOrders`, `filteredEquity`, `filteredDrawdown`.
+- `heroKpis`.
+
+The view orchestrates layout only; panels render their own data.
+
+Existing inbound nav (`initialContext`) continues to work:
+- `accountFilter` → sets `filters.account`.
+- `algoFilter` → sets `filters.algo`.
+- `scrollTo`:
+  - `"positions"` → switch to Live tab, scroll to position cards.
+  - `"orders"` / `"history"` → Live tab for live-session orders, Trades tab for completed roundtrips (if the nav was triggered from a historical context, tail to Trades; otherwise Live).
+  - `"stats"` → scroll hero into view (noop when hero is pinned and already in view).
+
+### Filter behavior
+
+Filters are global to the view. Each filter is independent; combining narrows the set. With any filter active:
+
+- Hero KPIs recompute from the narrowed roundtrip set (realized + current unrealized for currently-matching open positions).
+- Equity chart plots the sum of matching run equity series; when no runs match, shows a flat zero line.
+- Live tab: only matching cards / orders show; "No matching open positions" / "No matching orders" inline states render per panel.
+- Performance tab: breakdowns narrow; rows that don't match are hidden.
+- Analytics tab: distribution / heatmap / rolling metrics narrow.
+- Trades tab: roundtrips narrow.
+
+Clearing all filters returns every panel to the aggregate.
+
+### Shadow handling (no mode toggle)
+
+- Shadow positions, orders, and roundtrips render inline in every tab, tagged with a `Shadow` pill (yellow tone, matching today's visual language for shadow mode).
+- Equity chart overlays two series:
+  - Live — solid line, green/red below/above zero (matching today).
+  - Shadow — dashed line, same coloring.
+- Hero KPIs aggregate live + shadow by default when the `account` filter is `null`. When the filter is set to `"shadow"` or a live account, the hero narrows accordingly.
+- `LiveShadowDelta` (Performance tab module G) explicitly pairs each algo's live aggregate with its shadow aggregate (when both exist) and shows the delta + a crude slippage estimate (`(liveAvgTrade - shadowAvgTrade)`).
+
+### Drill-down panel (Trades tab)
+
+- Right-side, 42% of the tab content width, overlays the roundtrips table (table stays scrollable on the left).
+- Opens on row click; closes on Esc, close button, or clicking another row to replace.
+- Contents: header (symbol, side, time range, algo, account, shadow pill if applicable), KPI row (P&L, R multiple, duration), Execution (entry + exit price / time), Excursion (MAE, MFE timestamps and values), per-tick unrealized P&L chart from the captured `maeMfeSamples`.
+- Never covers the pinned hero / filter bar / tab bar.
+
+### Visual language
+
+- Colors use existing CSS variables (`--bg-primary`, `--bg-panel`, `--bg-secondary`, `--border`, `--text-primary`, `--text-secondary`, `--accent-blue`, `--accent-green`, `--accent-yellow`, `--accent-red`).
+- Pills, chips, and dot indicators match today's conventions.
+- Equity chart keeps today's step-line style; drawdown overlays as a muted-red band beneath the zero line using the underwater-curve technique.
+- Sparklines in breakdown tables use the same style as HomeView / AlgosView sparklines.
+- Row heights are compact: tables ~32px, cards ~72–96px.
+
+## Empty states
+
+| Situation | Rendering |
+|---|---|
+| No charts connected | Hero dims; filter bar collapses to label only; tab area shows "Connect a NinjaTrader chart to see trading activity." (matches the copy used elsewhere in the app.) |
+| Charts but no runs / no trades yet | Hero KPIs zero; equity is flat; Live tab: "No open positions or orders yet"; Performance: "No completed trades yet — breakdowns appear after your first roundtrip"; Analytics: same; Trades: same. |
+| Filters exclude everything in the active tab | Inline "No data matches these filters · Clear filters" inside the tab panel. |
+| No roundtrip selected (Trades tab) | Drill panel shows a subtle "Click a roundtrip to see execution detail"; roundtrips table takes full width. |
+
+## User flows
+
+### Monitor while trading
+
+1. Open Trading view → Live tab shows open positions as cards with running P&L, hold time, mini trend; order tape fills under them; risk strip sits above.
+2. Equity + drawdown pinned at top update in real time.
+3. Filters (Chart / Account / Algo) narrow every panel together.
+4. Switch to Performance or Analytics tab mid-session to check which algo / symbol is carrying, without losing the hero band.
+
+### Review a session
+
+1. After market close, open Trading view → hero shows final KPIs + full equity + drawdown.
+2. Performance tab: skim per-algo / per-symbol / per-account breakdowns; identify the problem algo.
+3. Analytics tab: distribution histogram confirms fat-tail losers; heatmap shows which session hours were profitable; rolling Sharpe confirms trend.
+4. Trades tab: click a bad roundtrip → drill-down shows entry/exit and how far the position drifted before closing.
+
+### Compare live to shadow
+
+1. Performance tab → Live vs. Shadow module: each algo with a shadow sibling is paired; Δ column shows live − shadow P&L.
+2. Clicking a row applies `{ algo: algoId }` to the global filter so every other panel narrows to that algo's live + shadow data.
+
+### Follow-through from another view
+
+1. In Algos view, click "View trades" on an instance → `onNavigate("trading", { accountFilter: "Sim101", scrollTo: "positions" })`.
+2. Trading view initializes with account filter applied, activates Live tab, scrolls to the position cards.
+
+## Testing strategy
+
+The project has no test runner configured. Verification follows the Home / Editor / Algos redesign convention:
+
+- **Type-check:** `npx tsc --noEmit` clean after each task.
+- **Manual smoke** against `npm run dev`:
+  - Hero KPIs + equity + drawdown render from initial state (flat zero) and after first fills.
+  - Start a live algo → Live tab: position card appears; order tape updates; hero KPIs update; equity chart appends points.
+  - Start a shadow algo → second card with Shadow pill; equity gains dashed shadow series; roundtrip on close tagged shadow.
+  - Close a live position → roundtrip appears in Trades tab; per-algo / per-symbol / per-account rows update in Performance; Analytics distribution + heatmap gain a point; rolling metrics update.
+  - Click a roundtrip row → detail panel opens with execution, MAE/MFE, and per-tick unrealized P&L chart.
+  - Filter bar: each filter reshapes every panel consistently; combining filters composes; "No data matches" appears at narrow settings; clearing returns to aggregate.
+  - Tab switching does not reset filters or selection.
+  - Rolling-metrics tab: Sharpe / Win% / Expectancy toggle re-renders in place.
+  - Deep-link in from Algos view lands in the right tab and scrolls to the anchor.
+  - Deep-link out (Performance row "open in editor" / "view algos") invokes `onNavigate` with the expected options.
+  - Chart removal (NinjaTrader disconnect) prunes matching live state; completed roundtrips persist in history.
+
+Pure helpers in `src/lib/tradingView.ts` and `src/lib/roundtrips.ts` are designed to be verifiable by inspection and via the manual cases above. Unit tests, when added, slot in cleanly.
+
+## Implementation notes
+
+- `App.tsx` composes the new hooks the same way it composes the existing ones. The hook outputs fan out as props into `TradingView`.
+- Reuse `useEquityTimeline` in the hero's `EquityChart` — the drawdown overlay reads from the same series; no secondary computation in the chart component.
+- `useTradeHistory` and `useTradingSimulation` must not race: the roundtrip-close-triggered equity update and the `nt-account` realized-P&L update can arrive in either order. `useEquityTimeline` resolves by keying on timestamp and using the most-recent account snapshot when one arrives.
+- MAE/MFE sampling uses a single shared `requestAnimationFrame` loop inside `useTradeHistory`, throttled by a ~250ms accumulator — only one RAF is alive regardless of how many positions are open.
+- `useTradeHistory` caps `maeMfeSamples` per roundtrip at 200 points; samples are decimated by time, not count, so longer holds don't skip later ticks.
+- Empty-state copy is explicit — no "--" fallbacks in places a user might mistake for a zero.
+- All new components keep props explicit (no shared context) so each is independently testable.
+- Props on `TradingView` expand (new hook outputs flow in) but do not break the existing `initialContext` / `onContextConsumed` surface.
+
+## Risks & open questions
+
+- **Partial fills and multi-leg positions.** Pairing must tolerate scale-in / scale-out (partial qty across multiple fills between flats). Pairing is anchored on flat events: every fill since the previous flat contributes to the current roundtrip. Average entry/exit prices are weighted by qty. Confirmed achievable from `nt-order-update` + `nt-position` alone; no new backend signal needed.
+- **Event ordering on fast markets.** NinjaTrader may emit `nt-position` flat before the closing fill arrives on `nt-order-update`. Mitigation: buffer the most recent fills and resolve on the next flat event. Worst case is a one-tick-late close price on a roundtrip — acceptable.
+- **Shadow slippage estimate.** `liveAvg − shadowAvg` is crude; anything more requires paired trade IDs the bridge does not expose. Ship the crude estimate and label it clearly ("est.").
+- **Rolling metrics window with sparse trades.** Early in a session the window is smaller than the target size. Show partial-window values with an indicator ("n/20 trades") rather than hiding.
+- **Drawdown overlay visual clarity.** Overlaid on the same axis as equity, the DD band can muddy the line at small scales. Implementation plan to validate this during layout and add a subtle separator / secondary axis if needed.
+- **`useTradingSimulation` reduction may affect HomeView / AlgosView.** Both consume the hook today. The reduction keeps all fields currently consumed by those views; anything removed from the hook must be verified against their usages before the PR lands.
+
+## References
+
+- Current implementation: `src/views/TradingView.tsx`, `src/hooks/useTradingSimulation.ts`
+- Navigation contract: `src/types.ts` (`View`, `NavOptions`)
+- Sibling-hook pattern: `src/hooks/useAlgoErrors.ts`, `src/hooks/useAlgoLogs.ts`, `src/hooks/useAlgoHealth.ts`
+- Prior redesigns for style cues and format: `docs/superpowers/specs/2026-04-18-home-view-redesign-design.md`, `docs/superpowers/specs/2026-04-19-editor-view-redesign-design.md`, `docs/superpowers/specs/2026-04-19-algos-view-redesign-design.md`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ import { RenameDialog } from "./components/RenameDialog";
 import { AiTerminalPanel } from "./components/AiTerminalPanel";
 import { ToastContainer, toast } from "./components/Toast";
 import { useTradingSimulation } from "./hooks/useTradingSimulation";
+import { useTradeHistory } from "./hooks/useTradeHistory";
+import { useEquityTimeline } from "./hooks/useEquityTimeline";
+import { useRollingMetrics } from "./hooks/useRollingMetrics";
 import { useAlgoErrors } from "./hooks/useAlgoErrors";
 import { useAlgoLogs } from "./hooks/useAlgoLogs";
 import { useAlgoHealth } from "./hooks/useAlgoHealth";
@@ -50,6 +53,9 @@ export const App = () => {
   const [venvReady, setVenvReady] = useState<boolean | null>(null);
 
   const simulation = useTradingSimulation(algos, activeRuns, dataSources);
+  const tradeHistory = useTradeHistory(algos, activeRuns);
+  const equity = useEquityTimeline(tradeHistory.roundtrips);
+  const rolling = useRollingMetrics(tradeHistory.roundtrips);
 
   const handleAutoStop = useCallback(async (instanceId: string) => {
     toast.error(`Algo instance ${instanceId.slice(0, 8)}... halted due to repeated errors`);
@@ -419,10 +425,16 @@ export const App = () => {
         {activeView === "trading" && (
           <TradingView
             simulation={simulation}
+            tradeHistory={tradeHistory}
+            equity={equity}
+            rolling={rolling}
             algos={algos}
             activeRuns={activeRuns}
+            dataSources={dataSources}
+            accounts={accounts}
             initialContext={pendingNavContext}
             onContextConsumed={clearPendingNavContext}
+            onNavigate={handleNavigate}
           />
         )}
 

--- a/src/components/AnalyticsTab.tsx
+++ b/src/components/AnalyticsTab.tsx
@@ -1,0 +1,33 @@
+import type { DistributionBucket, HeatCell } from "../lib/tradingView";
+import type { RollingMetrics } from "../hooks/useRollingMetrics";
+import { TradeDistribution } from "./TradeDistribution";
+import { SessionHeatmap } from "./SessionHeatmap";
+import { RollingMetricsChart } from "./RollingMetricsChart";
+
+type AnalyticsTabProps = {
+  distribution: DistributionBucket[];
+  heatmap: HeatCell[][];
+  rolling: RollingMetrics;
+  totalTrades: number;
+};
+
+export const AnalyticsTab = ({
+  distribution,
+  heatmap,
+  rolling,
+  totalTrades,
+}: AnalyticsTabProps) => {
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <TradeDistribution buckets={distribution} totalTrades={totalTrades} />
+      <div className="grid grid-cols-2 gap-3">
+        <SessionHeatmap grid={heatmap} />
+        <RollingMetricsChart
+          sharpe={rolling.sharpe}
+          winRate={rolling.winRate}
+          expectancy={rolling.expectancy}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/BreakdownTable.tsx
+++ b/src/components/BreakdownTable.tsx
@@ -57,7 +57,7 @@ export const BreakdownTable = ({
                   <td className="px-4 py-2 font-medium">
                     {row.label === "shadow" ? (
                       <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
-                        shadow
+                        Shadow
                       </span>
                     ) : (
                       row.label
@@ -99,6 +99,7 @@ export const BreakdownTable = ({
                         onClick={() => onRowDeepLink(row)}
                         className="text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent-blue)] transition-colors"
                         title={deepLinkLabel}
+                        aria-label={deepLinkLabel ?? "Open"}
                       >
                         →
                       </button>

--- a/src/components/BreakdownTable.tsx
+++ b/src/components/BreakdownTable.tsx
@@ -1,0 +1,115 @@
+import type { BreakdownRow } from "../lib/tradingView";
+import { formatPnl, pnlColorClass, sparklinePoints } from "../lib/tradingView";
+
+type BreakdownTableProps = {
+  title: string;
+  rows: BreakdownRow[];
+  labelHeader: string;
+  emptyMessage?: string;
+  onRowDeepLink?: (row: BreakdownRow) => void;
+  deepLinkLabel?: string;
+};
+
+const SPARK_W = 80;
+const SPARK_H = 20;
+
+export const BreakdownTable = ({
+  title,
+  rows,
+  labelHeader,
+  emptyMessage,
+  onRowDeepLink,
+  deepLinkLabel,
+}: BreakdownTableProps) => {
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[var(--border)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          {title}
+        </h2>
+      </div>
+      {rows.length === 0 ? (
+        <div className="px-4 py-6 text-center text-sm text-[var(--text-secondary)]">
+          {emptyMessage ?? "No data yet"}
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+              <th className="text-left px-4 py-2 font-medium">{labelHeader}</th>
+              <th className="text-right px-4 py-2 font-medium">Trades</th>
+              <th className="text-right px-4 py-2 font-medium">Win %</th>
+              <th className="text-right px-4 py-2 font-medium">P&L</th>
+              <th className="text-right px-4 py-2 font-medium">Sharpe</th>
+              <th className="text-right px-4 py-2 font-medium">Avg Win</th>
+              <th className="text-right px-4 py-2 font-medium">Avg Loss</th>
+              <th className="text-right px-4 py-2 font-medium">Profit Factor</th>
+              <th className="text-right px-4 py-2 font-medium">Trend</th>
+              {onRowDeepLink && <th className="text-right px-4 py-2 font-medium" />}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const strokeColor = row.pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+              const points = sparklinePoints(row.sparkline, SPARK_W, SPARK_H);
+              return (
+                <tr key={row.key} className="border-b border-[var(--border)] last:border-0">
+                  <td className="px-4 py-2 font-medium">
+                    {row.label === "shadow" ? (
+                      <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
+                        shadow
+                      </span>
+                    ) : (
+                      row.label
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.trades}</td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.winRate}%</td>
+                  <td className={`px-4 py-2 text-right font-mono tabular-nums font-medium ${pnlColorClass(row.pnl)}`}>
+                    {formatPnl(row.pnl)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.sharpe}</td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums text-[var(--accent-green)]">
+                    {formatPnl(row.avgWin)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums text-[var(--accent-red)]">
+                    {formatPnl(row.avgLoss)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{row.profitFactor}</td>
+                  <td className="px-4 py-2 text-right">
+                    {points ? (
+                      <svg
+                        className="inline-block"
+                        viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+                        preserveAspectRatio="none"
+                        width={SPARK_W}
+                        height={SPARK_H}
+                        aria-hidden
+                      >
+                        <polyline fill="none" stroke={strokeColor} strokeWidth="1.2" points={points} />
+                      </svg>
+                    ) : (
+                      <span className="text-[var(--text-muted)]">—</span>
+                    )}
+                  </td>
+                  {onRowDeepLink && (
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => onRowDeepLink(row)}
+                        className="text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent-blue)] transition-colors"
+                        title={deepLinkLabel}
+                      >
+                        →
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};

--- a/src/components/EquityChart.tsx
+++ b/src/components/EquityChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { EquityPoint, DrawdownPoint } from "../lib/tradingView";
 
 type EquityChartProps = {
@@ -25,7 +25,6 @@ const formatValue = (v: number) => `${v >= 0 ? "+" : "-"}$${Math.abs(v).toFixed(
 export const EquityChart = ({ live, shadow, drawdown }: EquityChartProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number>(0);
   const mouseRef = useRef<{ x: number; y: number } | null>(null);
   const liveRef = useRef(live);
   const shadowRef = useRef(shadow);
@@ -41,15 +40,224 @@ export const EquityChart = ({ live, shadow, drawdown }: EquityChartProps) => {
     ddRef.current = drawdown;
   }, [drawdown]);
 
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+    const rect = container.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    const dpr = window.devicePixelRatio || 1;
+    if (
+      canvas.width !== Math.round(rect.width * dpr) ||
+      canvas.height !== Math.round(rect.height * dpr)
+    ) {
+      canvas.width = Math.round(rect.width * dpr);
+      canvas.height = Math.round(rect.height * dpr);
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const w = rect.width;
+    const h = rect.height;
+    ctx.clearRect(0, 0, w, h);
+
+    const liveSeries = liveRef.current;
+    const shadowSeries = shadowRef.current;
+    const dd = ddRef.current;
+
+    const all: DrawData[] = [...liveSeries, ...shadowSeries];
+    if (all.length < 2) {
+      ctx.fillStyle = "rgba(136, 136, 160, 0.5)";
+      ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("No equity data yet", w / 2, h / 2);
+      return;
+    }
+
+    // Domain: time min/max across both series; value min/max anchored at 0.
+    // Single-pass min/max avoids the spread-apply ceiling on large arrays.
+    let tMin = Infinity;
+    let tMax = -Infinity;
+    let vMin = 0;
+    let vMax = 0;
+    for (const p of all) {
+      if (p.t < tMin) tMin = p.t;
+      if (p.t > tMax) tMax = p.t;
+      if (p.pnl < vMin) vMin = p.pnl;
+      if (p.pnl > vMax) vMax = p.pnl;
+    }
+    const tRange = Math.max(tMax - tMin, 1);
+    const vRange = vMax - vMin || 1;
+    const pad = vRange * 0.1;
+    const toX = (t: number) => ((t - tMin) / tRange) * w;
+    const toY = (v: number) => h - ((v - vMin + pad) / (vRange + pad * 2)) * h;
+
+    // Zero line
+    const zeroY = toY(0);
+    ctx.strokeStyle = GRID;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(0, zeroY);
+    ctx.lineTo(w, zeroY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Drawdown band (underwater area beneath live series)
+    if (dd.length >= 2) {
+      ctx.beginPath();
+      ctx.moveTo(toX(dd[0].t), toY(dd[0].peak));
+      for (let i = 1; i < dd.length; i++) {
+        ctx.lineTo(toX(dd[i].t), toY(dd[i].peak));
+      }
+      for (let i = dd.length - 1; i >= 0; i--) {
+        ctx.lineTo(toX(dd[i].t), toY(dd[i].pnl));
+      }
+      ctx.closePath();
+      ctx.fillStyle = DD_FILL;
+      ctx.fill();
+    }
+
+    const traceStep = (series: DrawData[]) => {
+      if (series.length === 0) return;
+      ctx.moveTo(toX(series[0].t), toY(series[0].pnl));
+      for (let i = 1; i < series.length; i++) {
+        ctx.lineTo(toX(series[i].t), toY(series[i - 1].pnl));
+        ctx.lineTo(toX(series[i].t), toY(series[i].pnl));
+      }
+    };
+
+    // Live series — split by sign for green/red coloring via clip regions.
+    if (liveSeries.length >= 2) {
+      const regions = [
+        { yStart: 0, yEnd: zeroY, color: GREEN, grad: ["rgba(0,214,143,0.2)", "rgba(0,214,143,0)"] },
+        { yStart: zeroY, yEnd: h, color: RED, grad: ["rgba(255,77,106,0)", "rgba(255,77,106,0.2)"] },
+      ];
+      for (const r of regions) {
+        if (r.yEnd - r.yStart <= 0) continue;
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(0, r.yStart, w, r.yEnd - r.yStart);
+        ctx.clip();
+        const g = ctx.createLinearGradient(0, r.yStart, 0, r.yEnd);
+        g.addColorStop(0, r.grad[0]);
+        g.addColorStop(1, r.grad[1]);
+        ctx.beginPath();
+        ctx.moveTo(toX(liveSeries[0].t), zeroY);
+        traceStep(liveSeries);
+        ctx.lineTo(toX(liveSeries[liveSeries.length - 1].t), zeroY);
+        ctx.closePath();
+        ctx.fillStyle = g;
+        ctx.fill();
+        ctx.beginPath();
+        traceStep(liveSeries);
+        ctx.strokeStyle = r.color;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+
+    // Shadow series — dashed overlay
+    if (shadowSeries.length >= 2) {
+      ctx.save();
+      ctx.setLineDash([4, 3]);
+      ctx.strokeStyle = SHADOW_COLOR;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      traceStep(shadowSeries);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // Crosshair + tooltip for the live series
+    const mouse = mouseRef.current;
+    if (mouse && liveSeries.length >= 2) {
+      // Nearest point by x
+      let nearestIdx = 0;
+      let nearestDx = Infinity;
+      for (let i = 0; i < liveSeries.length; i++) {
+        const dx = Math.abs(toX(liveSeries[i].t) - mouse.x);
+        if (dx < nearestDx) {
+          nearestDx = dx;
+          nearestIdx = i;
+        }
+      }
+      const point = liveSeries[nearestIdx];
+      const px = toX(point.t);
+      const py = toY(point.pnl);
+      const color = point.pnl >= 0 ? GREEN : RED;
+
+      ctx.strokeStyle = "rgba(136, 136, 160, 0.3)";
+      ctx.lineWidth = 1;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      ctx.moveTo(px, 0);
+      ctx.lineTo(px, h);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      ctx.beginPath();
+      ctx.arc(px, py, 5, 0, Math.PI * 2);
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.strokeStyle = "#1a1a28";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      const label = formatValue(point.pnl);
+      ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+      const metrics = ctx.measureText(label);
+      const tw = metrics.width + 16;
+      const th = 24;
+      const pad2 = 10;
+      let tx = px + pad2;
+      if (tx + tw > w) tx = px - tw - pad2;
+      let ty = py - th - pad2;
+      if (ty < 0) ty = py + pad2;
+      ctx.fillStyle = TOOLTIP_BG;
+      ctx.beginPath();
+      ctx.roundRect(tx, ty, tw, th, 4);
+      ctx.fill();
+      ctx.strokeStyle = TOOLTIP_BORDER;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+      ctx.fillStyle = color;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(label, tx + tw / 2, ty + th / 2);
+    }
+  }, []);
+
+  // Redraw on data change (props).
+  useEffect(() => {
+    draw();
+  }, [live, shadow, drawdown, draw]);
+
+  // Redraw on container resize + first-paint race when dimensions become non-zero.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const ro = new ResizeObserver(() => draw());
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [draw]);
+
+  // Mouse tracking: redraw only while hovering + when the mouse leaves (to clear crosshair).
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const move = (e: MouseEvent) => {
       const rect = canvas.getBoundingClientRect();
       mouseRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      draw();
     };
     const leave = () => {
       mouseRef.current = null;
+      draw();
     };
     canvas.addEventListener("mousemove", move);
     canvas.addEventListener("mouseleave", leave);
@@ -57,204 +265,7 @@ export const EquityChart = ({ live, shadow, drawdown }: EquityChartProps) => {
       canvas.removeEventListener("mousemove", move);
       canvas.removeEventListener("mouseleave", leave);
     };
-  }, []);
-
-  useEffect(() => {
-    const draw = () => {
-      const canvas = canvasRef.current;
-      const container = containerRef.current;
-      if (!canvas || !container) {
-        rafRef.current = requestAnimationFrame(draw);
-        return;
-      }
-      const rect = container.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
-      if (
-        canvas.width !== Math.round(rect.width * dpr) ||
-        canvas.height !== Math.round(rect.height * dpr)
-      ) {
-        canvas.width = Math.round(rect.width * dpr);
-        canvas.height = Math.round(rect.height * dpr);
-        canvas.style.width = `${rect.width}px`;
-        canvas.style.height = `${rect.height}px`;
-      }
-      const ctx = canvas.getContext("2d");
-      if (!ctx) {
-        rafRef.current = requestAnimationFrame(draw);
-        return;
-      }
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      const w = rect.width;
-      const h = rect.height;
-      ctx.clearRect(0, 0, w, h);
-
-      const liveSeries = liveRef.current;
-      const shadowSeries = shadowRef.current;
-      const dd = ddRef.current;
-
-      const all: DrawData[] = [...liveSeries, ...shadowSeries];
-      if (all.length < 2) {
-        ctx.fillStyle = "rgba(136, 136, 160, 0.5)";
-        ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText("No equity data yet", w / 2, h / 2);
-        rafRef.current = requestAnimationFrame(draw);
-        return;
-      }
-
-      // Domain: time min/max across both series; value min/max anchored at 0.
-      const tMin = Math.min(...all.map((p) => p.t));
-      const tMax = Math.max(...all.map((p) => p.t));
-      const tRange = Math.max(tMax - tMin, 1);
-      const vMin = Math.min(0, ...all.map((p) => p.pnl));
-      const vMax = Math.max(0, ...all.map((p) => p.pnl));
-      const vRange = vMax - vMin || 1;
-      const pad = vRange * 0.1;
-      const toX = (t: number) => ((t - tMin) / tRange) * w;
-      const toY = (v: number) => h - ((v - vMin + pad) / (vRange + pad * 2)) * h;
-
-      // Zero line
-      const zeroY = toY(0);
-      ctx.strokeStyle = GRID;
-      ctx.lineWidth = 1;
-      ctx.setLineDash([4, 4]);
-      ctx.beginPath();
-      ctx.moveTo(0, zeroY);
-      ctx.lineTo(w, zeroY);
-      ctx.stroke();
-      ctx.setLineDash([]);
-
-      // Drawdown band (underwater area beneath live series)
-      if (dd.length >= 2) {
-        ctx.beginPath();
-        ctx.moveTo(toX(dd[0].t), toY(dd[0].peak));
-        for (let i = 1; i < dd.length; i++) {
-          ctx.lineTo(toX(dd[i].t), toY(dd[i].peak));
-        }
-        for (let i = dd.length - 1; i >= 0; i--) {
-          ctx.lineTo(toX(dd[i].t), toY(dd[i].pnl));
-        }
-        ctx.closePath();
-        ctx.fillStyle = DD_FILL;
-        ctx.fill();
-      }
-
-      const traceStep = (series: DrawData[]) => {
-        if (series.length === 0) return;
-        ctx.moveTo(toX(series[0].t), toY(series[0].pnl));
-        for (let i = 1; i < series.length; i++) {
-          ctx.lineTo(toX(series[i].t), toY(series[i - 1].pnl));
-          ctx.lineTo(toX(series[i].t), toY(series[i].pnl));
-        }
-      };
-
-      // Live series — split by sign for green/red coloring via clip regions.
-      if (liveSeries.length >= 2) {
-        const regions = [
-          { yStart: 0, yEnd: zeroY, color: GREEN, grad: ["rgba(0,214,143,0.2)", "rgba(0,214,143,0)"] },
-          { yStart: zeroY, yEnd: h, color: RED, grad: ["rgba(255,77,106,0)", "rgba(255,77,106,0.2)"] },
-        ];
-        for (const r of regions) {
-          if (r.yEnd - r.yStart <= 0) continue;
-          ctx.save();
-          ctx.beginPath();
-          ctx.rect(0, r.yStart, w, r.yEnd - r.yStart);
-          ctx.clip();
-          const g = ctx.createLinearGradient(0, r.yStart, 0, r.yEnd);
-          g.addColorStop(0, r.grad[0]);
-          g.addColorStop(1, r.grad[1]);
-          ctx.beginPath();
-          ctx.moveTo(toX(liveSeries[0].t), zeroY);
-          traceStep(liveSeries);
-          ctx.lineTo(toX(liveSeries[liveSeries.length - 1].t), zeroY);
-          ctx.closePath();
-          ctx.fillStyle = g;
-          ctx.fill();
-          ctx.beginPath();
-          traceStep(liveSeries);
-          ctx.strokeStyle = r.color;
-          ctx.lineWidth = 2;
-          ctx.stroke();
-          ctx.restore();
-        }
-      }
-
-      // Shadow series — dashed overlay
-      if (shadowSeries.length >= 2) {
-        ctx.save();
-        ctx.setLineDash([4, 3]);
-        ctx.strokeStyle = SHADOW_COLOR;
-        ctx.lineWidth = 1.5;
-        ctx.beginPath();
-        traceStep(shadowSeries);
-        ctx.stroke();
-        ctx.restore();
-      }
-
-      // Crosshair + tooltip for the live series
-      const mouse = mouseRef.current;
-      if (mouse && liveSeries.length >= 2) {
-        // Nearest point by x
-        let nearestIdx = 0;
-        let nearestDx = Infinity;
-        for (let i = 0; i < liveSeries.length; i++) {
-          const dx = Math.abs(toX(liveSeries[i].t) - mouse.x);
-          if (dx < nearestDx) {
-            nearestDx = dx;
-            nearestIdx = i;
-          }
-        }
-        const point = liveSeries[nearestIdx];
-        const px = toX(point.t);
-        const py = toY(point.pnl);
-        const color = point.pnl >= 0 ? GREEN : RED;
-
-        ctx.strokeStyle = "rgba(136, 136, 160, 0.3)";
-        ctx.lineWidth = 1;
-        ctx.setLineDash([3, 3]);
-        ctx.beginPath();
-        ctx.moveTo(px, 0);
-        ctx.lineTo(px, h);
-        ctx.stroke();
-        ctx.setLineDash([]);
-
-        ctx.beginPath();
-        ctx.arc(px, py, 5, 0, Math.PI * 2);
-        ctx.fillStyle = color;
-        ctx.fill();
-        ctx.strokeStyle = "#1a1a28";
-        ctx.lineWidth = 2;
-        ctx.stroke();
-
-        const label = formatValue(point.pnl);
-        ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
-        const metrics = ctx.measureText(label);
-        const tw = metrics.width + 16;
-        const th = 24;
-        const pad2 = 10;
-        let tx = px + pad2;
-        if (tx + tw > w) tx = px - tw - pad2;
-        let ty = py - th - pad2;
-        if (ty < 0) ty = py + pad2;
-        ctx.fillStyle = TOOLTIP_BG;
-        ctx.beginPath();
-        ctx.roundRect(tx, ty, tw, th, 4);
-        ctx.fill();
-        ctx.strokeStyle = TOOLTIP_BORDER;
-        ctx.lineWidth = 1;
-        ctx.stroke();
-        ctx.fillStyle = color;
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(label, tx + tw / 2, ty + th / 2);
-      }
-
-      rafRef.current = requestAnimationFrame(draw);
-    };
-    rafRef.current = requestAnimationFrame(draw);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, []);
+  }, [draw]);
 
   return (
     <div ref={containerRef} className="flex-1 min-h-0">

--- a/src/components/EquityChart.tsx
+++ b/src/components/EquityChart.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef } from "react";
+import type { EquityPoint, DrawdownPoint } from "../lib/tradingView";
+
+type EquityChartProps = {
+  live: EquityPoint[];
+  shadow: EquityPoint[];
+  drawdown: DrawdownPoint[];
+};
+
+const GREEN = "#00d68f";
+const RED = "#ff4d6a";
+const DD_FILL = "rgba(255, 77, 106, 0.10)";
+const GRID = "rgba(136, 136, 160, 0.2)";
+const SHADOW_COLOR = "rgba(255, 193, 7, 0.8)";
+const TOOLTIP_BG = "rgba(26, 26, 40, 0.92)";
+const TOOLTIP_BORDER = "rgba(42, 42, 58, 0.8)";
+
+type DrawData = {
+  t: number;
+  pnl: number;
+};
+
+const formatValue = (v: number) => `${v >= 0 ? "+" : "-"}$${Math.abs(v).toFixed(2)}`;
+
+export const EquityChart = ({ live, shadow, drawdown }: EquityChartProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+  const mouseRef = useRef<{ x: number; y: number } | null>(null);
+  const liveRef = useRef(live);
+  const shadowRef = useRef(shadow);
+  const ddRef = useRef(drawdown);
+
+  useEffect(() => {
+    liveRef.current = live;
+  }, [live]);
+  useEffect(() => {
+    shadowRef.current = shadow;
+  }, [shadow]);
+  useEffect(() => {
+    ddRef.current = drawdown;
+  }, [drawdown]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const move = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouseRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    };
+    const leave = () => {
+      mouseRef.current = null;
+    };
+    canvas.addEventListener("mousemove", move);
+    canvas.addEventListener("mouseleave", leave);
+    return () => {
+      canvas.removeEventListener("mousemove", move);
+      canvas.removeEventListener("mouseleave", leave);
+    };
+  }, []);
+
+  useEffect(() => {
+    const draw = () => {
+      const canvas = canvasRef.current;
+      const container = containerRef.current;
+      if (!canvas || !container) {
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      if (
+        canvas.width !== Math.round(rect.width * dpr) ||
+        canvas.height !== Math.round(rect.height * dpr)
+      ) {
+        canvas.width = Math.round(rect.width * dpr);
+        canvas.height = Math.round(rect.height * dpr);
+        canvas.style.width = `${rect.width}px`;
+        canvas.style.height = `${rect.height}px`;
+      }
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const w = rect.width;
+      const h = rect.height;
+      ctx.clearRect(0, 0, w, h);
+
+      const liveSeries = liveRef.current;
+      const shadowSeries = shadowRef.current;
+      const dd = ddRef.current;
+
+      const all: DrawData[] = [...liveSeries, ...shadowSeries];
+      if (all.length < 2) {
+        ctx.fillStyle = "rgba(136, 136, 160, 0.5)";
+        ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText("No equity data yet", w / 2, h / 2);
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+
+      // Domain: time min/max across both series; value min/max anchored at 0.
+      const tMin = Math.min(...all.map((p) => p.t));
+      const tMax = Math.max(...all.map((p) => p.t));
+      const tRange = Math.max(tMax - tMin, 1);
+      const vMin = Math.min(0, ...all.map((p) => p.pnl));
+      const vMax = Math.max(0, ...all.map((p) => p.pnl));
+      const vRange = vMax - vMin || 1;
+      const pad = vRange * 0.1;
+      const toX = (t: number) => ((t - tMin) / tRange) * w;
+      const toY = (v: number) => h - ((v - vMin + pad) / (vRange + pad * 2)) * h;
+
+      // Zero line
+      const zeroY = toY(0);
+      ctx.strokeStyle = GRID;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(0, zeroY);
+      ctx.lineTo(w, zeroY);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Drawdown band (underwater area beneath live series)
+      if (dd.length >= 2) {
+        ctx.beginPath();
+        ctx.moveTo(toX(dd[0].t), toY(dd[0].peak));
+        for (let i = 1; i < dd.length; i++) {
+          ctx.lineTo(toX(dd[i].t), toY(dd[i].peak));
+        }
+        for (let i = dd.length - 1; i >= 0; i--) {
+          ctx.lineTo(toX(dd[i].t), toY(dd[i].pnl));
+        }
+        ctx.closePath();
+        ctx.fillStyle = DD_FILL;
+        ctx.fill();
+      }
+
+      const traceStep = (series: DrawData[]) => {
+        if (series.length === 0) return;
+        ctx.moveTo(toX(series[0].t), toY(series[0].pnl));
+        for (let i = 1; i < series.length; i++) {
+          ctx.lineTo(toX(series[i].t), toY(series[i - 1].pnl));
+          ctx.lineTo(toX(series[i].t), toY(series[i].pnl));
+        }
+      };
+
+      // Live series — split by sign for green/red coloring via clip regions.
+      if (liveSeries.length >= 2) {
+        const regions = [
+          { yStart: 0, yEnd: zeroY, color: GREEN, grad: ["rgba(0,214,143,0.2)", "rgba(0,214,143,0)"] },
+          { yStart: zeroY, yEnd: h, color: RED, grad: ["rgba(255,77,106,0)", "rgba(255,77,106,0.2)"] },
+        ];
+        for (const r of regions) {
+          if (r.yEnd - r.yStart <= 0) continue;
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(0, r.yStart, w, r.yEnd - r.yStart);
+          ctx.clip();
+          const g = ctx.createLinearGradient(0, r.yStart, 0, r.yEnd);
+          g.addColorStop(0, r.grad[0]);
+          g.addColorStop(1, r.grad[1]);
+          ctx.beginPath();
+          ctx.moveTo(toX(liveSeries[0].t), zeroY);
+          traceStep(liveSeries);
+          ctx.lineTo(toX(liveSeries[liveSeries.length - 1].t), zeroY);
+          ctx.closePath();
+          ctx.fillStyle = g;
+          ctx.fill();
+          ctx.beginPath();
+          traceStep(liveSeries);
+          ctx.strokeStyle = r.color;
+          ctx.lineWidth = 2;
+          ctx.stroke();
+          ctx.restore();
+        }
+      }
+
+      // Shadow series — dashed overlay
+      if (shadowSeries.length >= 2) {
+        ctx.save();
+        ctx.setLineDash([4, 3]);
+        ctx.strokeStyle = SHADOW_COLOR;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        traceStep(shadowSeries);
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      // Crosshair + tooltip for the live series
+      const mouse = mouseRef.current;
+      if (mouse && liveSeries.length >= 2) {
+        // Nearest point by x
+        let nearestIdx = 0;
+        let nearestDx = Infinity;
+        for (let i = 0; i < liveSeries.length; i++) {
+          const dx = Math.abs(toX(liveSeries[i].t) - mouse.x);
+          if (dx < nearestDx) {
+            nearestDx = dx;
+            nearestIdx = i;
+          }
+        }
+        const point = liveSeries[nearestIdx];
+        const px = toX(point.t);
+        const py = toY(point.pnl);
+        const color = point.pnl >= 0 ? GREEN : RED;
+
+        ctx.strokeStyle = "rgba(136, 136, 160, 0.3)";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([3, 3]);
+        ctx.beginPath();
+        ctx.moveTo(px, 0);
+        ctx.lineTo(px, h);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        ctx.beginPath();
+        ctx.arc(px, py, 5, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.fill();
+        ctx.strokeStyle = "#1a1a28";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+
+        const label = formatValue(point.pnl);
+        ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+        const metrics = ctx.measureText(label);
+        const tw = metrics.width + 16;
+        const th = 24;
+        const pad2 = 10;
+        let tx = px + pad2;
+        if (tx + tw > w) tx = px - tw - pad2;
+        let ty = py - th - pad2;
+        if (ty < 0) ty = py + pad2;
+        ctx.fillStyle = TOOLTIP_BG;
+        ctx.beginPath();
+        ctx.roundRect(tx, ty, tw, th, 4);
+        ctx.fill();
+        ctx.strokeStyle = TOOLTIP_BORDER;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.fillStyle = color;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(label, tx + tw / 2, ty + th / 2);
+      }
+
+      rafRef.current = requestAnimationFrame(draw);
+    };
+    rafRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex-1 min-h-0">
+      <canvas ref={canvasRef} className="w-full h-full" style={{ cursor: "crosshair" }} />
+    </div>
+  );
+};

--- a/src/components/LiveShadowDelta.tsx
+++ b/src/components/LiveShadowDelta.tsx
@@ -1,0 +1,62 @@
+import type { LiveShadowPair } from "../lib/tradingView";
+import { formatPnl, pnlColorClass } from "../lib/tradingView";
+
+type LiveShadowDeltaProps = {
+  pairs: LiveShadowPair[];
+};
+
+export const LiveShadowDelta = ({ pairs }: LiveShadowDeltaProps) => {
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[var(--border)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Live vs. Shadow
+        </h2>
+      </div>
+      {pairs.length === 0 ? (
+        <div className="px-4 py-6 text-center text-sm text-[var(--text-secondary)]">
+          No paired trades yet · run the same algo live and shadow to compare
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+              <th className="text-left px-4 py-2 font-medium">Algo</th>
+              <th className="text-right px-4 py-2 font-medium">Live P&L</th>
+              <th className="text-right px-4 py-2 font-medium">Shadow P&L</th>
+              <th className="text-right px-4 py-2 font-medium">Δ</th>
+              <th className="text-right px-4 py-2 font-medium">Live Win %</th>
+              <th className="text-right px-4 py-2 font-medium">Shadow Win %</th>
+              <th className="text-right px-4 py-2 font-medium">Slippage est.</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pairs.map((p) => (
+              <tr key={p.algoId} className="border-b border-[var(--border)] last:border-0">
+                <td className="px-4 py-2 font-medium">{p.algoName}</td>
+                <td className={`px-4 py-2 text-right font-mono tabular-nums ${pnlColorClass(p.live?.pnl ?? 0)}`}>
+                  {p.live ? formatPnl(p.live.pnl) : "—"}
+                </td>
+                <td className={`px-4 py-2 text-right font-mono tabular-nums ${pnlColorClass(p.shadow?.pnl ?? 0)}`}>
+                  {p.shadow ? formatPnl(p.shadow.pnl) : "—"}
+                </td>
+                <td className={`px-4 py-2 text-right font-mono tabular-nums font-semibold ${pnlColorClass(p.delta)}`}>
+                  {formatPnl(p.delta)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono tabular-nums">
+                  {p.live ? `${p.live.winRate}%` : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono tabular-nums">
+                  {p.shadow ? `${p.shadow.winRate}%` : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono tabular-nums text-[var(--text-secondary)]">
+                  {p.live && p.shadow ? `${formatPnl(p.slippagePerTrade)}/trade` : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};

--- a/src/components/LiveTab.tsx
+++ b/src/components/LiveTab.tsx
@@ -13,9 +13,9 @@ type LiveTabProps = {
   positions: Position[];
   orders: SimOrder[];
   accounts: Record<string, AccountSummary>;
-  // Map posKey ("dataSourceId:symbol:account") → open-since timestamp; provided by useTradeHistory
-  // so position cards can render "held Xm" consistently. If a card has no entry in the map,
-  // fallback to "--" via null.
+  // Map posKey ("dataSourceId:symbol:account") → open-since timestamp; maintained by the
+  // parent (TradingView's `useOpenSinceMap`) so position cards can render "held Xm"
+  // consistently. If a card has no entry in the map, fallback to "--" via null.
   openSinceByPosKey: Map<string, number>;
 };
 

--- a/src/components/LiveTab.tsx
+++ b/src/components/LiveTab.tsx
@@ -1,0 +1,59 @@
+import type { Position, SimOrder } from "../hooks/useTradingSimulation";
+import { RiskSummary } from "./RiskSummary";
+import { PositionCard } from "./PositionCard";
+import { OrderTape } from "./OrderTape";
+
+type AccountSummary = {
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+type LiveTabProps = {
+  positions: Position[];
+  orders: SimOrder[];
+  accounts: Record<string, AccountSummary>;
+  // Map posKey ("dataSourceId:symbol:account") → open-since timestamp; provided by useTradeHistory
+  // so position cards can render "held Xm" consistently. If a card has no entry in the map,
+  // fallback to "--" via null.
+  openSinceByPosKey: Map<string, number>;
+};
+
+export const LiveTab = ({ positions, orders, accounts, openSinceByPosKey }: LiveTabProps) => {
+  const hasAnything = positions.length > 0 || orders.length > 0;
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <RiskSummary positions={positions} accounts={accounts} />
+
+      <div className="bg-[var(--bg-panel)] rounded-lg p-3">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Open Positions
+          </h2>
+          <span className="text-[10px] text-[var(--text-muted)]">{positions.length}</span>
+        </div>
+        {positions.length === 0 ? (
+          <div className="text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)] rounded-lg p-6 text-center">
+            {hasAnything ? "No matching open positions" : "No open positions"}
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {positions.map((p) => {
+              const posKey = `${p.dataSourceId}:${p.symbol}:${p.account}`;
+              return (
+                <PositionCard
+                  key={posKey}
+                  position={p}
+                  openSinceTs={openSinceByPosKey.get(posKey) ?? null}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <OrderTape orders={orders} />
+    </div>
+  );
+};

--- a/src/components/OrderTape.tsx
+++ b/src/components/OrderTape.tsx
@@ -70,7 +70,7 @@ export const OrderTape = ({ orders }: OrderTapeProps) => {
                   <td className="px-4 py-2 text-[var(--text-secondary)]">
                     {o.account === "shadow" ? (
                       <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
-                        shadow
+                        Shadow
                       </span>
                     ) : (
                       o.account

--- a/src/components/OrderTape.tsx
+++ b/src/components/OrderTape.tsx
@@ -1,0 +1,87 @@
+import type { SimOrder } from "../hooks/useTradingSimulation";
+
+type OrderTapeProps = {
+  orders: SimOrder[];
+};
+
+const statusTone = (status: SimOrder["status"]): string => {
+  switch (status) {
+    case "Filled":
+      return "bg-[var(--accent-green)]/15 text-[var(--accent-green)]";
+    case "Working":
+      return "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
+    case "Cancelled":
+      return "bg-[var(--accent-red)]/15 text-[var(--accent-red)]";
+  }
+};
+
+export const OrderTape = ({ orders }: OrderTapeProps) => {
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Order Tape
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">
+          {orders.length > 0 ? `${orders.length} recent` : "live-updating"}
+        </span>
+      </div>
+      <div className="flex-1 overflow-auto max-h-[260px]">
+        {orders.length === 0 ? (
+          <div className="px-4 py-5 text-center text-sm text-[var(--text-secondary)]">
+            No orders yet
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+                <th className="text-left px-4 py-2 font-medium">Time</th>
+                <th className="text-left px-4 py-2 font-medium">Symbol</th>
+                <th className="text-left px-4 py-2 font-medium">Side</th>
+                <th className="text-right px-4 py-2 font-medium">Qty</th>
+                <th className="text-right px-4 py-2 font-medium">Price</th>
+                <th className="text-left px-4 py-2 font-medium">Status</th>
+                <th className="text-left px-4 py-2 font-medium">Algo</th>
+                <th className="text-left px-4 py-2 font-medium">Account</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((o) => (
+                <tr key={o.id} className="border-b border-[var(--border)] last:border-0">
+                  <td className="px-4 py-2 text-[var(--text-secondary)] font-mono text-[11px]">
+                    {o.time}
+                  </td>
+                  <td className="px-4 py-2 font-medium">{o.symbol}</td>
+                  <td
+                    className={`px-4 py-2 ${
+                      o.side === "Buy" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"
+                    }`}
+                  >
+                    {o.side}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{o.qty}</td>
+                  <td className="px-4 py-2 text-right font-mono tabular-nums">{o.price}</td>
+                  <td className="px-4 py-2">
+                    <span className={`text-[10px] px-2 py-0.5 rounded ${statusTone(o.status)}`}>
+                      {o.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-[var(--text-secondary)]">{o.algo || "—"}</td>
+                  <td className="px-4 py-2 text-[var(--text-secondary)]">
+                    {o.account === "shadow" ? (
+                      <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
+                        shadow
+                      </span>
+                    ) : (
+                      o.account
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -1,0 +1,56 @@
+import type { BreakdownRow, LiveShadowPair } from "../lib/tradingView";
+import { BreakdownTable } from "./BreakdownTable";
+import { LiveShadowDelta } from "./LiveShadowDelta";
+
+type PerformanceTabProps = {
+  byAlgo: BreakdownRow[];
+  bySymbol: BreakdownRow[];
+  byAccount: BreakdownRow[];
+  liveVsShadow: LiveShadowPair[];
+  onOpenAlgoInEditor: (algoId: number) => void;
+  onViewAccountInAlgos: (account: string) => void;
+};
+
+export const PerformanceTab = ({
+  byAlgo,
+  bySymbol,
+  byAccount,
+  liveVsShadow,
+  onOpenAlgoInEditor,
+  onViewAccountInAlgos,
+}: PerformanceTabProps) => {
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <BreakdownTable
+        title="By Algo"
+        labelHeader="Algo"
+        rows={byAlgo}
+        emptyMessage="No completed trades yet — breakdowns appear after your first roundtrip"
+        onRowDeepLink={(row) => {
+          const id = Number(row.key);
+          if (Number.isFinite(id) && id > 0) onOpenAlgoInEditor(id);
+        }}
+        deepLinkLabel="Open in Editor"
+      />
+
+      <div className="grid grid-cols-2 gap-3">
+        <BreakdownTable
+          title="By Symbol"
+          labelHeader="Symbol"
+          rows={bySymbol}
+          emptyMessage="No completed trades yet"
+        />
+        <BreakdownTable
+          title="By Account"
+          labelHeader="Account"
+          rows={byAccount}
+          emptyMessage="No completed trades yet"
+          onRowDeepLink={(row) => onViewAccountInAlgos(row.key)}
+          deepLinkLabel="View algos for this account"
+        />
+      </div>
+
+      <LiveShadowDelta pairs={liveVsShadow} />
+    </div>
+  );
+};

--- a/src/components/PositionCard.tsx
+++ b/src/components/PositionCard.tsx
@@ -11,7 +11,7 @@ export const PositionCard = ({ position, openSinceTs }: PositionCardProps) => {
   const isShadow = position.account === "shadow";
   const sideColor = position.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
   const now = Date.now();
-  const held = openSinceTs ? formatDuration(openSinceTs, now) : "--";
+  const held = openSinceTs ? formatDuration(openSinceTs, now) : "—";
 
   return (
     <div className="flex-1 min-w-[240px] bg-[var(--bg-elevated)] border border-[var(--border)] rounded-lg p-3">

--- a/src/components/PositionCard.tsx
+++ b/src/components/PositionCard.tsx
@@ -1,0 +1,46 @@
+import type { Position } from "../hooks/useTradingSimulation";
+import { formatPrice } from "../hooks/useTradingSimulation";
+import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
+
+type PositionCardProps = {
+  position: Position;
+  openSinceTs: number | null;
+};
+
+export const PositionCard = ({ position, openSinceTs }: PositionCardProps) => {
+  const isShadow = position.account === "shadow";
+  const sideColor = position.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
+  const now = Date.now();
+  const held = openSinceTs ? formatDuration(openSinceTs, now) : "--";
+
+  return (
+    <div className="flex-1 min-w-[240px] bg-[var(--bg-elevated)] border border-[var(--border)] rounded-lg p-3">
+      <div className="flex items-center justify-between mb-1">
+        <div className="text-sm font-semibold">{position.symbol}</div>
+        <span
+          className={`text-[9px] uppercase tracking-wider px-2 py-0.5 rounded font-semibold ${
+            isShadow
+              ? "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]"
+              : "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
+          }`}
+        >
+          {isShadow ? "Shadow" : "Live"}
+        </span>
+      </div>
+      <div className="text-[10px] text-[var(--text-secondary)] mb-2 truncate">
+        {position.algo || "—"} · {position.account}
+      </div>
+      <div className="flex items-center justify-between mb-1">
+        <span className={`text-sm font-medium ${sideColor}`}>
+          {position.side} {position.qty}
+        </span>
+        <span className={`text-sm font-semibold font-mono tabular-nums ${pnlColorClass(position.pnl)}`}>
+          {formatPnl(position.pnl)}
+        </span>
+      </div>
+      <div className="text-[10px] text-[var(--text-secondary)] font-mono">
+        entry {formatPrice(position.symbol, position.avgPrice)} · held {held}
+      </div>
+    </div>
+  );
+};

--- a/src/components/RiskSummary.tsx
+++ b/src/components/RiskSummary.tsx
@@ -31,8 +31,8 @@ export const RiskSummary = ({ positions, accounts }: RiskSummaryProps) => {
   const openRisk = positions.reduce((s, p) => s + (p.pnl < 0 ? Math.abs(p.pnl) : 0), 0);
   const openPositions = positions.length;
   const portfolioHeat =
-    totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(2) : "--";
-  const marginUsed = totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(0) : "--";
+    totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(2) : "—";
+  const marginUsed = totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(0) : "—";
 
   return (
     <div className="grid grid-cols-5 gap-4 p-3 bg-[var(--bg-panel)] rounded-lg">
@@ -43,13 +43,13 @@ export const RiskSummary = ({ positions, accounts }: RiskSummaryProps) => {
       />
       <Cell
         label="Portfolio Heat"
-        value={portfolioHeat === "--" ? "--" : `${portfolioHeat}%`}
+        value={portfolioHeat === "—" ? "—" : `${portfolioHeat}%`}
       />
       <Cell
         label="Buying Power"
-        value={totalBuyingPower > 0 ? formatDollars(totalBuyingPower) : "--"}
+        value={totalBuyingPower > 0 ? formatDollars(totalBuyingPower) : "—"}
       />
-      <Cell label="Margin Used" value={marginUsed === "--" ? "--" : `${marginUsed}%`} />
+      <Cell label="Margin Used" value={marginUsed === "—" ? "—" : `${marginUsed}%`} />
       <Cell label="Open Positions" value={`${openPositions}`} />
     </div>
   );

--- a/src/components/RiskSummary.tsx
+++ b/src/components/RiskSummary.tsx
@@ -1,0 +1,56 @@
+import type { Position } from "../hooks/useTradingSimulation";
+
+type AccountSummary = {
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+type RiskSummaryProps = {
+  positions: Position[];
+  accounts: Record<string, AccountSummary>;
+};
+
+const Cell = ({ label, value, tone }: { label: string; value: string; tone?: string }) => (
+  <div className="flex-1 min-w-0">
+    <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+      {label}
+    </div>
+    <div className={`text-base font-semibold font-mono tabular-nums ${tone ?? ""}`}>{value}</div>
+  </div>
+);
+
+const formatDollars = (v: number): string => `$${Math.abs(v).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+
+export const RiskSummary = ({ positions, accounts }: RiskSummaryProps) => {
+  const liveAccounts = Object.entries(accounts).filter(([name]) => name !== "shadow");
+  const totalBuyingPower = liveAccounts.reduce((s, [, a]) => s + a.buying_power, 0);
+
+  // Open risk = sum of negative unrealized P&Ls across open positions (how much we could still lose
+  // if every position adversely hit zero at current prices). A crude but useful gauge.
+  const openRisk = positions.reduce((s, p) => s + (p.pnl < 0 ? Math.abs(p.pnl) : 0), 0);
+  const openPositions = positions.length;
+  const portfolioHeat =
+    totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(2) : "--";
+  const marginUsed = totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(0) : "--";
+
+  return (
+    <div className="grid grid-cols-5 gap-4 p-3 bg-[var(--bg-panel)] rounded-lg">
+      <Cell
+        label="Open Risk"
+        value={openRisk > 0 ? `-${formatDollars(openRisk)}` : "$0"}
+        tone={openRisk > 0 ? "text-[var(--accent-yellow)]" : ""}
+      />
+      <Cell
+        label="Portfolio Heat"
+        value={portfolioHeat === "--" ? "--" : `${portfolioHeat}%`}
+      />
+      <Cell
+        label="Buying Power"
+        value={totalBuyingPower > 0 ? formatDollars(totalBuyingPower) : "--"}
+      />
+      <Cell label="Margin Used" value={marginUsed === "--" ? "--" : `${marginUsed}%`} />
+      <Cell label="Open Positions" value={`${openPositions}`} />
+    </div>
+  );
+};

--- a/src/components/RiskSummary.tsx
+++ b/src/components/RiskSummary.tsx
@@ -20,19 +20,29 @@ const Cell = ({ label, value, tone }: { label: string; value: string; tone?: str
   </div>
 );
 
-const formatDollars = (v: number): string => `$${Math.abs(v).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+const formatDollars = (v: number): string =>
+  `$${Math.abs(v).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 
 export const RiskSummary = ({ positions, accounts }: RiskSummaryProps) => {
   const liveAccounts = Object.entries(accounts).filter(([name]) => name !== "shadow");
   const totalBuyingPower = liveAccounts.reduce((s, [, a]) => s + a.buying_power, 0);
 
-  // Open risk = sum of negative unrealized P&Ls across open positions (how much we could still lose
-  // if every position adversely hit zero at current prices). A crude but useful gauge.
-  const openRisk = positions.reduce((s, p) => s + (p.pnl < 0 ? Math.abs(p.pnl) : 0), 0);
-  const openPositions = positions.length;
+  // Risk / exposure is reported against live accounts only: shadow has no buying power
+  // and its drawdown doesn't risk real capital, so including it would inflate the heat %
+  // against a denominator that excludes it.
+  const livePositions = positions.filter((p) => p.account !== "shadow");
+  const openPositions = livePositions.length;
+
+  // Open risk: sum of currently-underwater unrealized P&L across live positions (how much
+  // is already drawn down at current prices). A rough gauge of "how much am I holding onto").
+  const openRisk = livePositions.reduce((s, p) => s + (p.pnl < 0 ? Math.abs(p.pnl) : 0), 0);
+
+  // Open exposure: total notional value at work (qty × avgPrice). Different quantity than
+  // open risk — shows how much capital the strategies are actively committing.
+  const openExposure = livePositions.reduce((s, p) => s + p.qty * p.avgPrice, 0);
+
   const portfolioHeat =
     totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(2) : "—";
-  const marginUsed = totalBuyingPower > 0 ? ((openRisk / totalBuyingPower) * 100).toFixed(0) : "—";
 
   return (
     <div className="grid grid-cols-5 gap-4 p-3 bg-[var(--bg-panel)] rounded-lg">
@@ -49,7 +59,10 @@ export const RiskSummary = ({ positions, accounts }: RiskSummaryProps) => {
         label="Buying Power"
         value={totalBuyingPower > 0 ? formatDollars(totalBuyingPower) : "—"}
       />
-      <Cell label="Margin Used" value={marginUsed === "—" ? "—" : `${marginUsed}%`} />
+      <Cell
+        label="Open Exposure"
+        value={openExposure > 0 ? formatDollars(openExposure) : "$0"}
+      />
       <Cell label="Open Positions" value={`${openPositions}`} />
     </div>
   );

--- a/src/components/RollingMetricsChart.tsx
+++ b/src/components/RollingMetricsChart.tsx
@@ -15,10 +15,21 @@ const PICKERS: { id: RollingMetric; label: string }[] = [
 
 export const RollingMetricsChart = ({ sharpe, winRate, expectancy }: RollingMetricsChartProps) => {
   const [metric, setMetric] = useState<RollingMetric>("sharpe");
+  // Resize tick — bumped by the ResizeObserver so the draw effect re-runs when the
+  // container's width changes (tab switches, window resizes, first-paint race).
+  const [resizeTick, setResizeTick] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const series = metric === "sharpe" ? sharpe : metric === "winRate" ? winRate : expectancy;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const ro = new ResizeObserver(() => setResizeTick((t) => t + 1));
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -89,7 +100,7 @@ export const RollingMetricsChart = ({ sharpe, winRate, expectancy }: RollingMetr
     ctx.arc(lx, ly, 3, 0, Math.PI * 2);
     ctx.fillStyle = lastVal >= 0 ? "#00d68f" : "#ff4d6a";
     ctx.fill();
-  }, [series]);
+  }, [series, resizeTick]);
 
   const partialWindowNotice =
     series.length > 0 && series[0].windowSize < 20

--- a/src/components/RollingMetricsChart.tsx
+++ b/src/components/RollingMetricsChart.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useRef } from "react";
+import type { RollingMetric, RollingPoint } from "../hooks/useRollingMetrics";
+
+type RollingMetricsChartProps = {
+  sharpe: RollingPoint[];
+  winRate: RollingPoint[];
+  expectancy: RollingPoint[];
+};
+
+const PICKERS: { id: RollingMetric; label: string }[] = [
+  { id: "sharpe", label: "Sharpe" },
+  { id: "winRate", label: "Win %" },
+  { id: "expectancy", label: "Expectancy" },
+];
+
+export const RollingMetricsChart = ({ sharpe, winRate, expectancy }: RollingMetricsChartProps) => {
+  const [metric, setMetric] = useState<RollingMetric>("sharpe");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const series = metric === "sharpe" ? sharpe : metric === "winRate" ? winRate : expectancy;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+    const rect = container.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const w = rect.width;
+    const h = rect.height;
+    ctx.clearRect(0, 0, w, h);
+
+    if (series.length < 2) {
+      ctx.fillStyle = "rgba(136, 136, 160, 0.5)";
+      ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      const msg =
+        series.length === 0
+          ? "No rolling data yet"
+          : `Partial window · ${series[0].windowSize}/20 trades`;
+      ctx.fillText(msg, w / 2, h / 2);
+      return;
+    }
+
+    const values = series.map((p) => p.value);
+    const vMin = Math.min(0, ...values);
+    const vMax = Math.max(0, ...values);
+    const vRange = vMax - vMin || 1;
+    const pad = vRange * 0.1;
+    const toX = (i: number) => (i / Math.max(series.length - 1, 1)) * w;
+    const toY = (v: number) => h - ((v - vMin + pad) / (vRange + pad * 2)) * h;
+
+    // Zero line
+    const zeroY = toY(0);
+    ctx.strokeStyle = "rgba(136, 136, 160, 0.2)";
+    ctx.setLineDash([4, 4]);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, zeroY);
+    ctx.lineTo(w, zeroY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Line
+    const lastVal = values[values.length - 1];
+    ctx.strokeStyle = lastVal >= 0 ? "#00d68f" : "#ff4d6a";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    series.forEach((p, i) => {
+      const x = toX(i);
+      const y = toY(p.value);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // Last point dot
+    const lx = toX(series.length - 1);
+    const ly = toY(lastVal);
+    ctx.beginPath();
+    ctx.arc(lx, ly, 3, 0, Math.PI * 2);
+    ctx.fillStyle = lastVal >= 0 ? "#00d68f" : "#ff4d6a";
+    ctx.fill();
+  }, [series]);
+
+  const partialWindowNotice =
+    series.length > 0 && series[0].windowSize < 20
+      ? ` · partial ${series[0].windowSize}/20`
+      : "";
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Rolling Metrics
+          <span className="font-normal normal-case tracking-normal text-[var(--text-muted)]">
+            {" "}
+            · 20-trade window{partialWindowNotice}
+          </span>
+        </h2>
+        <div className="flex gap-1">
+          {PICKERS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setMetric(p.id)}
+              className={`text-[10px] px-2 py-1 rounded transition-colors ${
+                metric === p.id
+                  ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div ref={containerRef} className="flex-1 min-h-0 px-4 py-3">
+        <canvas ref={canvasRef} className="w-full h-full" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/RoundtripsTable.tsx
+++ b/src/components/RoundtripsTable.tsx
@@ -1,0 +1,109 @@
+import type { Roundtrip } from "../lib/tradingView";
+import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
+
+type RoundtripsTableProps = {
+  roundtrips: Roundtrip[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+const formatHm = (ts: number): string => {
+  const d = new Date(ts);
+  return d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" });
+};
+
+export const RoundtripsTable = ({
+  roundtrips,
+  selectedId,
+  onSelect,
+}: RoundtripsTableProps) => {
+  const sorted = [...roundtrips].sort((a, b) => b.closeTimestamp - a.closeTimestamp);
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Roundtrips
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">{sorted.length}</span>
+      </div>
+      {sorted.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)] px-4 py-6">
+          No completed trades yet
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-[var(--bg-panel)] z-10">
+              <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
+                <th className="text-left px-3 py-2 font-medium">Opened</th>
+                <th className="text-left px-3 py-2 font-medium">Closed</th>
+                <th className="text-left px-3 py-2 font-medium">Symbol</th>
+                <th className="text-left px-3 py-2 font-medium">Side</th>
+                <th className="text-right px-3 py-2 font-medium">Qty</th>
+                <th className="text-right px-3 py-2 font-medium">Dur</th>
+                <th className="text-right px-3 py-2 font-medium">R</th>
+                <th className="text-right px-3 py-2 font-medium">P&L</th>
+                <th className="text-left px-3 py-2 font-medium">Algo</th>
+                <th className="text-left px-3 py-2 font-medium">Account</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((r) => {
+                const isSelected = selectedId === r.id;
+                return (
+                  <tr
+                    key={r.id}
+                    onClick={() => onSelect(r.id)}
+                    className={`border-b border-[var(--border)] last:border-0 cursor-pointer transition-colors ${
+                      isSelected
+                        ? "bg-[var(--accent-blue)]/10 border-l-2 border-l-[var(--accent-blue)]"
+                        : "hover:bg-[var(--bg-secondary)]"
+                    }`}
+                  >
+                    <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">
+                      {formatHm(r.openTimestamp)}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">
+                      {formatHm(r.closeTimestamp)}
+                    </td>
+                    <td className="px-3 py-2 font-medium">{r.symbol}</td>
+                    <td
+                      className={`px-3 py-2 ${
+                        r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"
+                      }`}
+                    >
+                      {r.side}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums">{r.qty}</td>
+                    <td className="px-3 py-2 text-right text-[var(--text-secondary)] font-mono tabular-nums">
+                      {formatDuration(r.openTimestamp, r.closeTimestamp)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono tabular-nums">
+                      {r.rMultiple !== null ? r.rMultiple.toFixed(1) : "—"}
+                    </td>
+                    <td className={`px-3 py-2 text-right font-mono tabular-nums font-medium ${pnlColorClass(r.pnl)}`}>
+                      {formatPnl(r.pnl)}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] truncate max-w-[120px]">
+                      {r.algo || "—"}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">
+                      {r.isShadow ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
+                          shadow
+                        </span>
+                      ) : (
+                        r.account
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/RoundtripsTable.tsx
+++ b/src/components/RoundtripsTable.tsx
@@ -91,7 +91,7 @@ export const RoundtripsTable = ({
                     <td className="px-3 py-2 text-[var(--text-secondary)]">
                       {r.isShadow ? (
                         <span className="text-[10px] px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]">
-                          shadow
+                          Shadow
                         </span>
                       ) : (
                         r.account

--- a/src/components/SessionHeatmap.tsx
+++ b/src/components/SessionHeatmap.tsx
@@ -1,0 +1,71 @@
+import type { HeatCell } from "../lib/tradingView";
+
+type SessionHeatmapProps = {
+  grid: HeatCell[][];
+};
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const cellColor = (cell: HeatCell, absMax: number): string => {
+  if (cell.trades === 0) return "var(--bg-elevated)";
+  const intensity = Math.min(1, Math.abs(cell.pnl) / (absMax || 1));
+  const alpha = 0.15 + intensity * 0.75;
+  return cell.pnl >= 0
+    ? `rgba(0, 214, 143, ${alpha.toFixed(2)})`
+    : `rgba(255, 77, 106, ${alpha.toFixed(2)})`;
+};
+
+export const SessionHeatmap = ({ grid }: SessionHeatmapProps) => {
+  const totalTrades = grid.reduce((s, row) => s + row.reduce((a, c) => a + c.trades, 0), 0);
+  const absMax = Math.max(
+    1,
+    ...grid.flatMap((row) => row.map((c) => Math.abs(c.pnl))),
+  );
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Hour × Day Heatmap <span className="font-normal normal-case tracking-normal text-[var(--text-muted)]">· P&L</span>
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">{totalTrades} trades</span>
+      </div>
+      <div className="flex-1 px-4 py-3 overflow-auto">
+        {totalTrades === 0 ? (
+          <div className="h-full flex items-center justify-center text-sm text-[var(--text-secondary)]">
+            No completed trades yet
+          </div>
+        ) : (
+          <div className="flex flex-col gap-[2px]">
+            <div className="flex gap-[2px] pl-[40px] text-[9px] text-[var(--text-muted)] font-mono">
+              {Array.from({ length: 24 }, (_, h) => (
+                <div key={h} className="flex-1 text-center">
+                  {h % 3 === 0 ? h : ""}
+                </div>
+              ))}
+            </div>
+            {grid.map((row, d) => (
+              <div key={d} className="flex gap-[2px] items-center">
+                <div className="w-[36px] text-[10px] text-[var(--text-secondary)] font-mono">
+                  {DAY_LABELS[d]}
+                </div>
+                {row.map((cell, h) => (
+                  <div
+                    key={h}
+                    className="flex-1 h-[16px] rounded-sm"
+                    style={{ backgroundColor: cellColor(cell, absMax) }}
+                    title={
+                      cell.trades === 0
+                        ? "No trades"
+                        : `${cell.trades} trades · ${cell.winRate}% win · ${cell.pnl >= 0 ? "+" : "-"}$${Math.abs(cell.pnl).toFixed(2)}`
+                    }
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/TradeDetailPanel.tsx
+++ b/src/components/TradeDetailPanel.tsx
@@ -1,0 +1,195 @@
+import { useEffect } from "react";
+import type { Roundtrip } from "../lib/tradingView";
+import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
+import { formatPrice } from "../hooks/useTradingSimulation";
+
+type TradeDetailPanelProps = {
+  roundtrip: Roundtrip | null;
+  onClose: () => void;
+};
+
+const formatFullTime = (ts: number): string => {
+  const d = new Date(ts);
+  return d.toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+};
+
+const CHART_W = 320;
+const CHART_H = 80;
+
+const samplePoints = (
+  samples: { t: number; pnl: number }[],
+  width: number,
+  height: number,
+): { zeroY: number; path: string } => {
+  if (samples.length < 2) return { zeroY: height / 2, path: "" };
+  const tMin = samples[0].t;
+  const tMax = samples[samples.length - 1].t;
+  const tRange = Math.max(tMax - tMin, 1);
+  const pnls = samples.map((s) => s.pnl);
+  const vMin = Math.min(0, ...pnls);
+  const vMax = Math.max(0, ...pnls);
+  const vRange = vMax - vMin || 1;
+  const pad = vRange * 0.1;
+  const toX = (t: number) => ((t - tMin) / tRange) * width;
+  const toY = (v: number) => height - ((v - vMin + pad) / (vRange + pad * 2)) * height;
+  const path = samples
+    .map((s, i) => `${i === 0 ? "M" : "L"}${toX(s.t).toFixed(1)},${toY(s.pnl).toFixed(1)}`)
+    .join(" ");
+  return { zeroY: toY(0), path };
+};
+
+export const TradeDetailPanel = ({ roundtrip, onClose }: TradeDetailPanelProps) => {
+  useEffect(() => {
+    if (!roundtrip) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [roundtrip, onClose]);
+
+  if (!roundtrip) {
+    return (
+      <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)]">
+        Click a roundtrip to see execution detail
+      </div>
+    );
+  }
+
+  const r = roundtrip;
+  const sideColor = r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
+  const { zeroY, path } = samplePoints(r.maeMfeSamples, CHART_W, CHART_H);
+  const strokeColor = r.pnl >= 0 ? "var(--accent-green)" : "var(--accent-red)";
+
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <h2 className="text-sm font-semibold truncate">{r.symbol}</h2>
+            <span className={`text-xs font-medium ${sideColor}`}>{r.side}</span>
+            {r.isShadow && (
+              <span className="text-[9px] uppercase tracking-wider px-2 py-0.5 rounded bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)] font-semibold">
+                Shadow
+              </span>
+            )}
+          </div>
+          <div className="text-[11px] text-[var(--text-secondary)] font-mono">
+            {formatFullTime(r.openTimestamp)} → {formatFullTime(r.closeTimestamp)} · {r.algo || "—"} ·{" "}
+            {r.account}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-lg leading-none"
+          title="Close (Esc)"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="overflow-auto p-3 flex flex-col gap-3">
+        <div className="grid grid-cols-3 gap-3">
+          <div className="bg-[var(--bg-elevated)] rounded-md p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-0.5">
+              P&L
+            </div>
+            <div className={`text-base font-semibold font-mono tabular-nums ${pnlColorClass(r.pnl)}`}>
+              {formatPnl(r.pnl)}
+            </div>
+          </div>
+          <div className="bg-[var(--bg-elevated)] rounded-md p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-0.5">
+              R
+            </div>
+            <div className="text-base font-semibold font-mono tabular-nums">
+              {r.rMultiple !== null ? r.rMultiple.toFixed(2) : "—"}
+            </div>
+          </div>
+          <div className="bg-[var(--bg-elevated)] rounded-md p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-0.5">
+              Dur
+            </div>
+            <div className="text-base font-semibold font-mono tabular-nums">
+              {formatDuration(r.openTimestamp, r.closeTimestamp)}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+            Execution
+          </div>
+          <div className="text-sm space-y-1 font-mono">
+            <div>
+              <span className={r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"}>
+                {r.side === "Long" ? "Buy" : "Sell"} {r.qty} @ {formatPrice(r.symbol, r.entryPrice)}
+              </span>{" "}
+              <span className="text-[var(--text-muted)]">· {formatFullTime(r.openTimestamp)}</span>
+            </div>
+            <div>
+              <span className={r.side === "Long" ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"}>
+                {r.side === "Long" ? "Sell" : "Buy"} {r.qty} @ {formatPrice(r.symbol, r.exitPrice)}
+              </span>{" "}
+              <span className="text-[var(--text-muted)]">· {formatFullTime(r.closeTimestamp)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+            Excursion
+          </div>
+          <div className="text-sm space-y-1 font-mono">
+            <div>
+              <span className="text-[var(--text-secondary)]">MAE:</span>{" "}
+              <span className="text-[var(--accent-red)]">
+                {r.mae >= 0 ? "$0.00" : formatPnl(r.mae)}
+              </span>
+            </div>
+            <div>
+              <span className="text-[var(--text-secondary)]">MFE:</span>{" "}
+              <span className="text-[var(--accent-green)]">
+                {r.mfe <= 0 ? "$0.00" : formatPnl(r.mfe)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+            Unrealized P&L over hold
+          </div>
+          {path ? (
+            <svg
+              viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+              preserveAspectRatio="none"
+              width="100%"
+              height={CHART_H}
+              className="bg-[var(--bg-elevated)] rounded"
+            >
+              <line
+                x1={0}
+                y1={zeroY}
+                x2={CHART_W}
+                y2={zeroY}
+                stroke="rgba(136,136,160,0.3)"
+                strokeWidth={1}
+                strokeDasharray="4 4"
+              />
+              <path d={path} fill="none" stroke={strokeColor} strokeWidth={1.5} />
+            </svg>
+          ) : (
+            <div className="text-[var(--text-muted)] text-xs">Not enough samples</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TradeDetailPanel.tsx
+++ b/src/components/TradeDetailPanel.tsx
@@ -89,6 +89,7 @@ export const TradeDetailPanel = ({ roundtrip, onClose }: TradeDetailPanelProps) 
           onClick={onClose}
           className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-lg leading-none"
           title="Close (Esc)"
+          aria-label="Close trade detail"
         >
           ×
         </button>

--- a/src/components/TradeDetailPanel.tsx
+++ b/src/components/TradeDetailPanel.tsx
@@ -4,7 +4,10 @@ import { formatDuration, formatPnl, pnlColorClass } from "../lib/tradingView";
 import { formatPrice } from "../hooks/useTradingSimulation";
 
 type TradeDetailPanelProps = {
-  roundtrip: Roundtrip | null;
+  // TradesTab only mounts this panel when a roundtrip is selected, so the prop is
+  // always non-null. Changing the prop to `Roundtrip | null` would require an
+  // in-component empty state that would be unreachable in practice.
+  roundtrip: Roundtrip;
   onClose: () => void;
 };
 
@@ -45,21 +48,12 @@ const samplePoints = (
 
 export const TradeDetailPanel = ({ roundtrip, onClose }: TradeDetailPanelProps) => {
   useEffect(() => {
-    if (!roundtrip) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [roundtrip, onClose]);
-
-  if (!roundtrip) {
-    return (
-      <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden h-full items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)]">
-        Click a roundtrip to see execution detail
-      </div>
-    );
-  }
+  }, [onClose]);
 
   const r = roundtrip;
   const sideColor = r.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";

--- a/src/components/TradeDistribution.tsx
+++ b/src/components/TradeDistribution.tsx
@@ -1,0 +1,61 @@
+import type { DistributionBucket } from "../lib/tradingView";
+
+type TradeDistributionProps = {
+  buckets: DistributionBucket[];
+  totalTrades: number;
+};
+
+export const TradeDistribution = ({ buckets, totalTrades }: TradeDistributionProps) => {
+  if (buckets.length === 0 || totalTrades === 0) {
+    return (
+      <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+        <div className="px-4 py-2.5 border-b border-[var(--border)]">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Trade P&L Distribution
+          </h2>
+        </div>
+        <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)]">
+          No completed trades yet
+        </div>
+      </div>
+    );
+  }
+
+  const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+  return (
+    <div className="bg-[var(--bg-panel)] rounded-lg flex flex-col h-[220px]">
+      <div className="px-4 py-2.5 border-b border-[var(--border)] flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+          Trade P&L Distribution
+        </h2>
+        <span className="text-[10px] text-[var(--text-muted)]">{totalTrades} trades</span>
+      </div>
+      <div className="flex-1 px-4 py-3 flex flex-col">
+        <div className="flex-1 flex items-end gap-[2px]">
+          {buckets.map((b, i) => {
+            const height = `${(b.count / maxCount) * 100}%`;
+            const isNegative = b.hi <= 0;
+            const color = isNegative
+              ? "bg-[var(--accent-red)]"
+              : b.lo >= 0
+                ? "bg-[var(--accent-green)]"
+                : "bg-[var(--text-muted)]";
+            return (
+              <div
+                key={i}
+                className={`flex-1 rounded-t ${color}`}
+                style={{ height, minHeight: b.count > 0 ? "2px" : "0" }}
+                title={`${b.count} trades · ${b.lo.toFixed(2)} to ${b.hi.toFixed(2)}`}
+              />
+            );
+          })}
+        </div>
+        <div className="flex justify-between text-[10px] text-[var(--text-muted)] mt-2 font-mono">
+          <span>{buckets[0].lo.toFixed(0)}</span>
+          <span>0</span>
+          <span>+{buckets[buckets.length - 1].hi.toFixed(0)}</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TradesTab.tsx
+++ b/src/components/TradesTab.tsx
@@ -1,0 +1,30 @@
+import type { Roundtrip } from "../lib/tradingView";
+import { RoundtripsTable } from "./RoundtripsTable";
+import { TradeDetailPanel } from "./TradeDetailPanel";
+
+type TradesTabProps = {
+  roundtrips: Roundtrip[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+};
+
+export const TradesTab = ({ roundtrips, selectedId, onSelect }: TradesTabProps) => {
+  const selected = selectedId ? roundtrips.find((r) => r.id === selectedId) ?? null : null;
+
+  return (
+    <div className="flex gap-3 p-3 h-full min-h-0">
+      <div className={`flex-1 min-h-0 ${selected ? "basis-3/5" : ""}`}>
+        <RoundtripsTable
+          roundtrips={roundtrips}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      </div>
+      {selected && (
+        <div className="basis-2/5 min-h-0">
+          <TradeDetailPanel roundtrip={selected} onClose={() => onSelect(null)} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/TradingFilterBar.tsx
+++ b/src/components/TradingFilterBar.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from "react";
+import type { Filters, Roundtrip } from "../lib/tradingView";
+import { formatChartLabel } from "../lib/tradingView";
+import type { Algo, AlgoRun } from "../types";
+import type { DataSource, Position, SimOrder } from "../hooks/useTradingSimulation";
+
+type TradingFilterBarProps = {
+  filters: Filters;
+  onFiltersChange: (next: Filters) => void;
+  algos: Algo[];
+  activeRuns: AlgoRun[];
+  dataSources: DataSource[];
+  positions: Position[];
+  orders: SimOrder[];
+  roundtrips: Roundtrip[];
+};
+
+// Build the union of every chart / account / algo that has appeared this session:
+//   connected charts + accounts seen on positions/orders/roundtrips + algos seen on runs/roundtrips.
+const deriveFilterPools = (
+  algos: Algo[],
+  activeRuns: AlgoRun[],
+  dataSources: DataSource[],
+  positions: Position[],
+  orders: SimOrder[],
+  roundtrips: Roundtrip[],
+): { charts: string[]; accounts: string[]; algos: { id: number; name: string }[] } => {
+  const chartIds = new Set<string>();
+  for (const ds of dataSources) chartIds.add(ds.id);
+  for (const p of positions) chartIds.add(p.dataSourceId);
+  for (const o of orders) chartIds.add(o.dataSourceId);
+  for (const r of roundtrips) chartIds.add(r.dataSourceId);
+
+  const accountSet = new Set<string>();
+  for (const p of positions) accountSet.add(p.account);
+  for (const o of orders) accountSet.add(o.account);
+  for (const r of roundtrips) accountSet.add(r.account);
+  for (const run of activeRuns) accountSet.add(run.account);
+
+  const algoMap = new Map<number, string>();
+  for (const run of activeRuns) {
+    const a = algos.find((x) => x.id === run.algo_id);
+    algoMap.set(run.algo_id, a?.name ?? `algo ${run.algo_id}`);
+  }
+  for (const r of roundtrips) {
+    if (r.algoId !== 0) algoMap.set(r.algoId, r.algo || `algo ${r.algoId}`);
+  }
+
+  return {
+    charts: [...chartIds].sort(),
+    accounts: [...accountSet].sort(),
+    algos: [...algoMap.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  };
+};
+
+type ChipProps = { active: boolean; onClick: () => void; children: ReactNode };
+
+const Chip = ({ active, onClick, children }: ChipProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`px-3 py-1 text-[11px] rounded-md transition-colors ${
+      active
+        ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
+        : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
+    }`}
+  >
+    {children}
+  </button>
+);
+
+export const TradingFilterBar = ({
+  filters,
+  onFiltersChange,
+  algos,
+  activeRuns,
+  dataSources,
+  positions,
+  orders,
+  roundtrips,
+}: TradingFilterBarProps) => {
+  const { charts, accounts, algos: algoPool } = deriveFilterPools(
+    algos,
+    activeRuns,
+    dataSources,
+    positions,
+    orders,
+    roundtrips,
+  );
+
+  if (charts.length === 0 && accounts.length === 0 && algoPool.length === 0) {
+    return null;
+  }
+
+  const setChart = (v: string | null) => onFiltersChange({ ...filters, chart: v });
+  const setAccount = (v: string | null) => onFiltersChange({ ...filters, account: v });
+  const setAlgo = (v: number | null) => onFiltersChange({ ...filters, algo: v });
+
+  return (
+    <div className="flex items-center gap-4 px-2 flex-wrap">
+      {charts.length > 0 && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">
+            Chart
+          </span>
+          <Chip active={filters.chart === null} onClick={() => setChart(null)}>
+            All
+          </Chip>
+          {charts.map((id) => (
+            <Chip
+              key={id}
+              active={filters.chart === id}
+              onClick={() => setChart(filters.chart === id ? null : id)}
+            >
+              {formatChartLabel(id)}
+            </Chip>
+          ))}
+        </div>
+      )}
+
+      {accounts.length > 0 && (
+        <>
+          <div className="w-px h-5 bg-[var(--border)]" />
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">
+              Account
+            </span>
+            <Chip active={filters.account === null} onClick={() => setAccount(null)}>
+              All
+            </Chip>
+            {accounts.map((acc) => (
+              <Chip
+                key={acc}
+                active={filters.account === acc}
+                onClick={() => setAccount(filters.account === acc ? null : acc)}
+              >
+                {acc === "shadow" ? "shadow" : acc}
+              </Chip>
+            ))}
+          </div>
+        </>
+      )}
+
+      {algoPool.length > 0 && (
+        <>
+          <div className="w-px h-5 bg-[var(--border)]" />
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">
+              Algo
+            </span>
+            <Chip active={filters.algo === null} onClick={() => setAlgo(null)}>
+              All
+            </Chip>
+            {algoPool.map((a) => (
+              <Chip
+                key={a.id}
+                active={filters.algo === a.id}
+                onClick={() => setAlgo(filters.algo === a.id ? null : a.id)}
+              >
+                {a.name}
+              </Chip>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/TradingFilterBar.tsx
+++ b/src/components/TradingFilterBar.tsx
@@ -136,7 +136,7 @@ export const TradingFilterBar = ({
                 active={filters.account === acc}
                 onClick={() => setAccount(filters.account === acc ? null : acc)}
               >
-                {acc === "shadow" ? "shadow" : acc}
+                {acc}
               </Chip>
             ))}
           </div>

--- a/src/components/TradingHero.tsx
+++ b/src/components/TradingHero.tsx
@@ -29,12 +29,12 @@ export const TradingHero = ({ kpis, equityLive, equityShadow, drawdown }: Tradin
         <Kpi label="Realized" value={formatDollars(kpis.realizedPnl)} tone={pnlColorClass(kpis.realizedPnl)} />
         <Kpi label="Unrealized" value={formatDollars(kpis.unrealizedPnl)} tone={pnlColorClass(kpis.unrealizedPnl)} />
         <Kpi label="Total" value={formatDollars(kpis.totalPnl)} tone={pnlColorClass(kpis.totalPnl)} />
-        <Kpi label="Win Rate" value={kpis.trades > 0 ? `${kpis.winRate}%` : "--"} />
+        <Kpi label="Win Rate" value={kpis.trades > 0 ? `${kpis.winRate}%` : "—"} />
         <Kpi label="Trades" value={`${kpis.trades}`} />
         <Kpi label="Sharpe" value={kpis.sharpe} />
         <Kpi
           label="Max DD"
-          value={kpis.maxDrawdown > 0 ? `-$${kpis.maxDrawdown.toFixed(2)}` : "--"}
+          value={kpis.maxDrawdown > 0 ? `-$${kpis.maxDrawdown.toFixed(2)}` : "—"}
           tone={kpis.maxDrawdown > 0 ? "text-[var(--accent-red)]" : ""}
         />
       </div>

--- a/src/components/TradingHero.tsx
+++ b/src/components/TradingHero.tsx
@@ -1,0 +1,72 @@
+import type { HeroKpis, EquityPoint, DrawdownPoint } from "../lib/tradingView";
+import { pnlColorClass } from "../lib/tradingView";
+import { EquityChart } from "./EquityChart";
+
+type TradingHeroProps = {
+  kpis: HeroKpis;
+  equityLive: EquityPoint[];
+  equityShadow: EquityPoint[];
+  drawdown: DrawdownPoint[];
+};
+
+const Kpi = ({ label, value, tone }: { label: string; value: string; tone?: string }) => (
+  <div className="flex-1 min-w-0">
+    <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1">
+      {label}
+    </div>
+    <div className={`text-lg font-semibold font-mono tabular-nums truncate ${tone ?? ""}`}>
+      {value}
+    </div>
+  </div>
+);
+
+const formatDollars = (v: number): string => `${v >= 0 ? "+" : "-"}$${Math.abs(v).toFixed(2)}`;
+
+export const TradingHero = ({ kpis, equityLive, equityShadow, drawdown }: TradingHeroProps) => {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-7 gap-4 p-4 bg-[var(--bg-panel)] rounded-lg">
+        <Kpi label="Realized" value={formatDollars(kpis.realizedPnl)} tone={pnlColorClass(kpis.realizedPnl)} />
+        <Kpi label="Unrealized" value={formatDollars(kpis.unrealizedPnl)} tone={pnlColorClass(kpis.unrealizedPnl)} />
+        <Kpi label="Total" value={formatDollars(kpis.totalPnl)} tone={pnlColorClass(kpis.totalPnl)} />
+        <Kpi label="Win Rate" value={kpis.trades > 0 ? `${kpis.winRate}%` : "--"} />
+        <Kpi label="Trades" value={`${kpis.trades}`} />
+        <Kpi label="Sharpe" value={kpis.sharpe} />
+        <Kpi
+          label="Max DD"
+          value={kpis.maxDrawdown > 0 ? `-$${kpis.maxDrawdown.toFixed(2)}` : "--"}
+          tone={kpis.maxDrawdown > 0 ? "text-[var(--accent-red)]" : ""}
+        />
+      </div>
+
+      <div className="bg-[var(--bg-panel)] rounded-lg p-4 flex flex-col h-[220px]">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Equity
+            <span className="ml-2 font-normal normal-case tracking-normal text-[var(--text-muted)]">
+              · with drawdown overlay
+            </span>
+          </h2>
+          <div className="flex items-center gap-3 text-[10px] text-[var(--text-secondary)]">
+            <span className="flex items-center gap-1.5">
+              <span className="w-3 h-[2px] bg-[var(--accent-green)]" />
+              Live
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span
+                className="w-3 h-[2px]"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(90deg, var(--accent-yellow) 50%, transparent 50%)",
+                  backgroundSize: "4px 2px",
+                }}
+              />
+              Shadow
+            </span>
+          </div>
+        </div>
+        <EquityChart live={equityLive} shadow={equityShadow} drawdown={drawdown} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/TradingTabs.tsx
+++ b/src/components/TradingTabs.tsx
@@ -1,0 +1,32 @@
+export type TradingTab = "live" | "performance" | "analytics" | "trades";
+
+type TradingTabsProps = {
+  activeTab: TradingTab;
+  onChange: (tab: TradingTab) => void;
+};
+
+const TABS: { id: TradingTab; label: string }[] = [
+  { id: "live", label: "Live" },
+  { id: "performance", label: "Performance" },
+  { id: "analytics", label: "Analytics" },
+  { id: "trades", label: "Trades" },
+];
+
+export const TradingTabs = ({ activeTab, onChange }: TradingTabsProps) => (
+  <div className="flex gap-1 border-b border-[var(--border)] px-2">
+    {TABS.map((tab) => (
+      <button
+        key={tab.id}
+        type="button"
+        onClick={() => onChange(tab.id)}
+        className={`px-4 py-2 text-sm transition-colors border-b-2 -mb-px ${
+          activeTab === tab.id
+            ? "border-[var(--accent-blue)] text-[var(--accent-blue)]"
+            : "border-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        }`}
+      >
+        {tab.label}
+      </button>
+    ))}
+  </div>
+);

--- a/src/hooks/useEquityTimeline.ts
+++ b/src/hooks/useEquityTimeline.ts
@@ -33,11 +33,11 @@ export type EquityTimeline = {
   shadowDrawdown: DrawdownPoint[];
 };
 
-const INITIAL: EquityPoint[] = [{ t: Date.now(), pnl: 0 }];
+const makeInitial = (): EquityPoint[] => [{ t: Date.now(), pnl: 0 }];
 
 export const useEquityTimeline = (roundtrips: Roundtrip[]): EquityTimeline => {
-  const [live, setLive] = useState<EquityPoint[]>(INITIAL);
-  const [shadow, setShadow] = useState<EquityPoint[]>(INITIAL);
+  const [live, setLive] = useState<EquityPoint[]>(makeInitial);
+  const [shadow, setShadow] = useState<EquityPoint[]>(makeInitial);
   const lastLiveRealizedRef = useRef<number | null>(null);
   const lastShadowCumulativeRef = useRef(0);
   const lastShadowCloseRef = useRef(0);

--- a/src/hooks/useEquityTimeline.ts
+++ b/src/hooks/useEquityTimeline.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
-import type { Roundtrip, EquityPoint, DrawdownPoint } from "../lib/tradingView";
+import type { Roundtrip, EquityPoint } from "../lib/tradingView";
 
 type AccountSnapshot = {
   name: string;
@@ -16,21 +16,9 @@ const pushCapped = (arr: EquityPoint[], point: EquityPoint): EquityPoint[] => {
   return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
 };
 
-const deriveDrawdown = (series: EquityPoint[]): DrawdownPoint[] => {
-  let peak = 0;
-  const out: DrawdownPoint[] = [];
-  for (const p of series) {
-    if (p.pnl > peak) peak = p.pnl;
-    out.push({ t: p.t, peak, pnl: p.pnl, underwater: peak - p.pnl });
-  }
-  return out;
-};
-
 export type EquityTimeline = {
   live: EquityPoint[];
   shadow: EquityPoint[];
-  liveDrawdown: DrawdownPoint[];
-  shadowDrawdown: DrawdownPoint[];
 };
 
 const makeInitial = (): EquityPoint[] => [{ t: Date.now(), pnl: 0 }];
@@ -72,8 +60,5 @@ export const useEquityTimeline = (roundtrips: Roundtrip[]): EquityTimeline => {
     setShadow((prev) => pushCapped(prev, { t: latestClose, pnl: rounded }));
   }, [roundtrips]);
 
-  const liveDrawdown = useMemo(() => deriveDrawdown(live), [live]);
-  const shadowDrawdown = useMemo(() => deriveDrawdown(shadow), [shadow]);
-
-  return { live, shadow, liveDrawdown, shadowDrawdown };
+  return { live, shadow };
 };

--- a/src/hooks/useEquityTimeline.ts
+++ b/src/hooks/useEquityTimeline.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect, useRef, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { Roundtrip, EquityPoint, DrawdownPoint } from "../lib/tradingView";
+
+type AccountSnapshot = {
+  name: string;
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
+
+const MAX_POINTS = 500;
+
+const pushCapped = (arr: EquityPoint[], point: EquityPoint): EquityPoint[] => {
+  const next = [...arr, point];
+  return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+};
+
+const deriveDrawdown = (series: EquityPoint[]): DrawdownPoint[] => {
+  let peak = 0;
+  const out: DrawdownPoint[] = [];
+  for (const p of series) {
+    if (p.pnl > peak) peak = p.pnl;
+    out.push({ t: p.t, peak, pnl: p.pnl, underwater: peak - p.pnl });
+  }
+  return out;
+};
+
+export type EquityTimeline = {
+  live: EquityPoint[];
+  shadow: EquityPoint[];
+  liveDrawdown: DrawdownPoint[];
+  shadowDrawdown: DrawdownPoint[];
+};
+
+const INITIAL: EquityPoint[] = [{ t: Date.now(), pnl: 0 }];
+
+export const useEquityTimeline = (roundtrips: Roundtrip[]): EquityTimeline => {
+  const [live, setLive] = useState<EquityPoint[]>(INITIAL);
+  const [shadow, setShadow] = useState<EquityPoint[]>(INITIAL);
+  const lastLiveRealizedRef = useRef<number | null>(null);
+  const lastShadowCumulativeRef = useRef(0);
+  const lastShadowCloseRef = useRef(0);
+
+  // Live realized P&L comes from the nt-account stream (non-shadow accounts).
+  // Emit a new point whenever realized_pnl changes for any live account.
+  useEffect(() => {
+    const unlisten = listen<AccountSnapshot>("nt-account", (event) => {
+      const a = event.payload;
+      if (a.name === "shadow") return;
+      if (lastLiveRealizedRef.current === a.realized_pnl) return;
+      lastLiveRealizedRef.current = a.realized_pnl;
+      setLive((prev) => pushCapped(prev, { t: Date.now(), pnl: a.realized_pnl }));
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Shadow equity is derived from cumulative closed shadow roundtrips. Only append
+  // when a newly-closed shadow trip arrives after our last recorded shadow close.
+  useEffect(() => {
+    const shadowTrips = roundtrips.filter((r) => r.isShadow);
+    if (shadowTrips.length === 0) return;
+    const latestClose = shadowTrips.reduce((m, r) => Math.max(m, r.closeTimestamp), 0);
+    if (latestClose <= lastShadowCloseRef.current) return;
+    lastShadowCloseRef.current = latestClose;
+    const cum = shadowTrips.reduce((s, r) => s + r.pnl, 0);
+    const rounded = Math.round(cum * 100) / 100;
+    if (rounded === lastShadowCumulativeRef.current) return;
+    lastShadowCumulativeRef.current = rounded;
+    setShadow((prev) => pushCapped(prev, { t: latestClose, pnl: rounded }));
+  }, [roundtrips]);
+
+  const liveDrawdown = useMemo(() => deriveDrawdown(live), [live]);
+  const shadowDrawdown = useMemo(() => deriveDrawdown(shadow), [shadow]);
+
+  return { live, shadow, liveDrawdown, shadowDrawdown };
+};

--- a/src/hooks/useRollingMetrics.ts
+++ b/src/hooks/useRollingMetrics.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import type { Roundtrip } from "../lib/tradingView";
+
+export type RollingMetric = "sharpe" | "winRate" | "expectancy";
+
+export type RollingPoint = { t: number; value: number; windowSize: number };
+
+export type RollingMetrics = {
+  sharpe: RollingPoint[];
+  winRate: RollingPoint[];
+  expectancy: RollingPoint[];
+};
+
+const computeSharpe = (pnls: number[]): number | null => {
+  if (pnls.length < 2) return null;
+  const mean = pnls.reduce((a, b) => a + b, 0) / pnls.length;
+  const variance = pnls.reduce((s, v) => s + (v - mean) ** 2, 0) / pnls.length;
+  const std = Math.sqrt(variance);
+  return std > 0 ? Math.round((mean / std) * 100) / 100 : null;
+};
+
+const computeWinRate = (pnls: number[]): number => {
+  if (pnls.length === 0) return 0;
+  const wins = pnls.filter((p) => p > 0).length;
+  return Math.round((wins / pnls.length) * 100);
+};
+
+const computeExpectancy = (pnls: number[]): number => {
+  if (pnls.length === 0) return 0;
+  return Math.round((pnls.reduce((a, b) => a + b, 0) / pnls.length) * 100) / 100;
+};
+
+export const useRollingMetrics = (
+  roundtrips: Roundtrip[],
+  windowSize: number = 20,
+): RollingMetrics => {
+  return useMemo(() => {
+    const sorted = [...roundtrips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+    const sharpe: RollingPoint[] = [];
+    const winRate: RollingPoint[] = [];
+    const expectancy: RollingPoint[] = [];
+    for (let i = 0; i < sorted.length; i++) {
+      const start = Math.max(0, i - windowSize + 1);
+      const window = sorted.slice(start, i + 1);
+      const pnls = window.map((r) => r.pnl);
+      const t = sorted[i].closeTimestamp;
+      const ws = window.length;
+      const s = computeSharpe(pnls);
+      if (s !== null) sharpe.push({ t, value: s, windowSize: ws });
+      winRate.push({ t, value: computeWinRate(pnls), windowSize: ws });
+      expectancy.push({ t, value: computeExpectancy(pnls), windowSize: ws });
+    }
+    return { sharpe, winRate, expectancy };
+  }, [roundtrips, windowSize]);
+};

--- a/src/hooks/useTradeHistory.ts
+++ b/src/hooks/useTradeHistory.ts
@@ -1,0 +1,226 @@
+import { useState, useEffect, useRef, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { Algo, AlgoRun } from "../types";
+import {
+  type Roundtrip,
+  type BreakdownRow,
+  type LiveShadowPair,
+  type DistributionBucket,
+  type HeatCell,
+  aggregateByKey,
+  pairLiveShadow,
+  buildDistribution,
+  buildHeatmap,
+} from "../lib/tradingView";
+import {
+  type MaeMfeSample,
+  deriveMaeMfe,
+  computeRMultiple,
+  decimateSamples,
+} from "../lib/roundtrips";
+
+type PositionEvent = {
+  source_id: string;
+  account: string;
+  symbol: string;
+  direction: string;
+  qty: number;
+  avg_price: number;
+  unrealized_pnl: number;
+};
+
+type OrderEvent = {
+  source_id: string;
+  account: string;
+  instance_id: string;
+  order_id: string;
+  state: string;
+  symbol: string;
+  side: string | null;
+  filled_qty: number | null;
+  avg_fill_price: number | null;
+  fill_price: number | null;
+  remaining: number | null;
+  error: string | null;
+  timestamp: number | null;
+};
+
+type OpenPosition = {
+  posKey: string;
+  dataSourceId: string;
+  symbol: string;
+  account: string;
+  side: "Long" | "Short";
+  qty: number;
+  entryPrice: number;
+  openTimestamp: number;
+  lastPnl: number;
+  samples: MaeMfeSample[];
+  lastExitPrice: number | null;
+};
+
+export type TradeHistory = {
+  roundtrips: Roundtrip[];
+  byAlgo: BreakdownRow[];
+  bySymbol: BreakdownRow[];
+  byAccount: BreakdownRow[];
+  liveVsShadow: LiveShadowPair[];
+  distribution: DistributionBucket[];
+  heatmap: HeatCell[][];
+};
+
+const MAX_ROUNDTRIPS = 1000;
+const MAX_SAMPLES_PER_TRIP = 200;
+const SAMPLE_INTERVAL_MS = 250;
+
+const posKeyOf = (sourceId: string, symbol: string, account: string): string =>
+  `${sourceId}:${symbol}:${account}`;
+
+export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHistory => {
+  const [roundtrips, setRoundtrips] = useState<Roundtrip[]>([]);
+  const openPositions = useRef<Map<string, OpenPosition>>(new Map());
+  const algosRef = useRef(algos);
+  const activeRunsRef = useRef(activeRuns);
+
+  useEffect(() => {
+    algosRef.current = algos;
+  }, [algos]);
+  useEffect(() => {
+    activeRunsRef.current = activeRuns;
+  }, [activeRuns]);
+
+  // Resolve algo + instance attribution from the current live run table.
+  // If the instance has already stopped by the time the trip closes, we
+  // fall back to the best-effort values (algoId = 0, empty names).
+  const resolveAttribution = (dataSourceId: string, account: string) => {
+    const run = activeRunsRef.current.find(
+      (r) => r.data_source_id === dataSourceId && r.account === account,
+    );
+    if (!run) {
+      return { algoId: 0, algoName: "", instanceId: "" };
+    }
+    const algo = algosRef.current.find((a) => a.id === run.algo_id);
+    return {
+      algoId: run.algo_id,
+      algoName: algo?.name ?? `algo ${run.algo_id}`,
+      instanceId: run.instance_id,
+    };
+  };
+
+  // Position events — pairing, sampling, close-to-roundtrip construction.
+  useEffect(() => {
+    const unlisten = listen<PositionEvent>("nt-position", (event) => {
+      const p = event.payload;
+      const posKey = posKeyOf(p.source_id, p.symbol, p.account);
+      const now = Date.now();
+
+      if (p.direction === "Flat" || p.qty === 0) {
+        const open = openPositions.current.get(posKey);
+        if (!open) return;
+        const { algoId, algoName, instanceId } = resolveAttribution(
+          open.dataSourceId,
+          open.account,
+        );
+        const { mae, mfe } = deriveMaeMfe(open.samples);
+        const exitPrice = open.lastExitPrice ?? p.avg_price ?? open.entryPrice;
+        const trip: Roundtrip = {
+          id: `${posKey}-${open.openTimestamp}`,
+          symbol: open.symbol,
+          side: open.side,
+          qty: open.qty,
+          entryPrice: open.entryPrice,
+          exitPrice,
+          openTimestamp: open.openTimestamp,
+          closeTimestamp: now,
+          pnl: Math.round(open.lastPnl * 100) / 100,
+          mae: Math.round(mae * 100) / 100,
+          mfe: Math.round(mfe * 100) / 100,
+          rMultiple: computeRMultiple(open.lastPnl, mae),
+          algo: algoName,
+          algoId,
+          account: open.account,
+          dataSourceId: open.dataSourceId,
+          instanceId,
+          isShadow: open.account === "shadow",
+          maeMfeSamples: decimateSamples(open.samples, MAX_SAMPLES_PER_TRIP),
+        };
+        openPositions.current.delete(posKey);
+        setRoundtrips((prev) => {
+          const next = [...prev, trip];
+          return next.length > MAX_ROUNDTRIPS ? next.slice(-MAX_ROUNDTRIPS) : next;
+        });
+        return;
+      }
+
+      const side: "Long" | "Short" = p.direction === "Long" ? "Long" : "Short";
+      const existing = openPositions.current.get(posKey);
+      if (existing) {
+        existing.lastPnl = p.unrealized_pnl;
+        existing.qty = Math.abs(p.qty);
+        // Throttle samples: only append if SAMPLE_INTERVAL_MS has passed since the last.
+        const lastSample = existing.samples[existing.samples.length - 1];
+        if (!lastSample || now - lastSample.t >= SAMPLE_INTERVAL_MS) {
+          existing.samples.push({ t: now, pnl: p.unrealized_pnl });
+        }
+      } else {
+        openPositions.current.set(posKey, {
+          posKey,
+          dataSourceId: p.source_id,
+          symbol: p.symbol,
+          account: p.account,
+          side,
+          qty: Math.abs(p.qty),
+          entryPrice: p.avg_price,
+          openTimestamp: now,
+          lastPnl: p.unrealized_pnl,
+          samples: [{ t: now, pnl: p.unrealized_pnl }],
+          lastExitPrice: null,
+        });
+      }
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Order events — track the most recent fill price so we can record it as exitPrice on close.
+  useEffect(() => {
+    const unlisten = listen<OrderEvent>("nt-order-update", (event) => {
+      const o = event.payload;
+      if (o.state !== "filled" && o.state !== "partial") return;
+      const price = o.fill_price ?? o.avg_fill_price;
+      if (price == null) return;
+      const posKey = posKeyOf(o.source_id, o.symbol, o.account);
+      const open = openPositions.current.get(posKey);
+      if (open) open.lastExitPrice = price;
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Chart removal — drop any dangling open positions for that chart. Already-closed
+  // roundtrips stay in history.
+  useEffect(() => {
+    const unlisten = listen<string>("nt-chart-removed", (event) => {
+      const removedId = event.payload;
+      for (const [key, val] of openPositions.current) {
+        if (val.dataSourceId === removedId) {
+          openPositions.current.delete(key);
+        }
+      }
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  const byAlgo = useMemo(() => aggregateByKey(roundtrips, "algo"), [roundtrips]);
+  const bySymbol = useMemo(() => aggregateByKey(roundtrips, "symbol"), [roundtrips]);
+  const byAccount = useMemo(() => aggregateByKey(roundtrips, "account"), [roundtrips]);
+  const liveVsShadow = useMemo(() => pairLiveShadow(roundtrips), [roundtrips]);
+  const distribution = useMemo(() => buildDistribution(roundtrips), [roundtrips]);
+  const heatmap = useMemo(() => buildHeatmap(roundtrips), [roundtrips]);
+
+  return { roundtrips, byAlgo, bySymbol, byAccount, liveVsShadow, distribution, heatmap };
+};

--- a/src/lib/algoInstanceView.ts
+++ b/src/lib/algoInstanceView.ts
@@ -46,16 +46,8 @@ export const computeStatus = (errors: InstanceErrors | undefined): InstanceStatu
 export const aggregatePnl = (instances: InstanceView[]): number =>
   instances.reduce((sum, i) => sum + (i.stats?.pnl ?? 0), 0);
 
-export const sparklinePoints = (history: number[], width: number, height: number): string => {
-  if (history.length <= 1) return "";
-  const min = Math.min(...history);
-  const max = Math.max(...history);
-  const range = max - min || 1;
-  const stepX = width / (history.length - 1);
-  return history
-    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
-    .join(" ");
-};
+// Shared renderers live in ./format; re-export so callers keep their imports stable.
+export { formatPnl, pnlColorClass, sparklinePoints } from "./format";
 
 export const passesFilters = (inst: InstanceView, filters: ViewFilters): boolean => {
   if (filters.mode !== "all" && inst.run.mode !== filters.mode) return false;
@@ -198,17 +190,3 @@ export const buildGroups = (args: BuildArgs): GroupView[] => {
   return groups;
 };
 
-export const formatPnl = (value: number): string => {
-  const sign = value >= 0 ? "+" : "";
-  return `${sign}$${Math.abs(value).toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-};
-
-export const pnlColorClass = (value: number): string =>
-  value > 0
-    ? "text-[var(--accent-green)]"
-    : value < 0
-      ? "text-[var(--accent-red)]"
-      : "text-[var(--text-primary)]";

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,28 @@
+// Shared UI formatters used across Trading / Algos / Home views.
+// Kept here so every view renders P&L / color / sparkline consistently.
+
+export const formatPnl = (value: number): string => {
+  const sign = value >= 0 ? "+" : "-";
+  return `${sign}$${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+export const pnlColorClass = (value: number): string =>
+  value > 0
+    ? "text-[var(--accent-green)]"
+    : value < 0
+      ? "text-[var(--accent-red)]"
+      : "text-[var(--text-primary)]";
+
+export const sparklinePoints = (history: number[], width: number, height: number): string => {
+  if (history.length <= 1) return "";
+  const min = Math.min(...history);
+  const max = Math.max(...history);
+  const range = max - min || 1;
+  const stepX = width / (history.length - 1);
+  return history
+    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
+    .join(" ");
+};

--- a/src/lib/roundtrips.ts
+++ b/src/lib/roundtrips.ts
@@ -1,0 +1,32 @@
+// Pure helpers for roundtrip-level derivations. No React imports.
+
+export type MaeMfeSample = { t: number; pnl: number };
+
+export const deriveMaeMfe = (samples: MaeMfeSample[]): { mae: number; mfe: number } => {
+  if (samples.length === 0) return { mae: 0, mfe: 0 };
+  let mae = 0;
+  let mfe = 0;
+  for (const s of samples) {
+    if (s.pnl < mae) mae = s.pnl;
+    if (s.pnl > mfe) mfe = s.pnl;
+  }
+  return { mae, mfe };
+};
+
+export const computeRMultiple = (pnl: number, mae: number): number | null => {
+  if (mae >= 0) return null;
+  return Math.round((pnl / Math.abs(mae)) * 100) / 100;
+};
+
+// Decimate samples to a target count, preserving temporal ordering.
+// We always keep the first and last sample; intermediate samples are evenly spaced.
+export const decimateSamples = (samples: MaeMfeSample[], target: number): MaeMfeSample[] => {
+  if (samples.length <= target) return samples;
+  if (target <= 2) return [samples[0], samples[samples.length - 1]];
+  const step = (samples.length - 1) / (target - 1);
+  const out: MaeMfeSample[] = [];
+  for (let i = 0; i < target; i++) {
+    out.push(samples[Math.round(i * step)]);
+  }
+  return out;
+};

--- a/src/lib/tradingView.ts
+++ b/src/lib/tradingView.ts
@@ -1,0 +1,298 @@
+// Pure helpers for the Trading view. No React imports.
+
+import type { MaeMfeSample } from "./roundtrips";
+
+// ----- Shared types -----
+
+export type Roundtrip = {
+  id: string;
+  symbol: string;
+  side: "Long" | "Short";
+  qty: number;
+  entryPrice: number;
+  exitPrice: number;
+  openTimestamp: number;
+  closeTimestamp: number;
+  pnl: number;
+  mae: number;
+  mfe: number;
+  rMultiple: number | null;
+  algo: string;
+  algoId: number;
+  account: string;
+  dataSourceId: string;
+  instanceId: string;
+  isShadow: boolean;
+  maeMfeSamples: MaeMfeSample[];
+};
+
+export type EquityPoint = { t: number; pnl: number };
+export type DrawdownPoint = { t: number; peak: number; pnl: number; underwater: number };
+
+export type Filters = {
+  chart: string | null;
+  account: string | null;
+  algo: number | null;
+};
+
+export const EMPTY_FILTERS: Filters = { chart: null, account: null, algo: null };
+
+export type Filterable = {
+  dataSourceId: string;
+  account: string;
+  algoId: number;
+};
+
+export const matchesFilters = (item: Filterable, f: Filters): boolean => {
+  if (f.chart !== null && item.dataSourceId !== f.chart) return false;
+  if (f.account !== null && item.account !== f.account) return false;
+  if (f.algo !== null && item.algoId !== f.algo) return false;
+  return true;
+};
+
+export const applyFilters = <T extends Filterable>(items: T[], f: Filters): T[] =>
+  items.filter((i) => matchesFilters(i, f));
+
+export const isFilterActive = (f: Filters): boolean =>
+  f.chart !== null || f.account !== null || f.algo !== null;
+
+// ----- Formatting helpers (shared by components) -----
+
+export const formatPnl = (v: number): string => {
+  const sign = v >= 0 ? "+" : "-";
+  return `${sign}$${Math.abs(v).toFixed(2)}`;
+};
+
+export const pnlColorClass = (v: number): string =>
+  v > 0
+    ? "text-[var(--accent-green)]"
+    : v < 0
+      ? "text-[var(--accent-red)]"
+      : "text-[var(--text-primary)]";
+
+export const formatChartLabel = (dsId: string): string => {
+  const [instrument, tf] = dsId.split(":");
+  if (!instrument || !tf) return dsId;
+  return `${instrument.split(" ")[0]} ${tf}`;
+};
+
+export const formatDuration = (fromTs: number, toTs: number): string => {
+  const ms = toTs - fromTs;
+  if (ms < 60_000) return `${Math.max(0, Math.round(ms / 1000))}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+};
+
+export const sparklinePoints = (history: number[], width: number, height: number): string => {
+  if (history.length <= 1) return "";
+  const min = Math.min(...history);
+  const max = Math.max(...history);
+  const range = max - min || 1;
+  const stepX = width / (history.length - 1);
+  return history
+    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
+    .join(" ");
+};
+
+// ----- Breakdown aggregation -----
+
+export type BreakdownKey = "algo" | "symbol" | "account";
+
+export type BreakdownRow = {
+  key: string;
+  label: string;
+  trades: number;
+  pnl: number;
+  winRate: number;
+  sharpe: string;
+  profitFactor: string;
+  avgWin: number;
+  avgLoss: number;
+  sparkline: number[];
+};
+
+const keyOf = (r: Roundtrip, by: BreakdownKey): { key: string; label: string } => {
+  switch (by) {
+    case "algo":
+      return { key: String(r.algoId), label: r.algo || `algo ${r.algoId}` };
+    case "symbol":
+      return { key: r.symbol, label: r.symbol };
+    case "account":
+      return { key: r.account, label: r.account };
+  }
+};
+
+const sharpeString = (pnls: number[]): string => {
+  if (pnls.length < 2) return "--";
+  const mean = pnls.reduce((a, b) => a + b, 0) / pnls.length;
+  const variance = pnls.reduce((s, v) => s + (v - mean) ** 2, 0) / pnls.length;
+  const std = Math.sqrt(variance);
+  return std > 0 ? (mean / std).toFixed(2) : "--";
+};
+
+export const aggregateByKey = (roundtrips: Roundtrip[], by: BreakdownKey): BreakdownRow[] => {
+  const groups = new Map<string, { label: string; trips: Roundtrip[] }>();
+  for (const r of roundtrips) {
+    const { key, label } = keyOf(r, by);
+    const g = groups.get(key) ?? { label, trips: [] };
+    g.trips.push(r);
+    groups.set(key, g);
+  }
+  const rows: BreakdownRow[] = [];
+  for (const [key, { label, trips }] of groups) {
+    const wins = trips.filter((t) => t.pnl > 0);
+    const losses = trips.filter((t) => t.pnl < 0);
+    const totalPnl = trips.reduce((s, t) => s + t.pnl, 0);
+    const totalWin = wins.reduce((s, t) => s + t.pnl, 0);
+    const totalLoss = Math.abs(losses.reduce((s, t) => s + t.pnl, 0));
+    const winRate = trips.length > 0 ? Math.round((wins.length / trips.length) * 100) : 0;
+    const avgWin = wins.length > 0 ? totalWin / wins.length : 0;
+    const avgLoss = losses.length > 0 ? losses.reduce((s, t) => s + t.pnl, 0) / losses.length : 0;
+    const profitFactor =
+      totalLoss > 0 ? (totalWin / totalLoss).toFixed(2) : wins.length > 0 ? "∞" : "--";
+    const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+    const sparkline: number[] = [];
+    let cum = 0;
+    for (const r of sorted) {
+      cum += r.pnl;
+      sparkline.push(Math.round(cum * 100) / 100);
+    }
+    rows.push({
+      key,
+      label,
+      trades: trips.length,
+      pnl: Math.round(totalPnl * 100) / 100,
+      winRate,
+      sharpe: sharpeString(trips.map((t) => t.pnl)),
+      profitFactor,
+      avgWin: Math.round(avgWin * 100) / 100,
+      avgLoss: Math.round(avgLoss * 100) / 100,
+      sparkline,
+    });
+  }
+  return rows.sort((a, b) => b.pnl - a.pnl);
+};
+
+// ----- Live vs. shadow pairing -----
+
+export type LiveShadowPair = {
+  algoId: number;
+  algoName: string;
+  live: BreakdownRow | null;
+  shadow: BreakdownRow | null;
+  delta: number;
+  slippagePerTrade: number;
+};
+
+export const pairLiveShadow = (roundtrips: Roundtrip[]): LiveShadowPair[] => {
+  const liveByAlgo = new Map<number, Roundtrip[]>();
+  const shadowByAlgo = new Map<number, Roundtrip[]>();
+  for (const r of roundtrips) {
+    const bucket = r.isShadow ? shadowByAlgo : liveByAlgo;
+    const cur = bucket.get(r.algoId) ?? [];
+    cur.push(r);
+    bucket.set(r.algoId, cur);
+  }
+  const allAlgoIds = new Set<number>([...liveByAlgo.keys(), ...shadowByAlgo.keys()]);
+  const result: LiveShadowPair[] = [];
+  for (const algoId of allAlgoIds) {
+    const liveTrips = liveByAlgo.get(algoId) ?? [];
+    const shadowTrips = shadowByAlgo.get(algoId) ?? [];
+    const liveRow = liveTrips.length ? aggregateByKey(liveTrips, "algo")[0] : null;
+    const shadowRow = shadowTrips.length ? aggregateByKey(shadowTrips, "algo")[0] : null;
+    const algoName = liveRow?.label ?? shadowRow?.label ?? `algo ${algoId}`;
+    const delta = Math.round(((liveRow?.pnl ?? 0) - (shadowRow?.pnl ?? 0)) * 100) / 100;
+    const liveAvg = liveRow && liveRow.trades > 0 ? liveRow.pnl / liveRow.trades : 0;
+    const shadowAvg = shadowRow && shadowRow.trades > 0 ? shadowRow.pnl / shadowRow.trades : 0;
+    const slippagePerTrade = Math.round((liveAvg - shadowAvg) * 100) / 100;
+    result.push({ algoId, algoName, live: liveRow, shadow: shadowRow, delta, slippagePerTrade });
+  }
+  return result.sort((a, b) => a.algoName.localeCompare(b.algoName));
+};
+
+// ----- Distribution -----
+
+export type DistributionBucket = { lo: number; hi: number; count: number };
+
+export const buildDistribution = (
+  roundtrips: Roundtrip[],
+  bucketCount: number = 12,
+): DistributionBucket[] => {
+  if (roundtrips.length === 0) return [];
+  const pnls = roundtrips.map((r) => r.pnl);
+  const min = Math.min(...pnls);
+  const max = Math.max(...pnls);
+  const range = max - min || 1;
+  const step = range / bucketCount;
+  const buckets: DistributionBucket[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    const lo = min + i * step;
+    const hi = i === bucketCount - 1 ? max + 0.0001 : lo + step;
+    const count = pnls.filter((p) => p >= lo && p < hi).length;
+    buckets.push({ lo: Math.round(lo * 100) / 100, hi: Math.round(hi * 100) / 100, count });
+  }
+  return buckets;
+};
+
+// ----- Heatmap (day × hour) -----
+
+export type HeatCell = { trades: number; pnl: number; winRate: number };
+
+export const buildHeatmap = (roundtrips: Roundtrip[]): HeatCell[][] => {
+  // [day][hour] where day 0 = Sunday, hour 0–23
+  const grid: HeatCell[][] = Array.from({ length: 7 }, () =>
+    Array.from({ length: 24 }, () => ({ trades: 0, pnl: 0, winRate: 0 })),
+  );
+  const wins = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0));
+  for (const r of roundtrips) {
+    const d = new Date(r.closeTimestamp);
+    const day = d.getDay();
+    const hour = d.getHours();
+    grid[day][hour].trades += 1;
+    grid[day][hour].pnl += r.pnl;
+    if (r.pnl > 0) wins[day][hour] += 1;
+  }
+  for (let d = 0; d < 7; d++) {
+    for (let h = 0; h < 24; h++) {
+      const cell = grid[d][h];
+      cell.pnl = Math.round(cell.pnl * 100) / 100;
+      cell.winRate = cell.trades > 0 ? Math.round((wins[d][h] / cell.trades) * 100) : 0;
+    }
+  }
+  return grid;
+};
+
+// ----- Hero KPI derivation -----
+
+export type HeroKpis = {
+  realizedPnl: number;
+  unrealizedPnl: number;
+  totalPnl: number;
+  winRate: number;
+  trades: number;
+  sharpe: string;
+  maxDrawdown: number;
+};
+
+export const deriveHeroKpis = (
+  filteredRoundtrips: Roundtrip[],
+  filteredOpenPositions: { pnl: number }[],
+  drawdown: DrawdownPoint[],
+): HeroKpis => {
+  const realized = filteredRoundtrips.reduce((s, r) => s + r.pnl, 0);
+  const unrealized = filteredOpenPositions.reduce((s, p) => s + p.pnl, 0);
+  const wins = filteredRoundtrips.filter((r) => r.pnl > 0).length;
+  const winRate =
+    filteredRoundtrips.length > 0 ? Math.round((wins / filteredRoundtrips.length) * 100) : 0;
+  const sharpe = sharpeString(filteredRoundtrips.map((r) => r.pnl));
+  const maxDrawdown = drawdown.reduce((max, d) => Math.max(max, d.underwater), 0);
+  return {
+    realizedPnl: Math.round(realized * 100) / 100,
+    unrealizedPnl: Math.round(unrealized * 100) / 100,
+    totalPnl: Math.round((realized + unrealized) * 100) / 100,
+    winRate,
+    trades: filteredRoundtrips.length,
+    sharpe,
+    maxDrawdown: Math.round(maxDrawdown * 100) / 100,
+  };
+};

--- a/src/lib/tradingView.ts
+++ b/src/lib/tradingView.ts
@@ -56,19 +56,11 @@ export const applyFilters = <T extends Filterable>(items: T[], f: Filters): T[] 
 export const isFilterActive = (f: Filters): boolean =>
   f.chart !== null || f.account !== null || f.algo !== null;
 
-// ----- Formatting helpers (shared by components) -----
+// ----- Formatting helpers -----
 
-export const formatPnl = (v: number): string => {
-  const sign = v >= 0 ? "+" : "-";
-  return `${sign}$${Math.abs(v).toFixed(2)}`;
-};
-
-export const pnlColorClass = (v: number): string =>
-  v > 0
-    ? "text-[var(--accent-green)]"
-    : v < 0
-      ? "text-[var(--accent-red)]"
-      : "text-[var(--text-primary)]";
+// Shared renderers live in ./format; re-exported here so callers can keep
+// importing from "tradingView" without caring where the helper lives.
+export { formatPnl, pnlColorClass, sparklinePoints } from "./format";
 
 export const formatChartLabel = (dsId: string): string => {
   const [instrument, tf] = dsId.split(":");
@@ -81,17 +73,6 @@ export const formatDuration = (fromTs: number, toTs: number): string => {
   if (ms < 60_000) return `${Math.max(0, Math.round(ms / 1000))}s`;
   if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
   return `${(ms / 3_600_000).toFixed(1)}h`;
-};
-
-export const sparklinePoints = (history: number[], width: number, height: number): string => {
-  if (history.length <= 1) return "";
-  const min = Math.min(...history);
-  const max = Math.max(...history);
-  const range = max - min || 1;
-  const stepX = width / (history.length - 1);
-  return history
-    .map((v, i) => `${(i * stepX).toFixed(2)},${(height - ((v - min) / range) * height).toFixed(2)}`)
-    .join(" ");
 };
 
 // ----- Breakdown aggregation -----

--- a/src/views/TradingView.tsx
+++ b/src/views/TradingView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import type { Algo, AlgoRun, NavContext, View, NavOptions } from "../types";
 import type {
   TradingSimulation,
@@ -19,6 +19,7 @@ import {
   buildDistribution,
   buildHeatmap,
   deriveHeroKpis,
+  isFilterActive,
 } from "../lib/tradingView";
 import { TradingFilterBar } from "../components/TradingFilterBar";
 import { TradingHero } from "../components/TradingHero";
@@ -48,9 +49,9 @@ type TradingViewProps = {
   onNavigate: (view: View, options?: NavOptions) => void;
 };
 
-// Build a drawdown series from the currently-filtered roundtrips (used when a filter
-// is active; the hook's `equity.liveDrawdown` follows nt-account realized P&L across
-// all accounts and can't be narrowed after the fact).
+// Build a drawdown series from the closed roundtrips. Used for the hero's Max DD
+// and as the drawdown overlay source — consistent with how the hero's realized/
+// total P&L and trade metrics are derived (all from the same roundtrip set).
 const drawdownFromRoundtrips = (trips: Roundtrip[]): DrawdownPoint[] => {
   const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
   let peak = 0;
@@ -64,12 +65,15 @@ const drawdownFromRoundtrips = (trips: Roundtrip[]): DrawdownPoint[] => {
   return out;
 };
 
-// Position cards need "open since" timestamps — we track them here (not in the hook)
-// because the hook only keeps MAE/MFE samples, not the open time as a separate datum
-// that's available synchronously at render. We rebuild the map from the current positions.
+// Position cards need "open since" timestamps. The simulation hook only carries the
+// current unrealized P&L, not the moment a position opened. We shadow-track first-seen
+// timestamps here at render time so new positions get their timestamp synchronously
+// (useMemo rather than useEffect avoids the first-frame staleness that would leave a
+// just-opened card showing "--" for its hold duration).
 const useOpenSinceMap = (positions: Position[]): Map<string, number> => {
-  const [map] = useState(() => new Map<string, number>());
-  useEffect(() => {
+  const mapRef = useRef(new Map<string, number>());
+  return useMemo(() => {
+    const map = mapRef.current;
     const seen = new Set<string>();
     const now = Date.now();
     for (const p of positions) {
@@ -80,8 +84,8 @@ const useOpenSinceMap = (positions: Position[]): Map<string, number> => {
     for (const key of Array.from(map.keys())) {
       if (!seen.has(key)) map.delete(key);
     }
-  }, [positions, map]);
-  return map;
+    return map;
+  }, [positions]);
 };
 
 export const TradingView = ({
@@ -114,8 +118,7 @@ export const TradingView = ({
 
     if (initialContext.scrollTo) {
       const target = initialContext.scrollTo;
-      if (target === "positions") setActiveTab("live");
-      else if (target === "orders") setActiveTab("live");
+      if (target === "positions" || target === "orders") setActiveTab("live");
       else if (target === "history") setActiveTab("trades");
       // "stats" stays on whatever tab we're on — hero is always visible.
     }
@@ -135,8 +138,7 @@ export const TradingView = ({
     () => applyFilters(tradeHistory.roundtrips, filters),
     [tradeHistory.roundtrips, filters],
   );
-  const isFilterOn =
-    filters.chart !== null || filters.account !== null || filters.algo !== null;
+  const isFilterOn = isFilterActive(filters);
 
   const filteredByAlgo = useMemo(
     () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "algo") : tradeHistory.byAlgo),
@@ -163,11 +165,13 @@ export const TradingView = ({
     [tradeHistory.heatmap, filteredRoundtrips, isFilterOn],
   );
 
-  // Drawdown follows the filtered roundtrips when a filter is set; otherwise use the
-  // hook's raw live drawdown series (which tracks the nt-account realized P&L).
+  // Drawdown for hero KPIs + overlay: always derive from the (filtered) roundtrip set.
+  // This keeps the hero internally consistent — realized / Sharpe / max DD all come
+  // from the same source, whether or not a filter is active. The raw `equity.liveDrawdown`
+  // from nt-account is still available to callers that want live-account-only drawdown.
   const filteredDrawdown = useMemo(
-    () => (isFilterOn ? drawdownFromRoundtrips(filteredRoundtrips) : equity.liveDrawdown),
-    [equity.liveDrawdown, filteredRoundtrips, isFilterOn],
+    () => drawdownFromRoundtrips(filteredRoundtrips),
+    [filteredRoundtrips],
   );
 
   const heroKpis = useMemo(

--- a/src/views/TradingView.tsx
+++ b/src/views/TradingView.tsx
@@ -1,789 +1,247 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import { type TradingSimulation, type Position, formatPrice } from "../hooks/useTradingSimulation";
-import type { Algo, AlgoRun, NavContext } from "../types";
+import { useState, useEffect, useMemo } from "react";
+import type { Algo, AlgoRun, NavContext, View, NavOptions } from "../types";
+import type {
+  TradingSimulation,
+  DataSource,
+  Position,
+} from "../hooks/useTradingSimulation";
+import type { TradeHistory } from "../hooks/useTradeHistory";
+import type { EquityTimeline } from "../hooks/useEquityTimeline";
+import type { RollingMetrics } from "../hooks/useRollingMetrics";
+import {
+  type Filters,
+  type Roundtrip,
+  type DrawdownPoint,
+  EMPTY_FILTERS,
+  applyFilters,
+  aggregateByKey,
+  pairLiveShadow,
+  buildDistribution,
+  buildHeatmap,
+  deriveHeroKpis,
+} from "../lib/tradingView";
+import { TradingFilterBar } from "../components/TradingFilterBar";
+import { TradingHero } from "../components/TradingHero";
+import { TradingTabs, type TradingTab } from "../components/TradingTabs";
+import { LiveTab } from "../components/LiveTab";
+import { PerformanceTab } from "../components/PerformanceTab";
+import { AnalyticsTab } from "../components/AnalyticsTab";
+import { TradesTab } from "../components/TradesTab";
+
+type AccountSummary = {
+  buying_power: number;
+  cash: number;
+  realized_pnl: number;
+};
 
 type TradingViewProps = {
   simulation: TradingSimulation;
+  tradeHistory: TradeHistory;
+  equity: EquityTimeline;
+  rolling: RollingMetrics;
   algos: Algo[];
   activeRuns: AlgoRun[];
+  dataSources: DataSource[];
+  accounts: Record<string, AccountSummary>;
   initialContext?: NavContext | null;
   onContextConsumed?: () => void;
+  onNavigate: (view: View, options?: NavOptions) => void;
 };
 
-const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
-
-// Hook: smoothly interpolate position P&L toward targets using RAF
-const useSmoothedPositions = (positions: Position[]) => {
-  const displayRef = useRef<Position[]>(positions);
-  const [display, setDisplay] = useState(positions);
-  const rafRef = useRef<number>(0);
-  const isAnimating = useRef(false);
-
-  useEffect(() => {
-    displayRef.current = display;
-  }, [display]);
-
-  const tick = useCallback(() => {
-    const current = displayRef.current;
-    let needsMore = false;
-    const next = positions.map((p) => {
-      const existing = current.find((d) => d.symbol === p.symbol && d.algoId === p.algoId);
-      if (!existing) return p;
-      const smoothed = lerp(existing.pnl, p.targetPnl, 0.08);
-      if (Math.abs(smoothed - p.targetPnl) > 0.001) needsMore = true;
-      return { ...p, pnl: smoothed };
-    });
-    const changed = needsMore || next.length !== current.length ||
-      next.some((n, i) => Math.abs(n.pnl - current[i]?.pnl) > 0.001);
-    if (changed) {
-      displayRef.current = next;
-      setDisplay(next);
-    }
-    if (needsMore) {
-      rafRef.current = requestAnimationFrame(tick);
-    } else {
-      isAnimating.current = false;
-    }
-  }, [positions]);
-
-  useEffect(() => {
-    if (!isAnimating.current) {
-      isAnimating.current = true;
-      rafRef.current = requestAnimationFrame(tick);
-    }
-    return () => {
-      cancelAnimationFrame(rafRef.current);
-      isAnimating.current = false;
-    };
-  }, [tick]);
-
-  return display;
+// Build a drawdown series from the currently-filtered roundtrips (used when a filter
+// is active; the hook's `equity.liveDrawdown` follows nt-account realized P&L across
+// all accounts and can't be narrowed after the fact).
+const drawdownFromRoundtrips = (trips: Roundtrip[]): DrawdownPoint[] => {
+  const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+  let peak = 0;
+  let cum = 0;
+  const out: DrawdownPoint[] = [];
+  for (const r of sorted) {
+    cum += r.pnl;
+    if (cum > peak) peak = cum;
+    out.push({ t: r.closeTimestamp, peak, pnl: cum, underwater: peak - cum });
+  }
+  return out;
 };
 
-// Hook: smoothly count toward a target number
-const useAnimatedNumber = (target: number, speed = 0.08) => {
-  const currentRef = useRef(target);
-  const [display, setDisplay] = useState(target);
-  const rafRef = useRef<number>(0);
-  const isAnimating = useRef(false);
-
+// Position cards need "open since" timestamps — we track them here (not in the hook)
+// because the hook only keeps MAE/MFE samples, not the open time as a separate datum
+// that's available synchronously at render. We rebuild the map from the current positions.
+const useOpenSinceMap = (positions: Position[]): Map<string, number> => {
+  const [map] = useState(() => new Map<string, number>());
   useEffect(() => {
-    const tick = () => {
-      const next = lerp(currentRef.current, target, speed);
-      if (Math.abs(next - target) > 0.01) {
-        currentRef.current = next;
-        setDisplay(next);
-        rafRef.current = requestAnimationFrame(tick);
-      } else {
-        currentRef.current = target;
-        setDisplay(target);
-        isAnimating.current = false;
-      }
-    };
-
-    if (!isAnimating.current) {
-      isAnimating.current = true;
-      rafRef.current = requestAnimationFrame(tick);
+    const seen = new Set<string>();
+    const now = Date.now();
+    for (const p of positions) {
+      const key = `${p.dataSourceId}:${p.symbol}:${p.account}`;
+      seen.add(key);
+      if (!map.has(key)) map.set(key, now);
     }
-
-    return () => {
-      cancelAnimationFrame(rafRef.current);
-      isAnimating.current = false;
-    };
-  }, [target, speed]);
-
-  return display;
+    for (const key of Array.from(map.keys())) {
+      if (!seen.has(key)) map.delete(key);
+    }
+  }, [positions, map]);
+  return map;
 };
 
-type TradingMode = "live" | "shadow";
+export const TradingView = ({
+  simulation,
+  tradeHistory,
+  equity,
+  rolling,
+  algos,
+  activeRuns,
+  dataSources,
+  accounts,
+  initialContext,
+  onContextConsumed,
+  onNavigate,
+}: TradingViewProps) => {
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [activeTab, setActiveTab] = useState<TradingTab>("live");
+  const [selectedRoundtripId, setSelectedRoundtripId] = useState<string | null>(null);
 
-export const TradingView = ({ simulation, algos, activeRuns, initialContext, onContextConsumed }: TradingViewProps) => {
-  const { positions, orders, pnlHistory, shadowPnlHistory, runPnlHistories, stats, shadowStats } = simulation;
-  const [selectedAlgoId, setSelectedAlgoId] = useState<number | null>(null);
-  const [selectedAccount, setSelectedAccount] = useState<string | null>(null);
-  const [selectedChart, setSelectedChart] = useState<string | null>(null);
-  const [tradingMode, setTradingMode] = useState<TradingMode>("live");
-
-  // Clear algo selection if the selected algo stops running
-  useEffect(() => {
-    if (selectedAlgoId !== null && !activeRuns.some((r) => r.algo_id === selectedAlgoId)) {
-      setSelectedAlgoId(null);
-    }
-  }, [activeRuns, selectedAlgoId]);
-
+  // Honor inbound nav context (from Algos view etc.)
   useEffect(() => {
     if (!initialContext || initialContext.targetView !== "trading") return;
 
-    if (initialContext.accountFilter !== undefined) setSelectedAccount(initialContext.accountFilter);
-    if (initialContext.algoFilter !== undefined) setSelectedAlgoId(initialContext.algoFilter);
+    const next: Partial<Filters> = {};
+    if (initialContext.accountFilter !== undefined) next.account = initialContext.accountFilter;
+    if (initialContext.algoFilter !== undefined) next.algo = initialContext.algoFilter;
+    if (Object.keys(next).length > 0) {
+      setFilters((f) => ({ ...f, ...next }));
+    }
 
-    let rafHandle: number | undefined;
     if (initialContext.scrollTo) {
-      rafHandle = requestAnimationFrame(() => {
-        const scrollTarget = initialContext.scrollTo === "history" ? "orders" : initialContext.scrollTo;
-        const el = document.getElementById(`trading-anchor-${scrollTarget}`);
-        if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
-      });
+      const target = initialContext.scrollTo;
+      if (target === "positions") setActiveTab("live");
+      else if (target === "orders") setActiveTab("live");
+      else if (target === "history") setActiveTab("trades");
+      // "stats" stays on whatever tab we're on — hero is always visible.
     }
 
     onContextConsumed?.();
-
-    return () => {
-      if (rafHandle !== undefined) cancelAnimationFrame(rafHandle);
-    };
   }, [initialContext, onContextConsumed]);
 
-  const runningAlgos = algos.filter((a) => activeRuns.some((r) => r.algo_id === a.id));
+  const filteredPositions = useMemo(
+    () => applyFilters(simulation.positions, filters),
+    [simulation.positions, filters],
+  );
+  const filteredOrders = useMemo(
+    () => applyFilters(simulation.orders, filters),
+    [simulation.orders, filters],
+  );
+  const filteredRoundtrips = useMemo(
+    () => applyFilters(tradeHistory.roundtrips, filters),
+    [tradeHistory.roundtrips, filters],
+  );
+  const isFilterOn =
+    filters.chart !== null || filters.account !== null || filters.algo !== null;
 
-  // Derive active accounts and charts from active runs
-  const activeAccounts = [...new Set([
-    ...positions.map((p) => p.account),
-    ...orders.map((o) => o.account),
-  ])].sort();
+  const filteredByAlgo = useMemo(
+    () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "algo") : tradeHistory.byAlgo),
+    [tradeHistory.byAlgo, filteredRoundtrips, isFilterOn],
+  );
+  const filteredBySymbol = useMemo(
+    () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "symbol") : tradeHistory.bySymbol),
+    [tradeHistory.bySymbol, filteredRoundtrips, isFilterOn],
+  );
+  const filteredByAccount = useMemo(
+    () => (isFilterOn ? aggregateByKey(filteredRoundtrips, "account") : tradeHistory.byAccount),
+    [tradeHistory.byAccount, filteredRoundtrips, isFilterOn],
+  );
+  const filteredLiveVsShadow = useMemo(
+    () => (isFilterOn ? pairLiveShadow(filteredRoundtrips) : tradeHistory.liveVsShadow),
+    [tradeHistory.liveVsShadow, filteredRoundtrips, isFilterOn],
+  );
+  const filteredDistribution = useMemo(
+    () => (isFilterOn ? buildDistribution(filteredRoundtrips) : tradeHistory.distribution),
+    [tradeHistory.distribution, filteredRoundtrips, isFilterOn],
+  );
+  const filteredHeatmap = useMemo(
+    () => (isFilterOn ? buildHeatmap(filteredRoundtrips) : tradeHistory.heatmap),
+    [tradeHistory.heatmap, filteredRoundtrips, isFilterOn],
+  );
 
-  const activeCharts = [...new Set(activeRuns.map((r) => r.data_source_id))].sort();
+  // Drawdown follows the filtered roundtrips when a filter is set; otherwise use the
+  // hook's raw live drawdown series (which tracks the nt-account realized P&L).
+  const filteredDrawdown = useMemo(
+    () => (isFilterOn ? drawdownFromRoundtrips(filteredRoundtrips) : equity.liveDrawdown),
+    [equity.liveDrawdown, filteredRoundtrips, isFilterOn],
+  );
 
-  const formatChartLabel = (dsId: string) => {
-    const [instrument, tf] = dsId.split(":");
-    return `${instrument.split(" ")[0]} ${tf}`;
-  };
+  const heroKpis = useMemo(
+    () => deriveHeroKpis(filteredRoundtrips, filteredPositions, filteredDrawdown),
+    [filteredRoundtrips, filteredPositions, filteredDrawdown],
+  );
 
-  // Filter data based on mode and all selections
-  const applyFilters = <T extends { algoId: number; account: string; dataSourceId: string }>(items: T[]): T[] => {
-    let result = tradingMode === "shadow"
-      ? items.filter((i) => i.account === "shadow")
-      : items.filter((i) => i.account !== "shadow");
-    if (selectedAlgoId !== null) result = result.filter((i) => i.algoId === selectedAlgoId);
-    if (selectedAccount !== null) result = result.filter((i) => i.account === selectedAccount);
-    if (selectedChart !== null) result = result.filter((i) => i.dataSourceId === selectedChart);
-    return result;
-  };
+  const openSinceByPosKey = useOpenSinceMap(simulation.positions);
 
-  const filteredPositions = applyFilters(positions);
-  const filteredOrders = applyFilters(orders);
-
-  // Select data based on trading mode
-  const modeStats = tradingMode === "shadow" ? shadowStats : stats;
-  const modePnlHistory = tradingMode === "shadow" ? shadowPnlHistory : pnlHistory;
-
-  // P&L history: sum relevant run histories based on filters
-  const filteredPnlHistory = (() => {
-    if (selectedAlgoId === null && selectedAccount === null && selectedChart === null) return modePnlHistory;
-
-    // Find matching run keys (instance_ids)
-    const matchingKeys = Object.keys(runPnlHistories).filter((instanceId) => {
-      const run = activeRuns.find((r) => r.instance_id === instanceId);
-      if (!run) return false;
-      if (selectedAlgoId !== null && run.algo_id !== selectedAlgoId) return false;
-      if (selectedAccount !== null && run.account !== selectedAccount) return false;
-      if (selectedChart !== null && run.data_source_id !== selectedChart) return false;
-      return true;
-    });
-
-    if (matchingKeys.length === 0) return [0];
-
-    // Sum the matching histories point by point
-    const maxLen = Math.max(...matchingKeys.map((k) => runPnlHistories[k].length));
-    const summed: number[] = [];
-    for (let i = 0; i < maxLen; i++) {
-      let sum = 0;
-      for (const key of matchingKeys) {
-        const hist = runPnlHistories[key];
-        sum += hist[i] ?? (hist[hist.length - 1] ?? 0);
-      }
-      summed.push(Math.round(sum * 100) / 100);
-    }
-    return summed;
-  })();
-
-  const filteredStats = modeStats;
-
-  const smoothedPositions = useSmoothedPositions(filteredPositions);
-
-  const animatedRealized = useAnimatedNumber(filteredStats.realizedPnl);
-  const animatedUnrealized = useAnimatedNumber(filteredStats.unrealizedPnl);
-  const animatedTotal = useAnimatedNumber(filteredStats.totalPnl);
-
-  const hasActivity = filteredPositions.length > 0 || filteredOrders.length > 0;
+  const hasCharts = dataSources.length > 0;
 
   return (
-    <div className="flex-1 flex flex-col gap-3 p-4 overflow-hidden">
-      {/* Mode Toggle + View-Level Filters */}
-      {(runningAlgos.length > 0 || activeAccounts.length > 0) && (
-        <div className="flex items-center gap-4 px-2 flex-wrap">
-          {/* Mode Toggle */}
-          <div className="flex items-center gap-1.5">
-            <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">Mode</span>
-            {(["live", "shadow"] as const).map((mode) => (
-              <button
-                key={mode}
-                onClick={() => setTradingMode(mode)}
-                className={`px-3 py-1.5 text-[11px] rounded-md transition-colors flex items-center gap-1.5 ${
-                  tradingMode === mode
-                    ? mode === "live"
-                      ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
-                      : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                }`}
-              >
-                <span className={`w-1.5 h-1.5 rounded-full ${
-                  mode === "live" ? "bg-[var(--accent-green)]" : "bg-[var(--accent-yellow)]"
-                }`} />
-                {mode === "live" ? "Live" : "Shadow"}
-              </button>
-            ))}
-          </div>
+    <div className="flex-1 flex flex-col gap-3 p-4 overflow-hidden min-h-0">
+      <TradingFilterBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        algos={algos}
+        activeRuns={activeRuns}
+        dataSources={dataSources}
+        positions={simulation.positions}
+        orders={simulation.orders}
+        roundtrips={tradeHistory.roundtrips}
+      />
 
-          <div className="w-px h-5 bg-[var(--border)]" />
+      <TradingHero
+        kpis={heroKpis}
+        equityLive={equity.live}
+        equityShadow={equity.shadow}
+        drawdown={filteredDrawdown}
+      />
 
-          {/* Chart Filters */}
-          {activeCharts.length > 0 && (
-            <div className="flex items-center gap-1.5">
-              <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">Chart</span>
-              <button
-                onClick={() => setSelectedChart(null)}
-                className={`px-3 py-1.5 text-[11px] rounded-md transition-colors ${
-                  selectedChart === null
-                    ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                }`}
-              >
-                All
-              </button>
-              {activeCharts.map((dsId) => (
-                <button
-                  key={dsId}
-                  onClick={() => setSelectedChart(dsId === selectedChart ? null : dsId)}
-                  className={`px-3 py-1.5 text-[11px] rounded-md transition-colors ${
-                    selectedChart === dsId
-                      ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
-                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                  }`}
-                >
-                  {formatChartLabel(dsId)}
-                </button>
-              ))}
-            </div>
+      <TradingTabs activeTab={activeTab} onChange={setActiveTab} />
+
+      {!hasCharts ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)] rounded-lg">
+          Connect a NinjaTrader chart to see trading activity
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto min-h-0">
+          {activeTab === "live" && (
+            <LiveTab
+              positions={filteredPositions}
+              orders={filteredOrders}
+              accounts={accounts}
+              openSinceByPosKey={openSinceByPosKey}
+            />
           )}
-
-          {/* Divider */}
-          {activeCharts.length > 0 && activeAccounts.length > 0 && (
-            <div className="w-px h-5 bg-[var(--border)]" />
+          {activeTab === "performance" && (
+            <PerformanceTab
+              byAlgo={filteredByAlgo}
+              bySymbol={filteredBySymbol}
+              byAccount={filteredByAccount}
+              liveVsShadow={filteredLiveVsShadow}
+              onOpenAlgoInEditor={(algoId) => onNavigate("editor", { algoFilter: algoId })}
+              onViewAccountInAlgos={(account) => onNavigate("algos", { accountFilter: account })}
+            />
           )}
-
-          {/* Account Filters */}
-          {activeAccounts.length > 0 && (
-            <div className="flex items-center gap-1.5">
-              <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">Account</span>
-              <button
-                onClick={() => setSelectedAccount(null)}
-                className={`px-3 py-1.5 text-[11px] rounded-md transition-colors ${
-                  selectedAccount === null
-                    ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                }`}
-              >
-                All
-              </button>
-              {activeAccounts.map((account) => (
-                <button
-                  key={account}
-                  onClick={() => setSelectedAccount(account === selectedAccount ? null : account)}
-                  className={`px-3 py-1.5 text-[11px] rounded-md transition-colors ${
-                    selectedAccount === account
-                      ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
-                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                  }`}
-                >
-                  {account}
-                </button>
-              ))}
-            </div>
+          {activeTab === "analytics" && (
+            <AnalyticsTab
+              distribution={filteredDistribution}
+              heatmap={filteredHeatmap}
+              rolling={rolling}
+              totalTrades={filteredRoundtrips.length}
+            />
           )}
-
-          {/* Divider */}
-          {activeAccounts.length > 0 && runningAlgos.length > 0 && (
-            <div className="w-px h-5 bg-[var(--border)]" />
-          )}
-
-          {/* Algo Filters */}
-          {runningAlgos.length > 0 && (
-            <div className="flex items-center gap-1.5">
-              <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mr-1">Algo</span>
-              <button
-                onClick={() => setSelectedAlgoId(null)}
-                className={`px-3 py-1.5 text-[11px] rounded-md transition-colors ${
-                  selectedAlgoId === null
-                    ? "bg-[var(--accent-blue)]/15 text-[var(--accent-blue)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                }`}
-              >
-                All
-              </button>
-              {runningAlgos.map((algo) => {
-                const run = activeRuns.find((r) => r.algo_id === algo.id);
-                const isLive = run?.mode === "live";
-                const selectedClasses = isLive
-                  ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
-                  : "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]";
-                const dotClass = isLive
-                  ? "bg-[var(--accent-green)]"
-                  : "bg-[var(--accent-yellow)]";
-                return (
-                  <button
-                    key={algo.id}
-                    onClick={() => setSelectedAlgoId(algo.id === selectedAlgoId ? null : algo.id)}
-                    className={`px-3 py-1.5 text-[11px] rounded-md transition-colors flex items-center gap-1.5 ${
-                      selectedAlgoId === algo.id
-                        ? selectedClasses
-                        : "text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]"
-                    }`}
-                  >
-                    <span className={`w-1.5 h-1.5 rounded-full ${dotClass}`} />
-                    {algo.name}
-                  </button>
-                );
-              })}
-            </div>
+          {activeTab === "trades" && (
+            <TradesTab
+              roundtrips={filteredRoundtrips}
+              selectedId={selectedRoundtripId}
+              onSelect={setSelectedRoundtripId}
+            />
           )}
         </div>
       )}
-
-      {/* Top Row: P&L + Stats */}
-      <div className="flex gap-3">
-        <div id="trading-anchor-stats" />
-        <div className="flex-1 grid grid-cols-3 gap-4 p-4 bg-[var(--bg-panel)] rounded-lg">
-          <PnlCard label="Realized P&L" value={animatedRealized} />
-          <PnlCard label="Unrealized P&L" value={animatedUnrealized} />
-          <PnlCard label="Total P&L" value={animatedTotal} />
-        </div>
-        <div className="flex-1 grid grid-cols-4 gap-4 p-4 bg-[var(--bg-panel)] rounded-lg">
-          <StatCell label="Win Rate" value={filteredStats.totalTrades > 0 ? `${filteredStats.winRate}%` : "--"} />
-          <StatCell label="Trades" value={`${filteredStats.totalTrades}`} />
-          <StatCell label="Drawdown" value={filteredStats.totalTrades > 0 ? `$${Math.abs(filteredStats.maxDrawdown).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : "--"} />
-          <StatCell label="Sharpe" value={filteredStats.sharpe} />
-        </div>
-      </div>
-
-      {/* Middle: Chart Area */}
-      <div className="flex-1 bg-[var(--bg-panel)] rounded-lg p-4 flex flex-col min-h-0">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-            {tradingMode === "shadow" ? "Shadow P&L" : "Session P&L"}
-          </h2>
-        </div>
-        {filteredPnlHistory.length > 1 ? (
-          <PnlChart data={filteredPnlHistory} />
-        ) : (
-          <div className="flex-1 flex items-center justify-center text-sm text-[var(--text-secondary)] border border-dashed border-[var(--border)] rounded-lg">
-            {tradingMode === "shadow" ? "No shadow trades yet" : "Start an algo to see live P&L"}
-          </div>
-        )}
-      </div>
-
-      {/* Bottom Row: Positions + Orders */}
-      <div className="flex gap-3 flex-1 min-h-0">
-        <div className="flex-1 bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
-          <div id="trading-anchor-positions" />
-          <div className="px-4 py-2.5 border-b border-[var(--border)]">
-            <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-              Open Positions
-            </h2>
-          </div>
-          <div className="flex-1 overflow-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
-                  <th className="text-left px-4 py-2.5 font-medium">Symbol</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Side</th>
-                  <th className="text-right px-4 py-2.5 font-medium">Qty</th>
-                  <th className="text-right px-4 py-2.5 font-medium">Avg Price</th>
-                  <th className="text-right px-4 py-2.5 font-medium">P&L</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Algo</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Account</th>
-                </tr>
-              </thead>
-              <tbody>
-                {smoothedPositions.length === 0 ? (
-                  <tr>
-                    <td colSpan={7} className="px-4 py-5 text-center text-[var(--text-secondary)]">
-                      {hasActivity ? "No open positions" : "Start an algo to see positions"}
-                    </td>
-                  </tr>
-                ) : (
-                  smoothedPositions.map((p) => (
-                    <tr key={`${p.algoId}-${p.symbol}`} className="border-b border-[var(--border)] last:border-0">
-                      <td className="px-4 py-2.5 font-medium">{p.symbol}</td>
-                      <td className={`px-4 py-2.5 ${p.side === "Long" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"}`}>
-                        {p.side}
-                      </td>
-                      <td className="px-4 py-2.5 text-right">{p.qty}</td>
-                      <td className="px-4 py-2.5 text-right">{formatPrice(p.symbol, p.avgPrice)}</td>
-                      <td className={`px-4 py-2.5 text-right font-medium ${p.pnl >= 0 ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"}`}>
-                        {p.pnl >= 0 ? "+" : ""}{p.pnl.toFixed(2)}
-                      </td>
-                      <td className="px-4 py-2.5 text-[var(--text-secondary)]">{p.algo}</td>
-                      <td className="px-4 py-2.5 text-[var(--text-secondary)]">{p.account}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div className="flex-1 bg-[var(--bg-panel)] rounded-lg flex flex-col overflow-hidden">
-          <div id="trading-anchor-orders" />
-          <div className="px-4 py-2.5 border-b border-[var(--border)]">
-            <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-              Recent Orders
-            </h2>
-          </div>
-          <div className="flex-1 overflow-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-[var(--border)]">
-                  <th className="text-left px-4 py-2.5 font-medium">Time</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Symbol</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Side</th>
-                  <th className="text-right px-4 py-2.5 font-medium">Qty</th>
-                  <th className="text-right px-4 py-2.5 font-medium">Price</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Status</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Algo</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Account</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredOrders.length === 0 ? (
-                  <tr>
-                    <td colSpan={8} className="px-4 py-5 text-center text-[var(--text-secondary)]">
-                      No orders yet
-                    </td>
-                  </tr>
-                ) : (
-                  filteredOrders.map((o) => (
-                    <tr key={o.id} className="border-b border-[var(--border)] last:border-0">
-                      <td className="px-4 py-2.5 text-[var(--text-secondary)]">{o.time}</td>
-                      <td className="px-4 py-2.5 font-medium">{o.symbol}</td>
-                      <td className={`px-4 py-2.5 ${o.side === "Buy" ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]"}`}>
-                        {o.side}
-                      </td>
-                      <td className="px-4 py-2.5 text-right">{o.qty}</td>
-                      <td className="px-4 py-2.5 text-right">{o.price}</td>
-                      <td className="px-4 py-2.5">
-                        <span className={`text-xs px-2 py-0.5 rounded ${
-                          o.status === "Filled"
-                            ? "bg-[var(--accent-green)]/15 text-[var(--accent-green)]"
-                            : o.status === "Working"
-                              ? "bg-[var(--accent-yellow)]/15 text-[var(--accent-yellow)]"
-                              : "bg-[var(--accent-red)]/15 text-[var(--accent-red)]"
-                        }`}>
-                          {o.status}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2.5 text-[var(--text-secondary)]">{o.algo}</td>
-                      <td className="px-4 py-2.5 text-[var(--text-secondary)]">{o.account}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const PnlCard = ({ label, value }: { label: string; value: number }) => {
-  const color = value >= 0 ? "text-[var(--accent-green)]" : "text-[var(--accent-red)]";
-  return (
-    <div>
-      <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1.5">
-        {label}
-      </div>
-      <div className={`text-lg font-semibold ${color}`}>
-        {value >= 0 ? "+" : ""}${Math.abs(value).toFixed(2)}
-      </div>
-    </div>
-  );
-};
-
-const StatCell = ({ label, value }: { label: string; value: string }) => (
-  <div>
-    <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] mb-1.5">
-      {label}
-    </div>
-    <div className="text-base font-semibold">{value}</div>
-  </div>
-);
-
-
-const PnlChart = ({ data }: { data: number[] }) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const animatedDataRef = useRef<number[]>(data);
-  const rafRef = useRef<number>(0);
-  const targetDataRef = useRef<number[]>(data);
-  const mouseRef = useRef<{ x: number; y: number } | null>(null);
-
-  useEffect(() => {
-    targetDataRef.current = data;
-  }, [data]);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const handleMove = (e: MouseEvent) => {
-      const rect = canvas.getBoundingClientRect();
-      mouseRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-    };
-    const handleLeave = () => {
-      mouseRef.current = null;
-    };
-
-    canvas.addEventListener("mousemove", handleMove);
-    canvas.addEventListener("mouseleave", handleLeave);
-    return () => {
-      canvas.removeEventListener("mousemove", handleMove);
-      canvas.removeEventListener("mouseleave", handleLeave);
-    };
-  }, []);
-
-  const drawFrame = useCallback(() => {
-    const canvas = canvasRef.current;
-    const container = containerRef.current;
-    if (!canvas || !container) return;
-
-    const target = targetDataRef.current;
-    const current = animatedDataRef.current;
-
-    if (current.length < target.length) {
-      // New points: snap all existing points to their targets, animate only the new one
-      for (let i = 0; i < current.length; i++) {
-        current[i] = target[i];
-      }
-      for (let i = current.length; i < target.length; i++) {
-        current.push(current.length > 0 ? current[current.length - 1] : target[i]);
-      }
-    } else if (current.length > target.length) {
-      current.length = target.length;
-    }
-
-    // Only animate the last point; all others are locked
-    for (let i = 0; i < target.length - 1; i++) {
-      current[i] = target[i];
-    }
-    if (target.length > 0) {
-      const last = target.length - 1;
-      current[last] = lerp(current[last], target[last], 0.06);
-    }
-
-    const animData = animatedDataRef.current;
-    if (animData.length < 2) return;
-
-    const rect = container.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
-
-    if (canvas.width !== Math.round(rect.width * dpr) || canvas.height !== Math.round(rect.height * dpr)) {
-      canvas.width = Math.round(rect.width * dpr);
-      canvas.height = Math.round(rect.height * dpr);
-      canvas.style.width = `${rect.width}px`;
-      canvas.style.height = `${rect.height}px`;
-    }
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    const w = rect.width;
-    const h = rect.height;
-
-    ctx.clearRect(0, 0, w, h);
-
-    // Anchor Y-axis at $0
-    const dataMin = Math.min(...animData, 0);
-    const dataMax = Math.max(...animData, 0);
-    const range = dataMax - dataMin || 1;
-    const padding = range * 0.1;
-
-    const minPoints = 60;
-    const xScale = Math.max(animData.length - 1, minPoints);
-    const toX = (i: number) => (i / xScale) * w;
-    const toY = (v: number) => h - ((v - dataMin + padding) / (range + padding * 2)) * h;
-
-    // Zero line
-    const zeroY = toY(0);
-    ctx.strokeStyle = "rgba(136, 136, 160, 0.2)";
-    ctx.lineWidth = 1;
-    ctx.setLineDash([4, 4]);
-    ctx.beginPath();
-    ctx.moveTo(0, zeroY);
-    ctx.lineTo(w, zeroY);
-    ctx.stroke();
-    ctx.setLineDash([]);
-
-    const lastVal = animData[animData.length - 1];
-
-    // Build the step-line path (horizontal then vertical at each point)
-    const traceStepLine = () => {
-      ctx.moveTo(toX(0), toY(animData[0]));
-      for (let i = 1; i < animData.length; i++) {
-        // Horizontal segment to the next x position at the previous y
-        ctx.lineTo(toX(i), toY(animData[i - 1]));
-        // Vertical segment to the new y
-        ctx.lineTo(toX(i), toY(animData[i]));
-      }
-    };
-
-    // Draw fill and line for each region using clipping
-    const regions: { clipY: number; clipH: number; color: string; gradientStops: [string, string] }[] = [
-      {
-        clipY: 0,
-        clipH: zeroY,
-        color: "#00d68f",
-        gradientStops: ["rgba(0, 214, 143, 0.2)", "rgba(0, 214, 143, 0)"],
-      },
-      {
-        clipY: zeroY,
-        clipH: h - zeroY,
-        color: "#ff4d6a",
-        gradientStops: ["rgba(255, 77, 106, 0)", "rgba(255, 77, 106, 0.2)"],
-      },
-    ];
-
-    for (const region of regions) {
-      ctx.save();
-      ctx.beginPath();
-      ctx.rect(0, region.clipY, w, region.clipH);
-      ctx.clip();
-
-      // Fill
-      const grad = ctx.createLinearGradient(0, region.clipY, 0, region.clipY + region.clipH);
-      grad.addColorStop(0, region.gradientStops[0]);
-      grad.addColorStop(1, region.gradientStops[1]);
-
-      ctx.beginPath();
-      ctx.moveTo(toX(0), zeroY);
-      traceStepLine();
-      ctx.lineTo(toX(animData.length - 1), zeroY);
-      ctx.closePath();
-      ctx.fillStyle = grad;
-      ctx.fill();
-
-      // Line
-      ctx.beginPath();
-      traceStepLine();
-      ctx.strokeStyle = region.color;
-      ctx.lineWidth = 2;
-      ctx.stroke();
-
-      ctx.restore();
-    }
-
-    // Hover crosshair + tooltip
-    const mouse = mouseRef.current;
-    if (mouse) {
-      // Find nearest data index
-      const idx = Math.round((mouse.x / w) * xScale);
-      const clampedIdx = Math.max(0, Math.min(animData.length - 1, idx));
-      const val = animData[clampedIdx];
-      const pointX = toX(clampedIdx);
-      const pointY = toY(val);
-      const valColor = val >= 0 ? "#00d68f" : "#ff4d6a";
-
-      // Vertical crosshair line
-      ctx.strokeStyle = "rgba(136, 136, 160, 0.3)";
-      ctx.lineWidth = 1;
-      ctx.setLineDash([3, 3]);
-      ctx.beginPath();
-      ctx.moveTo(pointX, 0);
-      ctx.lineTo(pointX, h);
-      ctx.stroke();
-      ctx.setLineDash([]);
-
-      // Horizontal crosshair line
-      ctx.strokeStyle = "rgba(136, 136, 160, 0.2)";
-      ctx.setLineDash([3, 3]);
-      ctx.beginPath();
-      ctx.moveTo(0, pointY);
-      ctx.lineTo(w, pointY);
-      ctx.stroke();
-      ctx.setLineDash([]);
-
-      // Dot on the line
-      ctx.beginPath();
-      ctx.arc(pointX, pointY, 5, 0, Math.PI * 2);
-      ctx.fillStyle = valColor;
-      ctx.fill();
-      ctx.beginPath();
-      ctx.arc(pointX, pointY, 5, 0, Math.PI * 2);
-      ctx.strokeStyle = "#1a1a28";
-      ctx.lineWidth = 2;
-      ctx.stroke();
-
-      // Tooltip
-      const label = `${val >= 0 ? "+" : ""}$${Math.abs(val).toFixed(2)}`;
-      ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
-      const metrics = ctx.measureText(label);
-      const tooltipW = metrics.width + 16;
-      const tooltipH = 24;
-      const tooltipPad = 10;
-
-      // Position tooltip to avoid edges
-      let tx = pointX + tooltipPad;
-      if (tx + tooltipW > w) tx = pointX - tooltipW - tooltipPad;
-      let ty = pointY - tooltipH - tooltipPad;
-      if (ty < 0) ty = pointY + tooltipPad;
-
-      // Background
-      ctx.fillStyle = "rgba(26, 26, 40, 0.92)";
-      ctx.beginPath();
-      ctx.roundRect(tx, ty, tooltipW, tooltipH, 4);
-      ctx.fill();
-      ctx.strokeStyle = "rgba(42, 42, 58, 0.8)";
-      ctx.lineWidth = 1;
-      ctx.stroke();
-
-      // Text
-      ctx.fillStyle = valColor;
-      ctx.textAlign = "center";
-      ctx.textBaseline = "middle";
-      ctx.fillText(label, tx + tooltipW / 2, ty + tooltipH / 2);
-    }
-
-    // Pulsing dot (only when not hovering)
-    if (!mouse) {
-      const lastX = toX(animData.length - 1);
-      const lastY = toY(lastVal);
-      const dotColor = lastVal >= 0 ? "#00d68f" : "#ff4d6a";
-      ctx.beginPath();
-      ctx.arc(lastX, lastY, 4, 0, Math.PI * 2);
-      ctx.fillStyle = dotColor;
-      ctx.fill();
-
-      const pulse = 0.3 + Math.sin(Date.now() / 400) * 0.2;
-      ctx.beginPath();
-      ctx.arc(lastX, lastY, 8, 0, Math.PI * 2);
-      ctx.strokeStyle = dotColor;
-      ctx.lineWidth = 1.5;
-      ctx.globalAlpha = pulse;
-      ctx.stroke();
-      ctx.globalAlpha = 1;
-    }
-
-    rafRef.current = requestAnimationFrame(drawFrame);
-  }, []);
-
-  useEffect(() => {
-    rafRef.current = requestAnimationFrame(drawFrame);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [drawFrame]);
-
-  return (
-    <div ref={containerRef} className="flex-1 min-h-0">
-      <canvas ref={canvasRef} className="w-full h-full" style={{ cursor: "crosshair" }} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Rebuilds the Trading view as a unified dashboard per [`docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md`](docs/superpowers/specs/2026-04-19-trading-view-redesign-design.md):

- Pinned hero: 7 KPIs + equity curve with drawdown overlay
- Global Chart / Account / Algo filter bar (no more mode toggle — shadow renders inline with a Shadow pill)
- Four tabs: **Live** (position cards, risk summary, order tape), **Performance** (by algo / symbol / account + live-vs-shadow delta), **Analytics** (trade distribution, hour × day heatmap, rolling Sharpe / win% / expectancy), **Trades** (roundtrips table + right-side drill-down with MAE/MFE excursion chart)

Three new sibling hooks sit alongside the existing `useTradingSimulation` (unchanged):
- `useTradeHistory` — pairs fills into roundtrips, samples MAE/MFE, emits per-algo/symbol/account aggregates, distribution, heatmap.
- `useEquityTimeline` — timestamped live + shadow equity series.
- `useRollingMetrics` — windowed trade metrics.

Two pure helper modules:
- `src/lib/roundtrips.ts` — MAE/MFE + R-multiple + sample decimation.
- `src/lib/tradingView.ts` — filters, aggregation, bucketing, hero derivation.

Plus a small `src/lib/format.ts` that consolidates `formatPnl` / `pnlColorClass` / `sparklinePoints` (previously duplicated between `tradingView.ts` and `algoInstanceView.ts`; one copy had a latent sign-formatting bug that's now fixed). No backend / Tauri / event-payload changes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [ ] Smoke per `docs/superpowers/plans/2026-04-19-trading-view-redesign.md` Task 11 Step 2 — requires NinjaTrader + live chart:
  - Start live algo → Live tab: position card appears, order tape updates, hero KPIs update, equity curve appends points
  - Start shadow algo → second card with Shadow pill, equity chart gains dashed yellow series, roundtrip on close tagged shadow
  - Close position → roundtrip in Trades tab, Performance breakdowns update, Analytics distribution + heatmap gain point, rolling metrics update
  - Click a roundtrip → detail panel opens (Esc to close); MAE/MFE chart renders
  - Filter bar reshapes every panel consistently
  - Deep-link from Performance row: `→` opens Editor (algo rows) or Algos (account rows)
  - Home / Editor / Algos views unchanged

## Implementation plan

[`docs/superpowers/plans/2026-04-19-trading-view-redesign.md`](docs/superpowers/plans/2026-04-19-trading-view-redesign.md) — 11-task plan, all executed with per-task spec + code-quality review. Final holistic review: approved, no must-fix items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Trading View with tabbed interface: Live, Performance, Analytics, and Trades tabs
  * Added persistent global filter bar for Chart, Account, and Algo filtering
  * Enhanced KPI dashboard with equity chart showing drawdown overlay
  * New analytics: P&L distribution histogram, session heatmap, and rolling performance metrics
  * Live vs. Shadow performance comparison panel
  * Trade detail drill-down with unrealized P&L visualization over hold time
  * Improved position cards and live order tape display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->