### PR TITLE
fix: align per-trade and per-algo P&L with NinjaTrader

### DIFF
--- a/ninjatrader/WolfDenBridge.cs
+++ b/ninjatrader/WolfDenBridge.cs
@@ -40,6 +40,32 @@ namespace NinjaTrader.NinjaScript.Strategies
         private DateTime                                    _lastAccountSend = DateTime.MinValue;
         private DateTime                                    _lastPositionSend = DateTime.MinValue;
 
+        // Pre-Flat position snapshot. Updated by OnPositionUpdate so its values remain
+        // available when we emit the trade on the next transition back to Flat.
+        private MarketPosition                              _lastPosMarketPos = MarketPosition.Flat;
+        private int                                         _lastPosQty;
+        private double                                      _lastPosAvgPrice;
+
+        // NT-authoritative per-trade P&L tracking. We snapshot the account's realized P&L
+        // when a position opens and subtract that snapshot from the updated realized P&L after
+        // it closes — so the emitted `pnl` matches NT's own trade accounting (commission,
+        // exchange fees, slippage all included). The emit is deferred to the first
+        // RealizedProfitLoss update following Flat, since NT can post the P&L update either
+        // before OR after OnPositionUpdate fires.
+        private double                                      _realizedPnlAtOpen;
+        private bool                                        _positionWasOpen;
+        private bool                                        _emitTradeOnNextRealizedUpdate;
+        private string                                      _pendingSide;
+        private int                                         _pendingQty;
+        private double                                      _pendingEntryPrice;
+
+        // Captures the most recent closing fill so the trade message carries the real exit
+        // price/time/order attribution (averagePrice at Flat is 0).
+        private double                                      _lastExitPrice;
+        private DateTime                                    _lastExitTime = DateTime.MinValue;
+        private string                                      _lastExitOrderId;
+        private string                                      _lastExitInstanceId;
+
         private bool                                        _isRealtime;
 
         // Pre-built history JSON (built on NinjaScript thread, sent from background task)
@@ -379,6 +405,23 @@ namespace NinjaTrader.NinjaScript.Strategies
                 "remaining",      execution.Order.Quantity - execution.Order.Filled,
                 "timestamp",      ToUnixMs(time)
             ));
+
+            // Remember the most recent closing fill so the deferred trade emit (in
+            // OnPositionUpdate/OnAccountItemUpdate) can carry the real exit price, time,
+            // and algo attribution. Closing = execution side opposite of current position side.
+            if (_lastPosMarketPos != MarketPosition.Flat)
+            {
+                bool isClosingExec =
+                    (_lastPosMarketPos == MarketPosition.Long  && marketPosition == MarketPosition.Short) ||
+                    (_lastPosMarketPos == MarketPosition.Short && marketPosition == MarketPosition.Long);
+                if (isClosingExec)
+                {
+                    _lastExitPrice      = price;
+                    _lastExitTime       = time;
+                    _lastExitOrderId    = wolfDenId;
+                    _lastExitInstanceId = instanceId;
+                }
+            }
         }
 
         protected override void OnPositionUpdate(Position position, double averagePrice,
@@ -410,6 +453,63 @@ namespace NinjaTrader.NinjaScript.Strategies
                 "avg_price",      averagePrice,
                 "unrealized_pnl", unrealizedPnl
             ));
+
+            // Position lifecycle tracking for NT-authoritative trade P&L emission.
+            if (marketPosition != MarketPosition.Flat && !_positionWasOpen)
+            {
+                // Position just opened — snapshot account realized P&L as baseline.
+                _realizedPnlAtOpen = _cachedRealizedPnl;
+                _positionWasOpen   = true;
+            }
+            else if (marketPosition == MarketPosition.Flat && _positionWasOpen)
+            {
+                // Position just closed — capture the pre-Flat side/qty/avg price from the
+                // last non-Flat snapshot, then defer the trade emit until RealizedPnL refreshes.
+                _pendingSide       = _lastPosMarketPos == MarketPosition.Long ? "Long" : "Short";
+                _pendingQty        = _lastPosQty;
+                _pendingEntryPrice = _lastPosAvgPrice;
+                _emitTradeOnNextRealizedUpdate = true;
+                _positionWasOpen   = false;
+                // If the account update already fired before this Flat event, the delta is
+                // already correct — emit immediately rather than waiting.
+                if (_cachedRealizedPnl != _realizedPnlAtOpen)
+                    EmitPendingTrade();
+            }
+
+            // Record post-update snapshot (used by OnExecutionUpdate for closing-side detection).
+            _lastPosMarketPos = marketPosition;
+            _lastPosQty       = quantity;
+            _lastPosAvgPrice  = averagePrice;
+        }
+
+        private void EmitPendingTrade()
+        {
+            if (!_emitTradeOnNextRealizedUpdate) return;
+            if (_ws == null || !_ws.IsConnected) return;
+
+            double netPnl = _cachedRealizedPnl - _realizedPnlAtOpen;
+            long exitTimeMs = _lastExitTime == DateTime.MinValue
+                ? ToUnixMs(DateTime.UtcNow)
+                : ToUnixMs(_lastExitTime);
+
+            _ws.Send(Json.Build(
+                "type",        "trade",
+                "source_id",   _sourceId,
+                "symbol",      _symbol,
+                "side",        _pendingSide ?? "",
+                "qty",         _pendingQty,
+                "entry_price", _pendingEntryPrice,
+                "exit_price",  _lastExitPrice,
+                "exit_time",   exitTimeMs,
+                "pnl",         netPnl,
+                "gross_pnl",   netPnl,
+                "commission",  0.0,
+                "flattens",    true,
+                "order_id",    _lastExitOrderId ?? "",
+                "instance_id", _lastExitInstanceId ?? ""
+            ));
+
+            _emitTradeOnNextRealizedUpdate = false;
         }
 
         protected override void OnAccountItemUpdate(Account account, AccountItem accountItem, double value)
