### PR TITLE
chore: include NinjaTrader strategy in release artifacts

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -94,6 +94,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: release-notes.md
-          files: src-tauri/target/release/bundle/nsis/*.exe
+          files: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            ninjatrader/WolfDenBridge.cs
           draft: false
           prerelease: false


### PR DESCRIPTION
## Summary
- Attach `ninjatrader/WolfDenBridge.cs` to tagged GitHub Releases alongside the NSIS installer so users have a single download location for all files needed to run Wolf Den.

## Test plan
- [ ] Push a test tag (or re-run the workflow on a tag) and confirm both the `.exe` and `WolfDenBridge.cs` appear on the Releases page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)