@@ -420,7 +520,12 @@ namespace NinjaTrader.NinjaScript.Strategies
             {
                 case AccountItem.BuyingPower:           _cachedBuyingPower  = value; break;
                 case AccountItem.CashValue:             _cachedCash         = value; break;
-                case AccountItem.RealizedProfitLoss:    _cachedRealizedPnl  = value; break;
+                case AccountItem.RealizedProfitLoss:
+                    _cachedRealizedPnl = value;
+                    // Emit pending trade as soon as NT posts the updated realized P&L —
+                    // this is the earliest moment commission + fees are baked in.
+                    if (_emitTradeOnNextRealizedUpdate) EmitPendingTrade();
+                    break;
                 default: return;
             }
 
@@ -1224,8 +1329,8 @@ namespace NinjaTrader.NinjaScript.Strategies
                 string dummy;
                 _orderToId.TryRemove(order, out dummy);
             }
-            string dummy2;
-            _idToInstance.TryRemove(wolfDenId, out dummy2);
+            // Keep _idToInstance alive so trade messages emitted after order finalization
+            // can still resolve back to the originating algo instance.
         }
     }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -161,6 +161,22 @@ pub enum NtInbound {
         error: Option<String>,
         timestamp: Option<i64>,
     },
+    #[serde(rename = "trade")]
+    Trade {
+        source_id: String,
+        symbol: String,
+        side: String,
+        qty: i64,
+        entry_price: f64,
+        exit_price: f64,
+        exit_time: i64,
+        pnl: f64,
+        gross_pnl: f64,
+        commission: f64,
+        flattens: bool,
+        order_id: String,
+        instance_id: String,
+    },
     #[serde(rename = "history")]
     History {
         source_id: String,

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -46,6 +46,27 @@ pub struct PositionEvent {
     pub unrealized_pnl: f64,
 }
 
+/// Realized trade event emitted to the frontend. Sourced from NinjaTrader's per-execution
+/// P&L computation in the bridge — authoritative relative to the locally-derived unrealized
+/// snapshot the frontend previously used.
+#[derive(Debug, Clone, Serialize)]
+pub struct TradeEvent {
+    pub source_id: String,
+    pub account: String,
+    pub symbol: String,
+    pub side: String,
+    pub qty: i64,
+    pub entry_price: f64,
+    pub exit_price: f64,
+    pub exit_time: i64,
+    pub pnl: f64,
+    pub gross_pnl: f64,
+    pub commission: f64,
+    pub flattens: bool,
+    pub order_id: String,
+    pub instance_id: String,
+}
+
 /// Order update emitted to the frontend.
 #[derive(Debug, Clone, Serialize)]
 pub struct OrderEvent {
@@ -262,6 +283,34 @@ pub async fn start(
                                                 .unwrap_or_default()
                                                 .as_millis() as i64,
                                         }));
+                                    }
+                                }
+
+                                // On Trade (NT-computed realized P&L), emit with connection's account name
+                                if let NtInbound::Trade {
+                                    ref source_id, ref symbol, ref side, qty,
+                                    entry_price, exit_price, exit_time,
+                                    pnl, gross_pnl, commission, flattens,
+                                    ref order_id, ref instance_id,
+                                } = parsed {
+                                    let acct = account_name.read().await;
+                                    if let Some(ref name) = *acct {
+                                        let _ = app_handle.emit("nt-trade", TradeEvent {
+                                            source_id: source_id.clone(),
+                                            account: name.clone(),
+                                            symbol: symbol.clone(),
+                                            side: side.clone(),
+                                            qty,
+                                            entry_price,
+                                            exit_price,
+                                            exit_time,
+                                            pnl,
+                                            gross_pnl,
+                                            commission,
+                                            flattens,
+                                            order_id: order_id.clone(),
+                                            instance_id: instance_id.clone(),
+                                        });
                                     }
                                 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { DEFAULT_ALGO } from "./components/AlgoEditor";
@@ -14,7 +14,6 @@ import { AiTerminalPanel } from "./components/AiTerminalPanel";
 import { ToastContainer, toast } from "./components/Toast";
 import { useTradingSimulation } from "./hooks/useTradingSimulation";
 import { useTradeHistory } from "./hooks/useTradeHistory";
-import { useEquityTimeline } from "./hooks/useEquityTimeline";
 import { useRollingMetrics } from "./hooks/useRollingMetrics";
 import { useAlgoErrors } from "./hooks/useAlgoErrors";
 import { useAlgoLogs } from "./hooks/useAlgoLogs";
@@ -54,8 +53,16 @@ export const App = () => {
 
   const simulation = useTradingSimulation(algos, activeRuns, dataSources);
   const tradeHistory = useTradeHistory(algos, activeRuns);
-  const equity = useEquityTimeline(tradeHistory.roundtrips);
   const rolling = useRollingMetrics(tradeHistory.roundtrips);
+
+  // Merge backtest stats (from useTradingSimulation) with live roundtrip-derived stats
+  // (from useTradeHistory). Live overrides backtest once the instance has closed trades.
+  // runPnlHistories likewise comes from live roundtrips; the simulation hook returns {}.
+  const mergedAlgoStats = useMemo(
+    () => ({ ...simulation.algoStats, ...tradeHistory.statsByInstance }),
+    [simulation.algoStats, tradeHistory.statsByInstance],
+  );
+  const mergedRunPnlHistories = tradeHistory.pnlHistoryByInstance;
 
   const handleAutoStop = useCallback(async (instanceId: string) => {
     toast.error(`Algo instance ${instanceId.slice(0, 8)}... halted due to repeated errors`);
@@ -377,8 +384,8 @@ export const App = () => {
             stats={simulation.stats}
             positions={simulation.positions}
             pnlHistory={simulation.pnlHistory}
-            runPnlHistories={simulation.runPnlHistories}
-            algoStats={simulation.algoStats}
+            runPnlHistories={mergedRunPnlHistories}
+            algoStats={mergedAlgoStats}
             onNavigate={handleNavigate}
             onStopAlgo={handleStopAlgo}
           />
@@ -406,8 +413,8 @@ export const App = () => {
             algos={algos}
             dataSources={dataSources}
             activeRuns={activeRuns}
-            algoStats={simulation.algoStats}
-            runPnlHistories={simulation.runPnlHistories}
+            algoStats={mergedAlgoStats}
+            runPnlHistories={mergedRunPnlHistories}
             errorsByInstance={errorsByInstance}
             logsByInstance={logsByInstance}
             healthByInstance={healthByInstance}
@@ -426,7 +433,6 @@ export const App = () => {
           <TradingView
             simulation={simulation}
             tradeHistory={tradeHistory}
-            equity={equity}
             rolling={rolling}
             algos={algos}
             activeRuns={activeRuns}

--- a/src/hooks/useTradeHistory.ts
+++ b/src/hooks/useTradeHistory.ts
@@ -18,6 +18,7 @@ import {
   computeRMultiple,
   decimateSamples,
 } from "../lib/roundtrips";
+import type { AlgoStats } from "./useTradingSimulation";
 
 type PositionEvent = {
   source_id: string;
@@ -45,6 +46,23 @@ type OrderEvent = {
   timestamp: number | null;
 };
 
+type TradeEvent = {
+  source_id: string;
+  account: string;
+  symbol: string;
+  side: "Long" | "Short";
+  qty: number;
+  entry_price: number;
+  exit_price: number;
+  exit_time: number;
+  pnl: number;
+  gross_pnl: number;
+  commission: number;
+  flattens: boolean;
+  order_id: string;
+  instance_id: string;
+};
+
 type OpenPosition = {
   posKey: string;
   dataSourceId: string;
@@ -57,7 +75,21 @@ type OpenPosition = {
   lastPnl: number;
   samples: MaeMfeSample[];
   lastExitPrice: number | null;
+  // Accumulated P&L from nt-trade events (NT-reported, authoritative for live accounts)
+  ntPnl: number;
+  ntTradeCount: number;
+  ntExitPrice: number | null;
+  // Flat arrived from NT but we're still waiting for the nt-trade event that carries
+  // NT's final realized P&L. Finalize the roundtrip when the trade arrives (or on timeout).
+  closingPending: boolean;
+  closingFlatTimestamp: number | null;
+  closingTimeoutId: ReturnType<typeof setTimeout> | null;
 };
+
+// Live accounts wait this long after nt-position Flat for the nt-trade event before
+// falling back to the unrealized snapshot. NT normally posts realized-P&L within a few
+// hundred ms of the fill; 3 seconds is a generous safety net.
+const TRADE_WAIT_MS = 3000;
 
 export type TradeHistory = {
   roundtrips: Roundtrip[];
@@ -67,6 +99,71 @@ export type TradeHistory = {
   liveVsShadow: LiveShadowPair[];
   distribution: DistributionBucket[];
   heatmap: HeatCell[][];
+  // Live per-instance performance derived from roundtrips (keyed by AlgoRun.instance_id).
+  // Used to override backtest-only AlgoStats on the Algos/Home views so per-algo P&L reflects
+  // actual trade activity once the algo has closed at least one roundtrip.
+  statsByInstance: Record<string, AlgoStats>;
+  pnlHistoryByInstance: Record<string, number[]>;
+};
+
+const aggregateByInstance = (
+  roundtrips: Roundtrip[],
+): { stats: Record<string, AlgoStats>; pnlHistories: Record<string, number[]> } => {
+  const groups = new Map<string, Roundtrip[]>();
+  for (const r of roundtrips) {
+    if (!r.instanceId) continue; // unattributed — skip (shows as zero on the view)
+    const existing = groups.get(r.instanceId) ?? [];
+    existing.push(r);
+    groups.set(r.instanceId, existing);
+  }
+  const stats: Record<string, AlgoStats> = {};
+  const pnlHistories: Record<string, number[]> = {};
+  for (const [instanceId, trips] of groups) {
+    const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+    const wins = sorted.filter((t) => t.pnl > 0);
+    const losses = sorted.filter((t) => t.pnl < 0);
+    const totalPnl = sorted.reduce((s, t) => s + t.pnl, 0);
+    const totalWin = wins.reduce((s, t) => s + t.pnl, 0);
+    const totalLoss = Math.abs(losses.reduce((s, t) => s + t.pnl, 0));
+    const winRate = sorted.length > 0 ? Math.round((wins.length / sorted.length) * 100) : 0;
+    const avgWin = wins.length > 0 ? totalWin / wins.length : 0;
+    const avgLoss =
+      losses.length > 0 ? losses.reduce((s, t) => s + t.pnl, 0) / losses.length : 0;
+    const profitFactor =
+      totalLoss > 0 ? (totalWin / totalLoss).toFixed(2) : wins.length > 0 ? "∞" : "--";
+
+    const cum: number[] = [];
+    let running = 0;
+    let peak = 0;
+    let maxDrawdown = 0;
+    for (const r of sorted) {
+      running += r.pnl;
+      cum.push(Math.round(running * 100) / 100);
+      if (running > peak) peak = running;
+      const dd = peak - running;
+      if (dd > maxDrawdown) maxDrawdown = dd;
+    }
+
+    const pnls = sorted.map((t) => t.pnl);
+    const mean = pnls.length > 0 ? pnls.reduce((a, b) => a + b, 0) / pnls.length : 0;
+    const variance =
+      pnls.length > 0 ? pnls.reduce((s, v) => s + (v - mean) ** 2, 0) / pnls.length : 0;
+    const std = Math.sqrt(variance);
+    const sharpe = pnls.length >= 2 && std > 0 ? (mean / std).toFixed(2) : "--";
+
+    stats[instanceId] = {
+      totalTrades: sorted.length,
+      winRate,
+      pnl: Math.round(totalPnl * 100) / 100,
+      sharpe,
+      maxDrawdown: Math.round(maxDrawdown * 100) / 100,
+      avgWin: Math.round(avgWin * 100) / 100,
+      avgLoss: Math.round(avgLoss * 100) / 100,
+      profitFactor,
+    };
+    pnlHistories[instanceId] = cum;
+  }
+  return { stats, pnlHistories };
 };
 
 const MAX_ROUNDTRIPS = 1000;
@@ -107,6 +204,50 @@ export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHist
     };
   };
 
+  // Finalize a pending roundtrip. Called either when the nt-trade event arrives (carrying
+  // NT's authoritative net P&L) or when the trade-wait timer expires (fallback path —
+  // uses the last unrealized snapshot, which may drift from NT's real number).
+  const finalizeRoundtrip = (posKey: string) => {
+    const open = openPositions.current.get(posKey);
+    if (!open) return;
+    if (open.closingTimeoutId) {
+      clearTimeout(open.closingTimeoutId);
+      open.closingTimeoutId = null;
+    }
+    const closeTs = open.closingFlatTimestamp ?? Date.now();
+    const { algoId, algoName, instanceId } = resolveAttribution(open.dataSourceId, open.account);
+    const { mae, mfe } = deriveMaeMfe(open.samples);
+    const useNtPnl = open.account !== "shadow" && open.ntTradeCount > 0;
+    const finalPnl = useNtPnl ? open.ntPnl : open.lastPnl;
+    const exitPrice = open.ntExitPrice ?? open.lastExitPrice ?? open.entryPrice;
+    const trip: Roundtrip = {
+      id: `${posKey}-${open.openTimestamp}`,
+      symbol: open.symbol,
+      side: open.side,
+      qty: open.qty,
+      entryPrice: open.entryPrice,
+      exitPrice,
+      openTimestamp: open.openTimestamp,
+      closeTimestamp: closeTs,
+      pnl: Math.round(finalPnl * 100) / 100,
+      mae: Math.round(mae * 100) / 100,
+      mfe: Math.round(mfe * 100) / 100,
+      rMultiple: computeRMultiple(finalPnl, mae),
+      algo: algoName,
+      algoId,
+      account: open.account,
+      dataSourceId: open.dataSourceId,
+      instanceId,
+      isShadow: open.account === "shadow",
+      maeMfeSamples: decimateSamples(open.samples, MAX_SAMPLES_PER_TRIP),
+    };
+    openPositions.current.delete(posKey);
+    setRoundtrips((prev) => {
+      const next = [...prev, trip];
+      return next.length > MAX_ROUNDTRIPS ? next.slice(-MAX_ROUNDTRIPS) : next;
+    });
+  };
+
   // Position events — pairing, sampling, close-to-roundtrip construction.
   useEffect(() => {
     const unlisten = listen<PositionEvent>("nt-position", (event) => {
@@ -117,38 +258,18 @@ export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHist
       if (p.direction === "Flat" || p.qty === 0) {
         const open = openPositions.current.get(posKey);
         if (!open) return;
-        const { algoId, algoName, instanceId } = resolveAttribution(
-          open.dataSourceId,
-          open.account,
-        );
-        const { mae, mfe } = deriveMaeMfe(open.samples);
-        const exitPrice = open.lastExitPrice ?? p.avg_price ?? open.entryPrice;
-        const trip: Roundtrip = {
-          id: `${posKey}-${open.openTimestamp}`,
-          symbol: open.symbol,
-          side: open.side,
-          qty: open.qty,
-          entryPrice: open.entryPrice,
-          exitPrice,
-          openTimestamp: open.openTimestamp,
-          closeTimestamp: now,
-          pnl: Math.round(open.lastPnl * 100) / 100,
-          mae: Math.round(mae * 100) / 100,
-          mfe: Math.round(mfe * 100) / 100,
-          rMultiple: computeRMultiple(open.lastPnl, mae),
-          algo: algoName,
-          algoId,
-          account: open.account,
-          dataSourceId: open.dataSourceId,
-          instanceId,
-          isShadow: open.account === "shadow",
-          maeMfeSamples: decimateSamples(open.samples, MAX_SAMPLES_PER_TRIP),
-        };
-        openPositions.current.delete(posKey);
-        setRoundtrips((prev) => {
-          const next = [...prev, trip];
-          return next.length > MAX_ROUNDTRIPS ? next.slice(-MAX_ROUNDTRIPS) : next;
-        });
+        const isShadow = open.account === "shadow";
+        // Shadow accounts don't go through NT and never get nt-trade events; finalize now.
+        // Live accounts with a trade already buffered (event arrived before Flat) finalize now.
+        // Otherwise wait for nt-trade; if it never arrives within TRADE_WAIT_MS, fall back.
+        if (isShadow || open.ntTradeCount > 0) {
+          open.closingFlatTimestamp = now;
+          finalizeRoundtrip(posKey);
+        } else {
+          open.closingPending = true;
+          open.closingFlatTimestamp = now;
+          open.closingTimeoutId = setTimeout(() => finalizeRoundtrip(posKey), TRADE_WAIT_MS);
+        }
         return;
       }
 
@@ -175,7 +296,33 @@ export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHist
           lastPnl: p.unrealized_pnl,
           samples: [{ t: now, pnl: p.unrealized_pnl }],
           lastExitPrice: null,
+          ntPnl: 0,
+          ntTradeCount: 0,
+          ntExitPrice: null,
+          closingPending: false,
+          closingFlatTimestamp: null,
+          closingTimeoutId: null,
         });
+      }
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  // NinjaTrader-reported realized P&L per roundtrip. Accumulates into the open position;
+  // if the Flat event already arrived and is waiting on the trade, finalize immediately.
+  useEffect(() => {
+    const unlisten = listen<TradeEvent>("nt-trade", (event) => {
+      const t = event.payload;
+      const posKey = posKeyOf(t.source_id, t.symbol, t.account);
+      const open = openPositions.current.get(posKey);
+      if (!open) return;
+      open.ntPnl += t.pnl;
+      open.ntTradeCount += 1;
+      open.ntExitPrice = t.exit_price;
+      if (open.closingPending) {
+        finalizeRoundtrip(posKey);
       }
     });
     return () => {
@@ -206,6 +353,7 @@ export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHist
       const removedId = event.payload;
       for (const [key, val] of openPositions.current) {
         if (val.dataSourceId === removedId) {
+          if (val.closingTimeoutId) clearTimeout(val.closingTimeoutId);
           openPositions.current.delete(key);
         }
       }
@@ -221,6 +369,17 @@ export const useTradeHistory = (algos: Algo[], activeRuns: AlgoRun[]): TradeHist
   const liveVsShadow = useMemo(() => pairLiveShadow(roundtrips), [roundtrips]);
   const distribution = useMemo(() => buildDistribution(roundtrips), [roundtrips]);
   const heatmap = useMemo(() => buildHeatmap(roundtrips), [roundtrips]);
+  const byInstance = useMemo(() => aggregateByInstance(roundtrips), [roundtrips]);
 
-  return { roundtrips, byAlgo, bySymbol, byAccount, liveVsShadow, distribution, heatmap };
+  return {
+    roundtrips,
+    byAlgo,
+    bySymbol,
+    byAccount,
+    liveVsShadow,
+    distribution,
+    heatmap,
+    statsByInstance: byInstance.stats,
+    pnlHistoryByInstance: byInstance.pnlHistories,
+  };
 };

--- a/src/hooks/useTradingSimulation.ts
+++ b/src/hooks/useTradingSimulation.ts
@@ -151,6 +151,23 @@ type AccountSnapshot = {
   realized_pnl: number;
 };
 
+type TradeEvent = {
+  source_id: string;
+  account: string;
+  symbol: string;
+  side: "Long" | "Short";
+  qty: number;
+  entry_price: number;
+  exit_price: number;
+  exit_time: number;
+  pnl: number;
+  gross_pnl: number;
+  commission: number;
+  flattens: boolean;
+  order_id: string;
+  instance_id: string;
+};
+
 type CompletedTrade = {
   pnl: number;
 };
@@ -207,10 +224,18 @@ export const useTradingSimulation = (_algos: Algo[], _activeRuns: AlgoRun[], _da
   const [shadowCompletedTrades, setShadowCompletedTrades] = useState<CompletedTrade[]>([]);
   const [backtestStats, setBacktestStats] = useState<Record<string, AlgoStats & { label?: string }>>({});
   const nextOrderId = useRef(1);
-  // Track last known P&L per position key so we can record it on close
+  // Track last known unrealized P&L per position key (used as fallback for shadow accounts)
   const positionPnlRef = useRef<Map<string, number>>(new Map());
+  // NT-reported realized P&L accumulated per open position (authoritative for live accounts)
+  const ntPnlRef = useRef<Map<string, number>>(new Map());
+  const ntTradeCountRef = useRef<Map<string, number>>(new Map());
+  // Live positions whose Flat event arrived before nt-trade — we defer recording the
+  // completed trade until the NT-reported P&L lands (or the timeout expires).
+  const pendingCloseRef = useRef<Map<string, { isShadow: boolean; timeoutId: ReturnType<typeof setTimeout> }>>(new Map());
   // Track which positions are shadow (by posKey)
   const shadowPositionKeys = useRef<Set<string>>(new Set());
+
+  const TRADE_WAIT_MS_SIM = 3000;
   // Ref to avoid stale closures in the sampling interval
   const realizedPnlRef = useRef(0);
 
@@ -234,6 +259,46 @@ export const useTradingSimulation = (_algos: Algo[], _activeRuns: AlgoRun[], _da
     return () => { unlisten.then((f) => f()); };
   }, []);
 
+  // Record a completed trade into the stats pipeline. Called either when Flat + nt-trade
+  // have both arrived, or when the post-Flat timeout expires and we fall back to the
+  // unrealized snapshot. Separated from the Flat handler so the UI position removal can
+  // happen immediately while the stat recording waits for NT's authoritative number.
+  const recordCompletedTrade = (posKey: string, isShadow: boolean) => {
+    const pending = pendingCloseRef.current.get(posKey);
+    if (pending) {
+      clearTimeout(pending.timeoutId);
+      pendingCloseRef.current.delete(posKey);
+    }
+    const ntCount = ntTradeCountRef.current.get(posKey) ?? 0;
+    const ntPnl = ntPnlRef.current.get(posKey) ?? 0;
+    const lastPnl = positionPnlRef.current.get(posKey) ?? 0;
+    const tradePnl = !isShadow && ntCount > 0 ? ntPnl : lastPnl;
+    if (tradePnl !== 0) {
+      if (isShadow) {
+        setShadowCompletedTrades((prev) => {
+          const next = [...prev, { pnl: tradePnl }];
+          return next.length > 1000 ? next.slice(-1000) : next;
+        });
+        const newTotal = Math.round((shadowRealizedPnlRef.current + tradePnl) * 100) / 100;
+        setShadowRealizedPnl(newTotal);
+        shadowRealizedPnlRef.current = newTotal;
+        setShadowPnlHistory((h) => {
+          const next = [...h, newTotal];
+          return next.length > 500 ? next.slice(-500) : next;
+        });
+      } else {
+        setCompletedTrades((prev) => {
+          const next = [...prev, { pnl: tradePnl }];
+          return next.length > 1000 ? next.slice(-1000) : next;
+        });
+      }
+    }
+    positionPnlRef.current.delete(posKey);
+    ntPnlRef.current.delete(posKey);
+    ntTradeCountRef.current.delete(posKey);
+    shadowPositionKeys.current.delete(posKey);
+  };
+
   // Listen for position updates from NinjaTrader
   useEffect(() => {
     const unlisten = listen<PositionEvent>("nt-position", (event) => {
@@ -243,34 +308,20 @@ export const useTradingSimulation = (_algos: Algo[], _activeRuns: AlgoRun[], _da
       const isShadow = p.account === "shadow";
 
       if (p.direction === "Flat" || p.qty === 0) {
-        // Position closed — record the completed trade
-        const lastPnl = positionPnlRef.current.get(posKey) ?? 0;
-        if (lastPnl !== 0) {
-          if (isShadow) {
-            setShadowCompletedTrades((prev) => {
-              const next = [...prev, { pnl: lastPnl }];
-              return next.length > 1000 ? next.slice(-1000) : next;
-            });
-            const newTotal = Math.round((shadowRealizedPnlRef.current + lastPnl) * 100) / 100;
-            setShadowRealizedPnl(newTotal);
-            shadowRealizedPnlRef.current = newTotal;
-            setShadowPnlHistory((h) => {
-              const next = [...h, newTotal];
-              return next.length > 500 ? next.slice(-500) : next;
-            });
-          } else {
-            setCompletedTrades((prev) => {
-              const next = [...prev, { pnl: lastPnl }];
-              return next.length > 1000 ? next.slice(-1000) : next;
-            });
-          }
-        }
-        positionPnlRef.current.delete(posKey);
-        shadowPositionKeys.current.delete(posKey);
-
+        // Remove the live position from the UI immediately.
         setPositions((prev) => prev.filter(
           (pos) => !(pos.dataSourceId === p.source_id && pos.symbol === p.symbol)
         ));
+
+        // Record the completed trade. For shadow or already-arrived NT trade: record now.
+        // For live waiting on nt-trade: defer up to TRADE_WAIT_MS_SIM so stats reflect NT's number.
+        const ntCount = ntTradeCountRef.current.get(posKey) ?? 0;
+        if (isShadow || ntCount > 0) {
+          recordCompletedTrade(posKey, isShadow);
+        } else {
+          const timeoutId = setTimeout(() => recordCompletedTrade(posKey, false), TRADE_WAIT_MS_SIM);
+          pendingCloseRef.current.set(posKey, { isShadow: false, timeoutId });
+        }
         return;
       }
 
@@ -304,6 +355,23 @@ export const useTradingSimulation = (_algos: Algo[], _activeRuns: AlgoRun[], _da
         }
         return [...prev, newPos];
       });
+    });
+    return () => { unlisten.then((f) => f()); };
+  }, []);
+
+  // Listen for NT-reported trade P&L (authoritative realized P&L for the roundtrip).
+  // If Flat already arrived and we're waiting on this event, finalize now instead of
+  // letting the timeout fall back to the unrealized snapshot.
+  useEffect(() => {
+    const unlisten = listen<TradeEvent>("nt-trade", (event) => {
+      const t = event.payload;
+      const posKey = `${t.source_id}:${t.symbol}`;
+      ntPnlRef.current.set(posKey, (ntPnlRef.current.get(posKey) ?? 0) + t.pnl);
+      ntTradeCountRef.current.set(posKey, (ntTradeCountRef.current.get(posKey) ?? 0) + 1);
+      const pending = pendingCloseRef.current.get(posKey);
+      if (pending) {
+        recordCompletedTrade(posKey, pending.isShadow);
+      }
     });
     return () => { unlisten.then((f) => f()); };
   }, []);

--- a/src/views/TradingView.tsx
+++ b/src/views/TradingView.tsx
@@ -6,12 +6,12 @@ import type {
   Position,
 } from "../hooks/useTradingSimulation";
 import type { TradeHistory } from "../hooks/useTradeHistory";
-import type { EquityTimeline } from "../hooks/useEquityTimeline";
 import type { RollingMetrics } from "../hooks/useRollingMetrics";
 import {
   type Filters,
   type Roundtrip,
   type DrawdownPoint,
+  type EquityPoint,
   EMPTY_FILTERS,
   applyFilters,
   aggregateByKey,
@@ -38,7 +38,6 @@ type AccountSummary = {
 type TradingViewProps = {
   simulation: TradingSimulation;
   tradeHistory: TradeHistory;
-  equity: EquityTimeline;
   rolling: RollingMetrics;
   algos: Algo[];
   activeRuns: AlgoRun[];
@@ -61,6 +60,20 @@ const drawdownFromRoundtrips = (trips: Roundtrip[]): DrawdownPoint[] => {
     cum += r.pnl;
     if (cum > peak) peak = cum;
     out.push({ t: r.closeTimestamp, peak, pnl: cum, underwater: peak - cum });
+  }
+  return out;
+};
+
+// Build a cumulative equity series from closed roundtrips. The hero chart uses this
+// (instead of useEquityTimeline's account-level feed) so stopped-algo history and
+// manual NT trades don't show up on the "active algos" view.
+const equityFromRoundtrips = (trips: Roundtrip[]): EquityPoint[] => {
+  const sorted = [...trips].sort((a, b) => a.closeTimestamp - b.closeTimestamp);
+  let cum = 0;
+  const out: EquityPoint[] = [{ t: sorted[0]?.openTimestamp ?? Date.now(), pnl: 0 }];
+  for (const r of sorted) {
+    cum += r.pnl;
+    out.push({ t: r.closeTimestamp, pnl: Math.round(cum * 100) / 100 });
   }
   return out;
 };
@@ -91,7 +104,6 @@ const useOpenSinceMap = (positions: Position[]): Map<string, number> => {
 export const TradingView = ({
   simulation,
   tradeHistory,
-  equity,
   rolling,
   algos,
   activeRuns,
@@ -165,18 +177,39 @@ export const TradingView = ({
     [tradeHistory.heatmap, filteredRoundtrips, isFilterOn],
   );
 
-  // Drawdown for hero KPIs + overlay: always derive from the (filtered) roundtrip set.
-  // This keeps the hero internally consistent — realized / Sharpe / max DD all come
-  // from the same source, whether or not a filter is active. The raw `equity.liveDrawdown`
-  // from nt-account is still available to callers that want live-account-only drawdown.
-  const filteredDrawdown = useMemo(
-    () => drawdownFromRoundtrips(filteredRoundtrips),
-    [filteredRoundtrips],
+  // Hero + equity chart scope: only currently-active algo instances. The drill-down
+  // tabs below still see the full session (filteredRoundtrips), but the top-of-page
+  // snapshot reflects what running algos are doing right now — excludes closed trades
+  // from algos the user has since stopped, and excludes manual/account-level NT activity.
+  const activeInstanceIds = useMemo(
+    () => new Set(activeRuns.map((r) => r.instance_id)),
+    [activeRuns],
+  );
+  const activeChartAccountKeys = useMemo(
+    () => new Set(activeRuns.map((r) => `${r.data_source_id}:${r.account}`)),
+    [activeRuns],
+  );
+  const heroRoundtrips = useMemo(
+    () => filteredRoundtrips.filter((r) => activeInstanceIds.has(r.instanceId)),
+    [filteredRoundtrips, activeInstanceIds],
+  );
+  const heroPositions = useMemo(
+    () => filteredPositions.filter((p) => activeChartAccountKeys.has(`${p.dataSourceId}:${p.account}`)),
+    [filteredPositions, activeChartAccountKeys],
+  );
+  const heroDrawdown = useMemo(() => drawdownFromRoundtrips(heroRoundtrips), [heroRoundtrips]);
+  const heroEquityLive = useMemo(
+    () => equityFromRoundtrips(heroRoundtrips.filter((r) => !r.isShadow)),
+    [heroRoundtrips],
+  );
+  const heroEquityShadow = useMemo(
+    () => equityFromRoundtrips(heroRoundtrips.filter((r) => r.isShadow)),
+    [heroRoundtrips],
   );
 
   const heroKpis = useMemo(
-    () => deriveHeroKpis(filteredRoundtrips, filteredPositions, filteredDrawdown),
-    [filteredRoundtrips, filteredPositions, filteredDrawdown],
+    () => deriveHeroKpis(heroRoundtrips, heroPositions, heroDrawdown),
+    [heroRoundtrips, heroPositions, heroDrawdown],
   );
 
   const openSinceByPosKey = useOpenSinceMap(simulation.positions);
@@ -198,9 +231,9 @@ export const TradingView = ({
 
       <TradingHero
         kpis={heroKpis}
-        equityLive={equity.live}
-        equityShadow={equity.shadow}
-        drawdown={filteredDrawdown}
+        equityLive={heroEquityLive}
+        equityShadow={heroEquityShadow}
+        drawdown={heroDrawdown}
       />
 
       <TradingTabs activeTab={activeTab} onChange={setActiveTab} />


### PR DESCRIPTION
## Summary

Three connected fixes so the app's P&L agrees with NinjaTrader.

- **Bridge now sources trade P&L from NT's own account delta** rather than computing it locally. The old `(exit - entry) * pointValue - execution.Commission` formula produced gross numbers because `Execution.Commission` is often `0` at `OnExecutionUpdate` time — NT posts commission + exchange fees later via `AccountItem.RealizedProfitLoss`. Bridge snapshots `_cachedRealizedPnl` on open and emits a `trade` message after the post-Flat realized-pnl update, so `pnl` equals exactly what NT's trade tab shows.
- **Algos/Home views now show live per-algo P&L.** `useTradingSimulation.algoStats` was backtest-only and `runPnlHistories` was hard-coded to `{}`; live roundtrips from `useTradeHistory` were aggregated by algo *name* but never plumbed to the Algos view. Added `aggregateByInstance` keyed by `AlgoRun.instance_id` and merged in `App.tsx` (live overrides backtest once trades exist).
- **Trading view hero + equity chart now reflect active algos only.** Previously summed all roundtrips from all algos this session, including stopped ones, and the equity line was fed from NT's account-level realized PnL (included manual trades). Hero is now filtered by the currently-active `instance_id` set and the equity series is built locally from those roundtrips. Drill-down tabs still show the full session.

Frontend buffers Flat events for live accounts (3s safety timeout → unrealized snapshot fallback) because NT fires `RealizedProfitLoss` after `OnPositionUpdate`, so `nt-trade` arrives after `nt-position` Flat on the wire.

## Deployment note

The C# bridge needs to be recompiled in NT and re-enabled on each chart for the new `trade` events to start flowing. Without that step the frontend falls back to the old unrealized-snapshot path after the 3s timer (visibly stale by commission+fees).

## Test plan

- [ ] Compile `WolfDenBridge.cs` in NT's NinjaScript editor and re-enable the strategy on each chart
- [ ] Run a single round-trip on a live account; confirm the algo's P&L in Wolf Den matches NT's trade tab to the cent
- [ ] Stop an algo that has closed trades; confirm its trades disappear from the Trading hero and equity chart but remain in the Performance/Trades tabs
- [ ] Start multiple algos on different charts; confirm per-algo P&L on the Algos view attributes correctly
- [ ] Close a shadow (simulated) trade; confirm it still records via the unrealized-snapshot fallback (shadow bypasses NT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Real-time trade event integration capturing realized P&L from live trading accounts
* Per-algorithm performance statistics with cumulative P&L history tracking

**Improvements**
* Enhanced position lifecycle tracking for more accurate P&L attribution
* Improved equity and drawdown calculations using authoritative trading data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->